### PR TITLE
Added Porn genre, visible for all ratings

### DIFF
--- a/packages/models/src/lib/works/genres.enum.ts
+++ b/packages/models/src/lib/works/genres.enum.ts
@@ -12,6 +12,7 @@ export enum GenresFiction {
     Horror = 'Horror',
     Thriller = 'Thriller',
     Mystery = 'Mystery',
+    Porn = 'Porn',
     // Essay = 'Essay',
     // Journalism = 'Journalism',
     // Biography = 'Biography', 


### PR DESCRIPTION
Added Porn genre, visible for all ratings
- Enforcement for X rating only will be handled by mods

Programmatically having the Porn genre only appear for Explicit fics doesn't seem worth the hassle, especially when that means there should be logic to remove the Porn genre from a fic if it changes rating.