### PR TITLE
Adds logout functionality to the logout button

### DIFF
--- a/build_prod.sh
+++ b/build_prod.sh
@@ -3,7 +3,6 @@
 # Installing dependencies for server and building
 yarn install
 yarn build
-yarn buildNativeModules
 
 # Installing dependencies for frontend and building
 cd frontend

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,3 +8,5 @@ services:
     - .:/opt/pulpd
   mongo:
     image: "mongo:4.2.1"
+    ports:
+      - "27017:27017"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,6 +5,7 @@
     "ng": "ng",
     "start": "ng serve",
     "build": "ng build",
+    "build:dev": "ng build --watch",
     "test": "ng test",
     "test-headless": "ng test --watch false",
     "lint": "ng lint",

--- a/frontend/src/app/components/dropdowns/user-menu/user-menu.component.less
+++ b/frontend/src/app/components/dropdowns/user-menu/user-menu.component.less
@@ -8,6 +8,9 @@ div.user-menu {
     ul {
         list-style-type: none;
         width: 100%;
+        li {
+            cursor: pointer;
+        }
         li.item {
             a {
                 width: 100%;

--- a/frontend/src/app/components/dropdowns/user-menu/user-menu.component.ts
+++ b/frontend/src/app/components/dropdowns/user-menu/user-menu.component.ts
@@ -22,7 +22,6 @@ export class UserMenuComponent implements OnInit {
 
   logout() {
     this.authService.logout();
-    location.reload();
     this.close();
   }
 }

--- a/frontend/src/app/services/auth/auth.service.ts
+++ b/frontend/src/app/services/auth/auth.service.ts
@@ -87,6 +87,10 @@ export class AuthService {
    * navigates to home.
    */
   public logout(): void {
+    // Fire and forget. If this fails, it doesn't matter to the user, 
+    // and we don't want to leak that fact anyway.
+    this.http.get(`/api/auth/logout`, {withCredentials: true}).subscribe();
+    
     localStorage.removeItem('currentUser');
     this.currUserSubject.next(null);
     this.alertsService.success('See you next time!');

--- a/src/api/auth/auth.service.ts
+++ b/src/api/auth/auth.service.ts
@@ -56,6 +56,17 @@ export class AuthService {
     }
 
     /**
+     * Logs a user out by deleting their HTTP-only refresh token cookie. The rest of the logout process
+     * takes place in the user service, or client-side.
+     * @param req The incoming logout request     
+     */
+    logout(req: any) {
+        req._cookies = [
+            {name: 'refreshToken', value: "", options: {httpOnly: true, expires: new Date(Date.now())}}
+        ];
+    }
+
+    /**
      * Refreshes the login of a given user by generating a new JWT payload and reconstructing
      * the FrontendUser object of the requisite user.
      * 

--- a/src/db/users/users.service.ts
+++ b/src/db/users/users.service.ts
@@ -62,6 +62,15 @@ export class UsersService {
     async addRefreshToken(userId: string, sessionId: string): Promise<void> {
         return await this.userModel.updateOne({"_id": userId}, {$push: {"audit.sessions": sessionId}});
     }
+
+    /**
+     * Removes the given session ID from a user's sessions array on their document.
+     * @param userId A user's ID
+     * @param sessionId The session ID to remove
+     */
+    async clearRefreshToken(userId: string, sessionId: string) {
+        return await this.userModel.updateOne({"_id": userId}, {$pull: {"audit.sessions": sessionId}});
+    }
     
     /**
      * Builds a new FrontendUser object, including any available JSON web token.


### PR DESCRIPTION
There's a little bit of protection against the website failing to send a logout request to the server: if that happens, the user's refreshToken cookies sticks around in the browser, while the response from `logout()` normally clears it. 

If, upon login, we see that the user has an old, uncleared refreshToken, we go in and remove it from the user's document before we finish logging them in.