### PR TITLE
Make auth excellent

### DIFF
--- a/frontend/src/app/services/auth/auth.service.ts
+++ b/frontend/src/app/services/auth/auth.service.ts
@@ -87,6 +87,14 @@ export class AuthService {
         this.currUserSubject.next(user.body);
         return user.body.token;
       }), catchError(err => {
+        if (err.status === 403) {
+          // A 403 means that the refreshToken has expired, or we didn't send one up at all, which is Super Suspicious          
+          localStorage.removeItem('currentUser');
+          this.currUserSubject.next(null);    
+          this.router.navigate(['/home/latest']);    
+          this.alertsService.error(`${err.error.message}. You have been logged out.`);
+          return null;          
+        }
         this.alertsService.error(err.error.message);
         return throwError(err);
       }));

--- a/src/api/auth/auth.controller.ts
+++ b/src/api/auth/auth.controller.ts
@@ -21,7 +21,7 @@ export class AuthController {
     @Post('register')
     async register(@Request() req: any, @Body() newUser: models.CreateUser): Promise<models.FrontendUser> {
         const addedUser = await this.usersService.createUser(newUser);
-        const sessionId = uuidV4();                
+        const sessionId = uuidV4();
         const newSession = await this.usersService.addRefreshToken(addedUser._id, sessionId);
         return this.authService.login(addedUser, req, sessionId, newSession.expires);
     }
@@ -39,7 +39,7 @@ export class AuthController {
         }
 
         if (loginUser.rememberMe) {
-            const sessionId = uuidV4();                                    
+            const sessionId = uuidV4();
             const newSession = await this.usersService.addRefreshToken(verifiedUser._id, sessionId);
             return this.authService.login(verifiedUser, req, sessionId, newSession.expires);
         } else {

--- a/src/api/auth/auth.module.ts
+++ b/src/api/auth/auth.module.ts
@@ -5,6 +5,7 @@ import { AuthService } from './auth.service';
 import { AuthController } from './auth.controller';
 import { UsersModule } from 'src/db/users/users.module';
 import { ImagesModule } from '../images/images.module';
+import { getJwtSecretKey, JWT_EXPIRATION } from '../../util';
 
 
 @Module({
@@ -12,8 +13,8 @@ import { ImagesModule } from '../images/images.module';
     UsersModule, ImagesModule,
     JwtModule.registerAsync({
       useFactory: () => ({
-        secret: process.env.JWT_SECRET,
-        signOptions: {expiresIn: '3600s'}, // 3 hours, temporary until problems with auth tokens fixed.
+        secret: getJwtSecretKey(),
+        signOptions: {expiresIn: JWT_EXPIRATION},
       }),
     }),
   ],

--- a/src/api/content/content.module.ts
+++ b/src/api/content/content.module.ts
@@ -8,14 +8,15 @@ import { WorksModule } from 'src/db/works/works.module';
 import { PortfolioController } from './portfolio/portfolio.controller';
 import { UsersModule } from 'src/db/users/users.module';
 import { ImagesModule } from '../images/images.module';
+import { getJwtSecretKey, JWT_EXPIRATION } from 'src/util';
 
 @Module({
   imports: [
     BlogsModule, WorksModule, UsersModule, ImagesModule,
     JwtModule.registerAsync({
       useFactory: () => ({
-        secret: process.env.JWT_SECRET,
-        signOptions: {expiresIn: '3600s'}, // 3 hours, temporary until problems with auth tokens fixed.
+        secret: getJwtSecretKey(),
+        signOptions: {expiresIn: JWT_EXPIRATION},
       }),
     }),
   ],

--- a/src/api/contrib/contrib.module.ts
+++ b/src/api/contrib/contrib.module.ts
@@ -6,6 +6,7 @@ import { WorksModule } from '../../db/works/works.module';
 import { UsersModule } from '../../db/users/users.module';
 import { ContribController } from './contrib.controller';
 import { ApprovalQueueModule } from 'src/db/approval-queue/approval-queue.module';
+import { getJwtSecretKey, JWT_EXPIRATION } from 'src/util';
 
 @Module({
   imports: [
@@ -14,8 +15,8 @@ import { ApprovalQueueModule } from 'src/db/approval-queue/approval-queue.module
     ApprovalQueueModule,
     JwtModule.registerAsync({
       useFactory: () => ({
-        secret: process.env.JWT_SECRET,
-        signOptions: {expiresIn: '3600s'}, // 3 hours, temporary until problems with auth tokens fixed.
+        secret: getJwtSecretKey(),
+        signOptions: {expiresIn: JWT_EXPIRATION},
       }),
     }),
   ],

--- a/src/api/images/images.module.ts
+++ b/src/api/images/images.module.ts
@@ -2,14 +2,15 @@ import { Module } from '@nestjs/common';
 import { JwtModule } from '@nestjs/jwt';
 
 import { ImagesService } from './images.service';
+import { getJwtSecretKey, JWT_EXPIRATION } from 'src/util';
 
 
 @Module({
   imports: [
     JwtModule.registerAsync({
       useFactory: () => ({
-        secret: process.env.JWT_SECRET,
-        signOptions: { expiresIn: '3600s' }, // 3 hours, temporary until problems with auth tokens fixed.
+        secret: getJwtSecretKey(),
+        signOptions: {expiresIn: JWT_EXPIRATION},
       }),
     }),
   ],  

--- a/src/db/users/audit-session.schema.ts
+++ b/src/db/users/audit-session.schema.ts
@@ -1,0 +1,9 @@
+import { Schema } from "mongoose";
+
+import { AuditSession } from './models/audit-session.model';
+
+export const AuditSessionSchema = new Schema<AuditSession>({
+    _id: {type: String, required: [true, `You must provide a sessionId.`]},
+    expires: {type: Date, required: [true, `You must provide an expiration date.`]},
+    createdAt: {type: Date, default: Date.now()},
+});

--- a/src/db/users/models/audit-session.model.ts
+++ b/src/db/users/models/audit-session.model.ts
@@ -1,0 +1,7 @@
+import { Document } from 'mongoose';
+
+export interface AuditSession extends Document {
+    readonly _id: string;
+    readonly expires: Date,
+    readonly createdAt: Date,
+}

--- a/src/db/users/models/index.ts
+++ b/src/db/users/models/index.ts
@@ -7,6 +7,7 @@ export { ChangePassword } from './change-password.model';
 export { ChangeProfile } from './change-profile.model';
 export { Roles } from './roles.enum';
 export { SearchUser } from './search-user.model';
+export { AuditSession } from './audit-session.model';
 
 // Delete after the Offprint Alpha ends
 export { InviteCodes } from './invite-codes.model';

--- a/src/db/users/models/user.model.ts
+++ b/src/db/users/models/user.model.ts
@@ -1,5 +1,6 @@
 import { Document } from 'mongoose';
 import { Roles } from './roles.enum';
+import { AuditSession } from './audit-session.model';
 
 export interface User extends Document {
     readonly _id: string;
@@ -20,7 +21,7 @@ export interface User extends Document {
     };
     readonly audit: {
         readonly roles: Roles[];
-        readonly sessions: string[] | null;
+        readonly sessions: AuditSession[] | null;
     };
     readonly createdAt: Date;
     readonly updatedAt: Date;

--- a/src/db/users/users.schema.ts
+++ b/src/db/users/users.schema.ts
@@ -4,6 +4,7 @@ import { hash, argon2id } from 'argon2';
 import * as sanitize from 'sanitize-html';
 
 import { User, Roles } from './models';
+import { AuditSessionSchema } from './audit-session.schema';
 
 export const UsersSchema = new Schema({
     _id: {type: String, default: generate()},
@@ -24,7 +25,7 @@ export const UsersSchema = new Schema({
     },
     audit: {
         roles: {type: [String], enum: Object.keys(Roles), default: ['User']},
-        sessions: {type: [String], default: null},
+        sessions: {type: [AuditSessionSchema], default: null},
         isDeleted: {type: String, default: false},
     },
     createdAt: {type: Date, default: Date.now()},

--- a/src/db/users/users.service.ts
+++ b/src/db/users/users.service.ts
@@ -83,7 +83,7 @@ export class UsersService {
      * Adds a new refresh session ID to the user's sessions array on their document.
      * 
      * @param userId A user's ID
-     * @param signedSessionId A user's session ID, signed using the refresh signing key
+     * @param sessionId A user's session ID
      */
     async addRefreshToken(userId: string, sessionId: string): Promise<models.AuditSession> {
         const hashedSessionId = createHash('sha256').update(sessionId).digest('base64');

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -1,0 +1,2 @@
+export { isNullOrUndefined } from './validation';
+export * from './secrets';

--- a/src/util/secrets.ts
+++ b/src/util/secrets.ts
@@ -1,0 +1,19 @@
+/**
+ * The secret key used to sign JWTs. Obtained from the 
+ * JWT_SECRET environment variable.
+ */
+export function getJwtSecretKey(): string {
+    return process.env.JWT_SECRET;
+} 
+
+/**
+ * The amount of time, in seconds, before a JWT expires.
+ * Set to 3,600 seconds, or 1 hour.
+ */
+export const JWT_EXPIRATION: number = 3600;
+
+/**
+ * The amount of time, in seconds, before a JWT expires.
+ * Set to 2,592,000,000 seconds, or 30 days.
+ */
+export const REFRESH_EXPIRATION: number = 2_592_000_000;


### PR DESCRIPTION
Closes #41.

- Audit Sessions are now fully-fledged objects, including creation and expiration dates
- Refresh tokens are now SHA256-hashed in the database
- JWT configuration options are centralized in /src/util/secrets.ts
- Failing to refresh your token now results in a 403
- Receiving a 403 on refresh attempt will now log a user out