### PR TITLE
Fix/scrolling on section publish

### DIFF
--- a/frontend/src/app/pages/work-page/viewmodels/section-info.viewmodel.ts
+++ b/frontend/src/app/pages/work-page/viewmodels/section-info.viewmodel.ts
@@ -1,0 +1,17 @@
+import { SectionInfo } from 'shared-models';
+
+export class SectionInfoViewModel {
+    readonly _id: string;
+    title: string;
+    published: boolean;
+    words: number;
+    createdAt: Date;
+
+    constructor(private backingInfo: SectionInfo) {
+        this._id = backingInfo._id;
+        this.title = backingInfo.title;
+        this.published = backingInfo.published;
+        this.words = backingInfo.stats.words;
+        this.createdAt = backingInfo.createdAt;
+    }
+}

--- a/frontend/src/app/pages/work-page/work-page.component.html
+++ b/frontend/src/app/pages/work-page/work-page.component.html
@@ -64,7 +64,7 @@
     <ng-container *ngIf="route.children.length === 0 && workData.sections.length > 0">
         <div class="section-list" *ngIf="currentUserIsSame(); else notSameUser">
             <ul>
-                <li *ngFor="let section of workData.sections; let i = index">
+                <li *ngFor="let section of allSectionViewModels; let i = index">
                     <div *ngIf="section.published === true">
                         <div class="section-box">
                             <div>
@@ -77,7 +77,7 @@
                             </div>
                             <div>
                                 <div class="section-stats">
-                                    {{ section.stats.words | toLocaleString }} word{{ section.stats.words | pluralize }}<span>//</span>{{ section.createdAt | date:'mediumDate'}}
+                                    {{ section.words | toLocaleString }} word{{ section.words | pluralize }}<span>//</span>{{ section.createdAt | date:'mediumDate'}}
                                 </div>
                             </div>
                             <div>
@@ -97,7 +97,7 @@
                             </div>
                             <div>
                                 <div class="section-stats">
-                                    {{ section.stats.words | toLocaleString }} word{{ section.stats.words | pluralize }}<span>//</span>{{ section.createdAt | date:'mediumDate'}}
+                                    {{ section.words | toLocaleString }} word{{ section.words | pluralize }}<span>//</span>{{ section.createdAt | date:'mediumDate'}}
                                 </div>
                             </div>
                             <div>
@@ -111,14 +111,14 @@
         <ng-template #notSameUser>
             <div class="section-list">
                 <ul>
-                    <li *ngFor="let section of pubSections; let i = index">
+                    <li *ngFor="let section of pubSectionViewModels; let i = index">
                         <div class="section-box" style="padding: 10px;">
                             <div style="flex: 1;">
                                 <a class="section-info" [routerLink]="['/work', workData._id, workData.title | slugify, i + 1, section.title | slugify]">{{ section.title }}</a>
                             </div>
                             <div>
                                 <div class="section-stats" style="margin-right: 2rem;">
-                                    {{ section.stats.words | toLocaleString }} word{{ section.stats.words | pluralize }}<span>//</span>{{ section.createdAt | date:'mediumDate'}}
+                                    {{ section.words | toLocaleString }} word{{ section.words | pluralize }}<span>//</span>{{ section.createdAt | date:'mediumDate'}}
                                 </div>
                             </div>
                         </div>

--- a/frontend/src/app/services/content/works.service.ts
+++ b/frontend/src/app/services/content/works.service.ts
@@ -50,7 +50,7 @@ export class WorksService {
     return this.http.put<Section>(`${this.url}/create-section/${workId}`, info, {observe: 'response', withCredentials: true})
       .pipe(map(res => {
         this.alertsService.success(`Section successfully created.`);
-        return res.body._id;
+        return res.body;
       }), catchError(err => {
         this.alertsService.error(`Something went wrong! Try again in a little bit.`);
         return throwError(err);

--- a/frontend/src/app/services/content/works.service.ts
+++ b/frontend/src/app/services/content/works.service.ts
@@ -180,7 +180,11 @@ export class WorksService {
   public setPublishStatusSection(workId: string, sectionId: string, pubStatus: PublishSection) {
     return this.http.patch(`${this.url}/set-publishing-status/${workId}/${sectionId}`, pubStatus, {observe: 'response', withCredentials: true})
       .pipe(map(() => {
-        this.alertsService.success(`Section published successfully!`);
+        if (pubStatus.newPub === true) {
+          this.alertsService.success(`Section published!`);
+        } else {
+          this.alertsService.success('Section unpublished!');
+        }
       }), catchError(err => {
         this.alertsService.error(`Something went wrong! Try again in a little bit.`);
         return throwError(err);


### PR DESCRIPTION
Closes #84.

Basically, the problem before was that the page modified `workData`, which forced a re-render of the entire list, which would rocket you to the top as the whole page briefly collapsed.

Now, instead, we just modify the `published` property on the section, and let Angular data binding take care of the rest.
However, because the `SectionInfo` interface is immutable, I've introduced an intermediate `SectionInfoViewModel` to act as mutable bundle o' state, and we now bind to _those_ instead.