### PR TITLE
Replace Quill TextBlot with one that supports soft line breaks

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -43,7 +43,7 @@
     "@angular/compiler-cli": "~10.0.6",
     "@types/jasmine": "~3.5.0",
     "@types/jasminewd2": "~2.0.3",
-    "@types/node": "^12.11.1",
+    "@types/node": "^12.11.1",    
     "codelyzer": "^6.0.0",
     "jasmine-core": "~3.5.0",
     "jasmine-spec-reporter": "~5.0.0",

--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -43,7 +43,7 @@ import { DashboardComponent, ApprovalQueueComponent, NewsManagementComponent, Re
 
 import { DocsComponent, CreateDocComponent, EditDocComponent} from './pages/dashboard/docs';
 
-import { Divider, dividerHandler } from './util/quill';
+import { Divider, dividerHandler, TextSoftBreakBlot, shiftEnterHandler, brMatcher, textNodeMatcher } from './util/quill';
 import { NetworkInputComponent } from './components/network-input/network-input.component';
 
 const Quill: any = QuillNamespace;
@@ -66,6 +66,7 @@ icons.bullet = '<i class="fas fa-list"></i>';
 icons.divider = '—';
 
 Quill.register(Divider);
+Quill.register('blots/text', TextSoftBreakBlot);
 
 const toolbarOptions = [
   [{header: []}, 'bold', 'italic', 'underline', 'strike'],
@@ -98,9 +99,24 @@ const toolbarOptions = [
         toolbar: {
           container: toolbarOptions,
           handlers: {
-            'divider': dividerHandler,
+            'divider': dividerHandler,            
           }
         },
+        keyboard: {
+          bindings: {
+            "shift enter": {
+              key: 13,
+              shiftKey: true,
+              handler: shiftEnterHandler
+            }
+          }
+        },
+        clipboard: {
+          matchers: [           
+            [ Node.TEXT_NODE, textNodeMatcher ],
+            [ "BR", brMatcher ]
+          ],          
+        }
       },
     }),
   ],

--- a/frontend/src/app/util/quill/index.ts
+++ b/frontend/src/app/util/quill/index.ts
@@ -1,2 +1,3 @@
 export { Divider, dividerHandler } from './divider';
 export { imageHandler } from './image-link';
+export { TextSoftBreakBlot, shiftEnterHandler, brMatcher, textNodeMatcher } from './soft-line-break';

--- a/frontend/src/app/util/quill/soft-line-break.ts
+++ b/frontend/src/app/util/quill/soft-line-break.ts
@@ -1,0 +1,180 @@
+import * as Quill from 'quill';
+
+const LINE_SEPARATOR = '\u2028';
+const Delta = Quill.import('delta');
+const TextBlot = Quill.import('blots/text');
+
+interface QuillRange {
+    index: number;
+    length: number;
+}
+
+/**
+ * Extends and **replaces** the base Quill TextBlot. It gives it
+ * the capacity to handle single line breaks, which are represented as the 
+ * Unicode LINE SEPARATOR (U+2028) character.
+ */
+export class TextSoftBreakBlot extends TextBlot {
+    // These two fields are "inherited" from TextBlot, but because we 
+    // can't import it traditionally, we have to shadow them manually.
+    protected text: string;
+    public domNode!: Text;
+
+    constructor(node: Node) {
+        super(node);
+        this.setText(this.text);
+    }
+
+    // Converts a DOM node to text to be stored in a Delta.
+    static value(domNode: Text): string {
+        return toDeltaText(TextBlot.value(domNode));
+    }
+
+    deleteAt(index: number, length: number): void {
+        this.setText(this.text.slice(0, index) + this.text.slice(index + length));
+    }
+
+    insertAt(index: number, value: string, def?: any): void {
+        if (def == null) {
+            this.setText(this.text.slice(0, index) + value + this.text.slice(index));
+        } else {
+            this.insertAt(index, value, def);
+        }
+    }
+
+    private setText(deltaText: string): void {
+        this.text = deltaText;
+        this.domNode.data = toDomText(deltaText);
+    }
+}
+
+function toDeltaText(domText: string): string {
+    // Text node content that ends in \n\n is rendered as two blank lines.
+    // Convert to one line separator, and let the second \n be handled
+    // by Quill closing the text block.
+    return domText
+        .replace(/\n\n$/, LINE_SEPARATOR)
+        .replace(/\n/g, LINE_SEPARATOR);
+}
+
+function toDomText(deltaText: string): string {
+    return deltaText
+        .replace(new RegExp(`${LINE_SEPARATOR}$`), '\n\n')
+        .replace(new RegExp(LINE_SEPARATOR, 'g'), '\n');
+}
+
+export function shiftEnterHandler(this: any, range: QuillRange) {
+    this.quill.history.cutoff();
+    // wrap this in cutoff()s so it gets seen as a single change
+    const delta = new Delta()
+        .retain(range.index)
+        .delete(range.length)
+        .insert(LINE_SEPARATOR);
+    this.quill.updateContents(delta, Quill.sources.USER);
+
+    this.quill.history.cutoff();
+
+    this.quill.setSelection(range.index + 1, Quill.sources.SILENT);
+    console.log(this.quill.getContents());
+}
+
+export function brMatcher(node: Node) {
+    if (node.nextSibling && !node.nextSibling.textContent.startsWith('\n')) {
+        return new Delta().insert(LINE_SEPARATOR);
+    } else {
+        // If this node is a <br>, and the next node doesn't exist, 
+        // or is a <br>, just return an empty Delta.
+        // TODO: Is this actually ideal behavior?
+        return new Delta();
+    }
+}
+
+export function textNodeMatcher(node: any, delta: any) {
+    // This code is almost identical to the default TextMatcher code--
+    // just with extra calls to toDeltaText().
+    let text = node.data;
+    // Word represents empty line with <o:p>&nbsp;</o:p>
+    if (node.parentNode.tagName === 'O:P') {
+        text = toDeltaText(text);
+        return new Delta().insert(text.trim());
+    }
+    if (text.trim().length === 0 && text.includes('\n')) {
+        return new Delta().insert(text);
+    }
+    if (!isPre(node)) {
+        const replacer = (collapse, match) => {
+            const replaced = match.replace(/[^\u00a0]/g, ''); // \u00a0 is nbsp;
+            return replaced.length < 1 && collapse ? ' ' : replaced;
+        };
+        text = text.replace(/\r\n/g, ' ').replace(/\n/g, ' ');
+        text = text.replace(/\s\s+/g, replacer.bind(replacer, true)); // collapse whitespace
+        if (
+            (node.previousSibling == null && isLine(node.parentNode)) ||
+            (node.previousSibling != null && isLine(node.previousSibling))
+        ) {
+            text = text.replace(/^\s+/, replacer.bind(replacer, false));
+        }
+        if (
+            (node.nextSibling == null && isLine(node.parentNode)) ||
+            (node.nextSibling != null && isLine(node.nextSibling))
+        ) {
+            text = text.replace(/\s+$/, replacer.bind(replacer, false));
+        }
+    }
+    text = toDeltaText(text);
+    return new Delta().insert(text);
+}
+
+// All the code below is taken from the default TextMatcher.
+const preNodes = new WeakMap();
+function isPre(node) {
+    if (node == null) return false;
+    if (!preNodes.has(node)) {
+        if (node.tagName === 'PRE') {
+            preNodes.set(node, true);
+        } else {
+            preNodes.set(node, isPre(node.parentNode));
+        }
+    }
+    return preNodes.get(node);
+}
+
+function isLine(node) {
+    if (node.childNodes.length === 0) return false; // Exclude embed blocks
+    return [
+        'address',
+        'article',
+        'blockquote',
+        'canvas',
+        'dd',
+        'div',
+        'dl',
+        'dt',
+        'fieldset',
+        'figcaption',
+        'figure',
+        'footer',
+        'form',
+        'h1',
+        'h2',
+        'h3',
+        'h4',
+        'h5',
+        'h6',
+        'header',
+        'iframe',
+        'li',
+        'main',
+        'nav',
+        'ol',
+        'output',
+        'p',
+        'pre',
+        'section',
+        'table',
+        'td',
+        'tr',
+        'ul',
+        'video',
+    ].includes(node.tagName.toLowerCase());
+}

--- a/frontend/src/styles.less
+++ b/frontend/src/styles.less
@@ -302,7 +302,14 @@ button, a.button, input[type=submit] {
             font-family: 'Raleway';
             height: 100%;
 
+            p {
+                margin: 1em 0px;
+            }
+
             div.ql-editor {
+                &.ql-blank::before {
+                    margin: 1em 0px;
+                }
                 iframe {
                     width: 500px;
                     height: 300px;
@@ -334,6 +341,10 @@ quill-view {
         font-family: 'Raleway';
         height: 100%;
 
+        p {
+            margin: 1em 0px;
+        }
+
         div.ql-editor {
             iframe {
                 width: 500px;
@@ -343,6 +354,9 @@ quill-view {
                 max-width: 100%;
                 max-height: 100%;
                 object-fit: contain;
+            }
+            &.ql-blank::before {
+                margin: 1em 0px;
             }
         }
 
@@ -362,6 +376,14 @@ quill-view-html {
         font-size: 16px;
         font-family: 'Raleway';
         height: 100%;
+
+        p {
+            margin: 1em 0px;
+        }
+
+        div.ql-edtior.ql-blank::before {
+            margin: 1em 0px;
+        }
 
         a {
             color: var(--site-accent) !important;
@@ -404,6 +426,14 @@ quill-editor {
         font-size: 16px;
         font-family: 'Raleway';
         box-shadow: var(--site-dropshadow);
+
+        p {
+            margin: 1em 0px;
+        }
+        
+        div.ql-editor.ql-blank::before {
+            margin: 1em 0px;
+        }
 
         a {
             color: var(--site-accent) !important;


### PR DESCRIPTION
Closes #70.

It uses the approach described in the issue description. It's a bit heavy-handed--we straight up replace the default TextBlot with one that's been extended to be capable of handling soft line breaks. It works pretty well with Fimfic, Ao3, and probably anything that does HTML rich paste. It does have some caveats though:
 * Anything copied from a plaintext document will be interpreted as one big paragraph with a bunch of line breaks inside of it. This isn't terrible, and will _probably_ be a minority of users. We may even be able to handle it in the future by making the matcher a little smarter.
 * `<br>` tags seem to get double spaced, because they come across, then get stripped out, leaving us with HTML with blank spaces in it that looks like this:
```HTML
<p>I am a thing.</p>

<p>I am the second line</p>
```
...and that blank space gets rendered as whitespace in most browsers.