### PR TITLE
Set up CI with Azure Pipelines

### DIFF
--- a/.azure-pipelines/azure-pipelines-backend.yml
+++ b/.azure-pipelines/azure-pipelines-backend.yml
@@ -16,10 +16,9 @@ steps:
       versionSpec: '12.17.0'
     displayName: 'Install Node.js 12.17.0'
 
-  - script: |
-      yarn global add @angular/cli@8.3.21
-      yarn global add @nestjs/cli@6.12.6
-      yarn global add typescript@3.7.2 
+  - script: |      
+      yarn global add @nestjs/cli@7.1.5
+      yarn global add typescript@3.8.3
     displayName: 'Install global tools'
 
   - script: |

--- a/.azure-pipelines/azure-pipelines-backend.yml
+++ b/.azure-pipelines/azure-pipelines-backend.yml
@@ -1,0 +1,50 @@
+trigger:
+  branches:
+    include:
+      - master
+  paths:
+    exclude: 
+      - /frontend
+      - /.azure-pipelines/azure-pipelines-frontend.yml
+
+pool:
+  vmImage: 'ubuntu-latest'
+
+steps: 
+  - task: NodeTool@0
+    inputs:
+      versionSpec: '12.17.0'
+    displayName: 'Install Node.js 12.17.0'
+
+  - script: |
+      yarn global add @angular/cli@8.3.21
+      yarn global add @nestjs/cli@6.12.6
+      yarn global add typescript@3.7.2 
+    displayName: 'Install global tools'
+
+  - script: |
+      docker pull mongo:4.2
+      docker run -p 27017:27017 --name pulp-fiction-mongo-db -d mongo:4.2
+    displayName: 'Set up MongoDB'
+
+  - script: |
+      printf "%s\n" "DATABASE_URL=mongodb://localhost:27017/my_database" "JWT_SECRET=whatever" > .env
+    displayName: 'Create .env file'
+
+  - task: Cache@2
+    inputs:
+    # Note that the cache key is the hash of of yarn.lock. If the lockfile changes, the cache gets invalidated.
+      key: 'yarn | "$(Agent.OS)" | $(Build.SourcesDirectory)/yarn.lock'
+      path: '$(Build.SourcesDirectory)/node_modules'
+      cacheHitVar: 'CacheRestored'
+    displayName: "Cache node_modules"
+
+  - script: yarn install
+    displayName: "Yarn install"
+    condition: ne(variables['CacheRestored'], 'true')
+
+  - script: yarn build
+    displayName: "Build"
+
+  - script: yarn test
+    displayName: "Test"

--- a/.azure-pipelines/azure-pipelines-frontend.yml
+++ b/.azure-pipelines/azure-pipelines-frontend.yml
@@ -1,0 +1,48 @@
+trigger:
+  branches:
+    include:
+      - master
+  paths:
+    exclude: 
+      - /
+    include: 
+      - /frontend/*
+      - /.azure-pipelines/azure-pipelines-frontend.yml
+
+pool:
+  vmImage: 'ubuntu-latest'
+
+steps:
+- task: NodeTool@0
+  inputs:
+    versionSpec: '12.17.0'
+  displayName: 'Install Node.js 12.17.0'
+
+- script: |
+    yarn global add @angular/cli@8.3.21    
+    yarn global add typescript@3.7.2 
+  displayName: 'Install global tools'
+
+- task: Cache@2
+  inputs:
+  # Note that the cache key is the hash of of yarn.lock. If the lockfile changes, the cache gets invalidated.
+    key: 'yarn | "$(Agent.OS)" | $(Build.SourcesDirectory)/frontend/yarn.lock'
+    path: '$(Build.SourcesDirectory)/frontend/node_modules'
+    cacheHitVar: 'CacheRestored'
+  displayName: "Cache node_modules"
+
+- script: |
+    cd frontend
+    yarn install
+  displayName: "Yarn install"
+  condition: ne(variables['CacheRestored'], 'true')
+
+- script: |
+    cd frontend
+    yarn build
+  displayName: "Build"
+
+- script: |
+    cd frontend
+    yarn test-headless
+  displayName: "Test"

--- a/.azure-pipelines/azure-pipelines-frontend.yml
+++ b/.azure-pipelines/azure-pipelines-frontend.yml
@@ -19,8 +19,8 @@ steps:
   displayName: 'Install Node.js 12.17.0'
 
 - script: |
-    yarn global add @angular/cli@8.3.21    
-    yarn global add typescript@3.7.2 
+    yarn global add @angular/cli@9.1.5    
+    yarn global add typescript@3.8.3 
   displayName: 'Install global tools'
 
 - task: Cache@2

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,6 +6,7 @@
     "start": "ng serve",
     "build": "ng build",
     "test": "ng test",
+    "test-headless": "ng test --watch false",
     "lint": "ng lint",
     "e2e": "ng e2e"
   },


### PR DESCRIPTION
Sets up some basic CI in Azure DevOps. You can see [how it turned out here](https://dev.azure.com/mcalistern/offprint-fork/_build).

A few caveats:
 * Tests in both frontend and backend fail. Backend because they're just default tests, frontend because the test agent isn't running an X server, and can't run the tests. I left the tests enabled for now, because ¯\\\_(ツ)_/¯
* Part of the backend CI process fetches and runs MongoDB in a docker container, which isn't _strictly_ necessary, as it never actually runs the backend. But in the future, if any of the integration tests require a database, it's nice to have it there.
* `node_modules` is cached using [DevOps' caching feature](https://docs.microsoft.com/en-us/azure/devops/pipelines/release/caching?view=azure-devops). It saves about ~20s per build.
* I didn't even sketch out a deploy task, because I have nooooo idea what the deploy process would look like. But fundamentally, I'd probably divide the build process into two `stage`s, and publish artifacts from the "build" stage to a theoretical "deploy" stage, then send it off to Digital Ocean, or wherever.