### PR TITLE
Make titles on work pages play nicely with rating badges, remove fancy CSS effect that didn't work

### DIFF
--- a/frontend/src/app/pages/work-page/work-page.component.less
+++ b/frontend/src/app/pages/work-page/work-page.component.less
@@ -54,10 +54,9 @@ div.work-box {
             div.work-header {
                 margin-bottom: 0;
                 h1 {
-                    display: inline-block;
+                    display: inline;
                     font-weight: 700;
-                    color: whitesmoke;
-                    margin-bottom: 0;
+                    color: whitesmoke;                    
                     a {
                         color: whitesmoke;
                         padding: 10px 5px 0 5px;

--- a/frontend/src/styles.less
+++ b/frontend/src/styles.less
@@ -317,29 +317,10 @@ button, a.button, input[type=submit] {
             a {
                 color: whitesmoke !important;
                 text-decoration: none !important;
-                background: linear-gradient(0deg, var(--site-accent) 0%, var(--site-accent-hover) 10%, var(--site-accent) 50%);                
-                z-index: 1; // necessary, otherwise the highlight covers the text
-                position: relative; // allows us to use position: aboslute in the ::before            
-                &::before {
-                    content: "";
-                    position: absolute;
-                    top: 0;
-                    bottom: 0;
-                    width: 100%;
-                    height: 100%;
-                    transform: scaleY(0%);
-                    opacity: 0;
-                    background: linear-gradient(0deg, var(--site-accent) 0%, var(--site-accent-hover) 10%, var(--site-accent-hover) 90%, var(--site-accent) 100%);
-                    transition: transform 0.3s, opacity 0.1s;
-                    z-index: -1; // necessary, otherwise the highlight covers the text
-                }
-                &:hover::before {
-                    opacity: 1;
-                    transform: scaleY(110%);
-                    transform-origin: bottom center;
-                }
+                background: linear-gradient(0deg, var(--site-accent) 0%, var(--site-accent-hover) 10%, var(--site-accent) 50%);                                
                 &:hover {
                     color: whitesmoke !important;
+                    background: linear-gradient(0deg, var(--site-accent) 0%, var(--site-accent-hover) 10%, var(--site-accent-hover) 90%, var(--site-accent) 100%);
                     text-decoration: none !important;                    
                 }
             }


### PR DESCRIPTION
Example of title issue:
![image](https://user-images.githubusercontent.com/5133649/90561523-7fea3700-e1a9-11ea-9e93-481d80fc3f0f.png)

Fixed: 
![image](https://user-images.githubusercontent.com/5133649/90561549-8aa4cc00-e1a9-11ea-961e-ccd52f50dd8c.png)

...and removed all the extra junk for link styles in work boxes. They have a proper, basic highlight on hover now.