### PR TITLE
Work page sections now update in real time

### DIFF
--- a/packages/client/src/app/pages/work-page/section-page/section-page.component.ts
+++ b/packages/client/src/app/pages/work-page/section-page/section-page.component.ts
@@ -11,6 +11,8 @@ import { Section, SectionInfo, EditSection} from '@pulp-fiction/models/works';
 import { Observable } from 'rxjs';
 import { AlertsService } from '../../../modules/alerts';
 import { getQuillHtml } from '../../../util/functions';
+import { SectionInfoViewModel } from '../viewmodels/section-info.viewmodel';
+import { SectionKind } from '../../../services/content/local-sections.service';
 
 enum SectionState {
   User,
@@ -29,12 +31,12 @@ export class SectionPageComponent implements OnInit {
   loading = false; // controls the spinner above section selection boxes
   sectionSwitching: boolean = false; // controls the spinner between the section selection boxes  
   
-  sectionsList: SectionInfo[];
+  sectionsList: ReadonlyArray<SectionInfoViewModel>;
   sectionData: Section;
   hideContents: boolean = false;
   indexNext = 0;
   indexPrev = 0;
-  currSection: SectionInfo = null;
+  currSection: SectionInfoViewModel = null;
     
   workId: string;  
   workTitle: string;
@@ -138,7 +140,7 @@ export class SectionPageComponent implements OnInit {
    * 
    * @param event The section changed to
    */
-  onSelectChange(event: SectionInfo) {
+  onSelectChange(event: SectionInfoViewModel) {
     const thisSectionIndex = this.sectionsList.indexOf(event);
     this.router.navigate([`/work/${this.workId}/${this.workTitle}/${thisSectionIndex + 1}/${this.slugify.transform(event.title)}`])
   }
@@ -257,6 +259,8 @@ export class SectionPageComponent implements OnInit {
   askDelete() {
     if (confirm(`Are you sure you want to delete this section? This action is irreversible.`)) {
       this.worksService.deleteSection(this.workId, this.sectionId).subscribe(() => {
+        const publishState: SectionKind = this.sectionData.published ? SectionKind.Published : SectionKind.Unpublished;
+        this.sectionsService.removeSection(this.sectionId, publishState);
         this.router.navigate([`/work/${this.workId}/${this.workTitle}`]);
         return;
       }, err => {

--- a/packages/client/src/app/pages/work-page/viewmodels/section-info.viewmodel.ts
+++ b/packages/client/src/app/pages/work-page/viewmodels/section-info.viewmodel.ts
@@ -1,5 +1,9 @@
 import { SectionInfo } from '@pulp-fiction/models/works';
 
+/**
+ * A mutable view over `SectionInfo`, to be used by the frontend in instances where we need to modify
+ * displayed data without getting new data from the backend.
+ */
 export class SectionInfoViewModel {
     readonly _id: string;
     title: string;
@@ -7,7 +11,7 @@ export class SectionInfoViewModel {
     words: number;
     createdAt: Date;
 
-    constructor(private backingInfo: SectionInfo) {
+    constructor(backingInfo: SectionInfo) {
         this._id = backingInfo._id;
         this.title = backingInfo.title;
         this.published = backingInfo.published;

--- a/packages/client/src/app/pages/work-page/work-page.component.ts
+++ b/packages/client/src/app/pages/work-page/work-page.component.ts
@@ -23,8 +23,7 @@ export class WorkPageComponent implements OnInit {
   loading = false; // Loading check for fetching data
 
   workId: string; // This work's ID
-  workData: Work; // This work's data.
-  pubSections: SectionInfo[]; // This work's published sections
+  workData: Work; // This work's data.  
   userHist: History;
   editWork: ToppyControl;
   updateCoverArt: ToppyControl;
@@ -32,8 +31,12 @@ export class WorkPageComponent implements OnInit {
 
   // The sections list binds to these, as they can be mutated individually,
   // without requiring us to re-assign workData (which forces the entire section list to be rebuilt)
-  allSectionViewModels: SectionInfoViewModel[];
-  pubSectionViewModels: SectionInfoViewModel[];
+  get allSectionViewModels(): ReadonlyArray<SectionInfoViewModel> {
+    return this.sectionsService.allSections;
+  }
+  get pubSectionViewModels(): ReadonlyArray<SectionInfoViewModel> {
+    return this.sectionsService.publishedSections;
+  }
 
   constructor(private authService: AuthService, private worksService: WorksService,
     public route: ActivatedRoute, private router: Router, private toppy: Toppy, private queueService: QueueService,
@@ -92,14 +95,12 @@ export class WorkPageComponent implements OnInit {
     this.workId = this.route.snapshot.paramMap.get('workId');        
     this.worksService.fetchWork(this.workId).subscribe(work => {
       this.workData = work;
-      this.pubSections = work.sections.filter(section => { return section.published === true; });
-      this.allSectionViewModels = work.sections.map(x => new SectionInfoViewModel(x));
-      this.pubSectionViewModels = this.pubSections.map(x => new SectionInfoViewModel(x));
       this.worksService.thisWorkId = this.workId;
+      const pubSections = work.sections.filter(section => { return section.published === true; });      
       if (this.currentUserIsSame()) {
-        this.sectionsService.setInfo(this.pubSections, work.author._id, this.workData.sections);
+        this.sectionsService.setInfo(pubSections, work.author._id, this.workData.sections);
       }  else {
-        this.sectionsService.setInfo(this.pubSections, work.author._id);
+        this.sectionsService.setInfo(pubSections, work.author._id);
       }
     }, () => {
       this.loading = false;


### PR DESCRIPTION
Closes #138.

_everything is viewmodels_

Basically, the frontend now only works with the mutable versions of Sections, so that 1) the work page can mutate their published state, and 2) the source of truth for locally-stored sections is now the LocalSectionsService.