### PR TITLE
Remove clang (etc) from the Dockerfile, and update readme to match

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,10 +14,7 @@ RUN wget --quiet --output-document=node-latest.deb 'https://deb.nodesource.com/n
     
 RUN apt-get update && apt-get install -y \
     yarn=1.22.1-1 \
-    build-essential \
-    llvm-dev \
-    libclang-dev \
-    clang
+    build-essential
 
 RUN yarn add --dev typescript@3.9.7 \
     @angular/cli@10.0.4 \
@@ -29,11 +26,11 @@ RUN yarn add --dev typescript@3.9.7 \
 RUN curl https://sh.rustup.rs -sSf |  bash -s -- -y
 RUN echo 'source $HOME/.cargo/env' >> $HOME/.bashrc
 
-WORKDIR /opt/pulpd
-
 ENV PATH "$PATH:/opt/pulpd/node_modules/.bin"
 
 EXPOSE 3333
 EXPOSE 4200
 EXPOSE 3000
 EXPOSE 9229
+
+WORKDIR /opt/pulpd

--- a/README.md
+++ b/README.md
@@ -20,9 +20,6 @@ You must have the following tools installed on your system (or in a docker conta
 * The [Rust 1.15 (or later) toolchain](https://rustup.rs/).
     * You may also need the following packages in order to compile the Rust packages:
         * `build-essential`
-        * `llvm-dev`
-        * `libclang-dev`
-        * `clang`
 
 Once you've installed and verified that these dependencies are working as expected, run `./build_dev.sh` in the root project directory to start an initial compilation and fetch all necessary libraries.
 


### PR DESCRIPTION
Still haven't figured out how to make `yarn install` happen as part of the `docker` process, but one extra command once inside the container isn't so bad.