### PR TITLE
Increase genre limit to 3, and update new work and edit work strings

### DIFF
--- a/packages/client/src/app/components/content-forms/work-form/work-form.component.html
+++ b/packages/client/src/app/components/content-forms/work-form/work-form.component.html
@@ -37,7 +37,7 @@
                         <!--Genres for Fiction-->
                         <div *ngIf="isFiction()">
                             <mat-form-field class="work-form">
-                                <mat-label>Choose Genres (max 2)</mat-label>
+                                <mat-label>Genres (Up to {{ maxGenresPerFiction }})</mat-label>
                                 <mat-select formControlName="theseGenres" multiple>
                                     <mat-option *ngFor="let genre of genresFiction | keyvalue" [value]="genre.key">
                                         {{ genre.value }}
@@ -62,7 +62,7 @@
                     <div *ngIf="isFanfiction()" [ngStyle]="isFanfiction() ? {'flex': '0.5', 'overflow': 'auto'} : {'flex': 'none'}">
                         <!--Fandoms-->
                         <mat-form-field class="work-form">
-                            <mat-label>Choose Fandoms (max 5)</mat-label>
+                            <mat-label>Fandoms (Up to {{ maxFandomsPerStory }})</mat-label>
                             <mat-select formControlName="theseFandoms" multiple>
                                 <mat-option *ngFor="let fandom of fandoms | keyvalue" [value]="fandom.key">
                                     {{ fandom.value }}

--- a/packages/client/src/app/components/content-forms/work-form/work-form.component.html
+++ b/packages/client/src/app/components/content-forms/work-form/work-form.component.html
@@ -13,7 +13,7 @@
                     <div>
                         <!--Content Rating-->
                         <mat-form-field class="work-form">
-                            <mat-label>Select a rating</mat-label>
+                            <mat-label>Content Rating</mat-label>
                             <mat-select formControlName="rating">
                                 <mat-option *ngFor="let rate of rating | keyvalue" [value]="rate.key">
                                     {{ rate.value }}
@@ -24,7 +24,7 @@
                     <span>//</span>
                     <div>
                         <mat-form-field class="work-form">
-                            <mat-label>Select a category</mat-label>
+                            <mat-label>Category</mat-label>
                             <mat-select formControlName="thisCategory">
                                 <mat-option *ngFor="let cat of categories | keyvalue" [value]="cat.key">
                                     {{ cat.value }}
@@ -49,7 +49,7 @@
                         <!--Genres for Poetry-->
                         <div *ngIf="isPoetry()">
                             <mat-form-field class="work-form">
-                                <mat-label>Choose Genre</mat-label>
+                                <mat-label>Genre</mat-label>
                                 <mat-select formControlName="theseGenres" multiple>
                                     <mat-option *ngFor="let genre of genresPoetry | keyvalue" [value]="genre.key">
                                         {{ genre.value }}
@@ -80,7 +80,7 @@
 
                 <div class="work-stats">
                     <mat-form-field class="work-form">
-                        <mat-label>Choose a status</mat-label>
+                        <mat-label>Status</mat-label>
                         <mat-select formControlName="status">
                             <mat-option *ngFor="let stat of status | keyvalue" [value]="stat.key">
                                 {{ stat.value }}

--- a/packages/client/src/app/components/content-forms/work-form/work-form.component.ts
+++ b/packages/client/src/app/components/content-forms/work-form/work-form.component.ts
@@ -6,7 +6,8 @@ import { MatAutocomplete, MatAutocompleteSelectedEvent } from '@angular/material
 import { COMMA, ENTER } from '@angular/cdk/keycodes';
 
 import { Categories, ContentRating, CreateWork, Fandoms, Genres, GenresFiction, 
-  GenresPoetry, WorkStatus } from '@pulp-fiction/models/works';
+  GenresPoetry, WorkStatus, MAX_FANDOMS_PER_STORY, MAX_GENRES_PER_FANFIC, MAX_GENRES_PER_POEM,
+  MAX_GENRES_PER_ORIGINAL } from '@pulp-fiction/models/works';
 import { WorksService } from '../../../services/content';
 
 @Component({
@@ -145,8 +146,8 @@ export class WorkFormComponent implements OnInit {
         this.snackbar.open(`You must pick at least one fandom.`);
         this.loading = false;
         return;
-      } else if (this.fields.theseFandoms.value.length > 5) {
-        this.snackbar.open(`You can only have up to five fandoms.`);
+      } else if (this.fields.theseFandoms.value.length > MAX_FANDOMS_PER_STORY) {
+        this.snackbar.open(`You can only have up to ${MAX_FANDOMS_PER_STORY} fandoms.`);
         this.loading = false;
         return;
       }
@@ -156,12 +157,18 @@ export class WorkFormComponent implements OnInit {
       this.snackbar.open(`You must have at least one genre.`);
       this.loading = false;
       return;
-    } else if (this.fields.thisCategory.value === Categories.Poetry && this.fields.theseGenres.value.length > 1) {
+    } else if (this.fields.thisCategory.value === Categories.Poetry 
+      && this.fields.theseGenres.value.length > MAX_GENRES_PER_POEM) {
       this.snackbar.open(`Poetry can only have one genre.`);
       this.loading = false;
       return;
-    } else if (this.fields.theseGenres.value.length > 2) {
-      this.snackbar.open(`You can only have up to two genres.`);
+    } else if (this.fields.thisCategory.value === Categories.Fanfiction 
+      && this.fields.theseGenres.value.length > MAX_GENRES_PER_FANFIC) {
+      this.snackbar.open(`You can only have up to ${MAX_GENRES_PER_FANFIC} genres.`);
+      this.loading = false;
+      return;
+    } else if (this.fields.theseGenres.value.length > MAX_GENRES_PER_ORIGINAL) {
+      this.snackbar.open(`You can only have up to ${MAX_GENRES_PER_ORIGINAL} genres.`);
       this.loading = false;
       return;
     }

--- a/packages/client/src/app/components/content-forms/work-form/work-form.component.ts
+++ b/packages/client/src/app/components/content-forms/work-form/work-form.component.ts
@@ -6,8 +6,8 @@ import { MatAutocomplete, MatAutocompleteSelectedEvent } from '@angular/material
 import { COMMA, ENTER } from '@angular/cdk/keycodes';
 
 import { Categories, ContentRating, CreateWork, Fandoms, Genres, GenresFiction, 
-  GenresPoetry, WorkStatus, MAX_FANDOMS_PER_STORY, MAX_GENRES_PER_FANFIC, MAX_GENRES_PER_POEM,
-  MAX_GENRES_PER_ORIGINAL } from '@pulp-fiction/models/works';
+  GenresPoetry, WorkStatus, MAX_FANDOMS_PER_STORY, MAX_GENRES_PER_FICTION,
+  MAX_GENRES_PER_POEM } from '@pulp-fiction/models/works';
 import { WorksService } from '../../../services/content';
 
 @Component({
@@ -36,6 +36,10 @@ export class WorkFormComponent implements OnInit {
   genresPoetry = GenresPoetry; // Alias for poetry genres
   rating = ContentRating; // Alias for content ratings
   status = WorkStatus; // Alias for work statuses
+  
+  maxFandomsPerStory = MAX_FANDOMS_PER_STORY;
+  maxGenresPerFiction = MAX_GENRES_PER_FICTION;
+  maxGenresPerPoem = MAX_GENRES_PER_POEM;
 
   workForm = new FormGroup({
     title: new FormControl('', [Validators.required, Validators.minLength(3), Validators.maxLength(100)]),
@@ -162,13 +166,8 @@ export class WorkFormComponent implements OnInit {
       this.snackbar.open(`Poetry can only have one genre.`);
       this.loading = false;
       return;
-    } else if (this.fields.thisCategory.value === Categories.Fanfiction 
-      && this.fields.theseGenres.value.length > MAX_GENRES_PER_FANFIC) {
-      this.snackbar.open(`You can only have up to ${MAX_GENRES_PER_FANFIC} genres.`);
-      this.loading = false;
-      return;
-    } else if (this.fields.theseGenres.value.length > MAX_GENRES_PER_ORIGINAL) {
-      this.snackbar.open(`You can only have up to ${MAX_GENRES_PER_ORIGINAL} genres.`);
+    } else if (this.fields.theseGenres.value.length > MAX_GENRES_PER_FICTION) {
+      this.snackbar.open(`You can only have up to ${MAX_GENRES_PER_FICTION} genres.`);
       this.loading = false;
       return;
     }

--- a/packages/client/src/app/components/modals/works/edit-work/edit-work.component.html
+++ b/packages/client/src/app/components/modals/works/edit-work/edit-work.component.html
@@ -37,12 +37,12 @@
 
         <!--Fandom-->
         <div *ngIf="isFanfiction()">
-            <label>Fandoms (Up to 5)</label>
+            <label>Fandoms (Up to {{ maxFandomsPerStory }})</label>
             <ng-select [items]="fandoms | keyvalue"
                         bindLabel="value"
                         bindValue="key"
                         [multiple]="true"
-                        maxSelectedItems="5"
+                        maxSelectedItems="{{ maxFandomsPerStory }}"
                         placeholder="Select fandoms"
                         clearAllText="Clear"
                         formControlName="theseFandoms"
@@ -51,12 +51,12 @@
 
         <!--Genres for Fiction-->
         <div *ngIf="isFiction()">
-            <label>Genres (Up to 2)</label>
+            <label>Genres (Up to {{ maxGenresPerFiction }})</label>
             <ng-select [items]="genresFiction | keyvalue"
                         bindLabel="value"
                         bindValue="key"
                         [multiple]="true"
-                        maxSelectedItems="2"
+                        maxSelectedItems="{{ maxGenresPerFiction }}"
                         placeholder="Select genres"
                         clearAllText="Clear"
                         formControlName="theseGenres"
@@ -66,7 +66,7 @@
 
         <!--Genres for Poetry-->
         <div *ngIf="isPoetry()">
-            <label>Genres</label>
+            <label>Genre (Up to {{ maxGenresPerPoem }})</label>
             <ng-select [items]="genresPoetry | keyvalue"
                         bindLabel="value"
                         bindValue="key"

--- a/packages/client/src/app/components/modals/works/edit-work/edit-work.component.ts
+++ b/packages/client/src/app/components/modals/works/edit-work/edit-work.component.ts
@@ -6,7 +6,8 @@ import { dividerHandler, imageHandler } from '../../../../util/quill';
 import { WorksService } from '../../../../services/content';
 import { AlertsService } from '../../../../modules/alerts';
 import { Categories, EditWork, Fandoms, GenresFiction, GenresPoetry, 
-  ContentRating, WorkStatus, Work } from '@pulp-fiction/models/works';
+  ContentRating, WorkStatus, Work, MAX_FANDOMS_PER_STORY, MAX_GENRES_PER_FICTION,
+  MAX_GENRES_PER_POEM } from '@pulp-fiction/models/works';
 import { getQuillHtml } from 'packages/client/src/app/util/functions';
 
 @Component({
@@ -25,6 +26,9 @@ export class EditWorkComponent implements OnInit {
   genresPoetry = GenresPoetry; // Alias for poetry genres
   rating = ContentRating; // Alias for content ratings
   status = WorkStatus; // Alias for work statuses
+  maxFandomsPerStory = MAX_FANDOMS_PER_STORY;
+  maxGenresPerFiction = MAX_GENRES_PER_FICTION;
+  maxGenresPerPoem = MAX_GENRES_PER_POEM;
 
   editorFormats = [
     'header', 'bold', 'italic', 'underline', 'strike',

--- a/packages/client/src/app/pipes/separate-entities.pipe.ts
+++ b/packages/client/src/app/pipes/separate-entities.pipe.ts
@@ -8,7 +8,8 @@ export class SeparateEntitiesPipe implements PipeTransform {
             if (value.length === 1) {
                 return GenresFiction[value[0]];
               } else {
-                const theseGenres: string[] = [GenresFiction[value[0]], GenresFiction[value[1]]];
+                let theseGenres: string[] = new Array();
+                value.forEach(genre => { theseGenres.push(GenresFiction[genre]) });
                 return theseGenres.join(', ');
               }
         } else if (Categories[category] === Categories.Poetry) {

--- a/packages/models/src/lib/works/genres.enum.ts
+++ b/packages/models/src/lib/works/genres.enum.ts
@@ -28,6 +28,5 @@ export enum GenresPoetry {
     FixedVerse = 'Fixed Verse'
 }
 
-export const MAX_GENRES_PER_FANFIC: number = 3;
+export const MAX_GENRES_PER_FICTION: number = 3;
 export const MAX_GENRES_PER_POEM: number = 1;
-export const MAX_GENRES_PER_ORIGINAL: number = 3;

--- a/packages/models/src/lib/works/genres.enum.ts
+++ b/packages/models/src/lib/works/genres.enum.ts
@@ -28,6 +28,6 @@ export enum GenresPoetry {
     FixedVerse = 'Fixed Verse'
 }
 
-export const MAX_GENRES_PER_FANFIC: number = 2;
+export const MAX_GENRES_PER_FANFIC: number = 3;
 export const MAX_GENRES_PER_POEM: number = 1;
-export const MAX_GENRES_PER_ORIGINAL: number = 2;
+export const MAX_GENRES_PER_ORIGINAL: number = 3;

--- a/packages/models/src/lib/works/index.ts
+++ b/packages/models/src/lib/works/index.ts
@@ -3,7 +3,7 @@ export { Section } from './section.model';
 export { Categories } from './categories.enum';
 export { Fandoms, MAX_FANDOMS_PER_STORY } from './fandoms.enum';
 export { ContentRating } from './content-rating.enum';
-export { Genres, GenresFiction, GenresPoetry, MAX_GENRES_PER_FANFIC, MAX_GENRES_PER_POEM, MAX_GENRES_PER_ORIGINAL } from './genres.enum';
+export { Genres, GenresFiction, GenresPoetry, MAX_GENRES_PER_FICTION, MAX_GENRES_PER_POEM } from './genres.enum';
 export { WorkStatus } from './work-status.enum';
 export { ApprovalStatus } from './approval-status.enum';
 export { ContentFilter } from './content-filter.enum';

--- a/packages/server/src/app/api/content/works/works.controller.ts
+++ b/packages/server/src/app/api/content/works/works.controller.ts
@@ -137,13 +137,13 @@ export class WorksController {
             if (work.fandoms.length < 1 || work.fandoms.length > models.MAX_FANDOMS_PER_STORY) {
                 throw new BadRequestException(`You must select between 1 and ${models.MAX_FANDOMS_PER_STORY} fandoms.`);
             }
-            if (work.genres.length < 1 || work.genres.length > models.MAX_GENRES_PER_FANFIC) {
-                throw new BadRequestException(`You must select between 1 and ${models.MAX_GENRES_PER_FANFIC} genres.`);
+            if (work.genres.length < 1 || work.genres.length > models.MAX_GENRES_PER_FICTION) {
+                throw new BadRequestException(`You must select between 1 and ${models.MAX_GENRES_PER_FICTION} genres.`);
             }
         }
         if (work.category === models.Categories.OriginalFiction) {
-            if (work.genres.length < 1 || work.genres.length > models.MAX_GENRES_PER_ORIGINAL) {
-                throw new BadRequestException(`You must select between 1 and ${models.MAX_GENRES_PER_ORIGINAL} genres.`);
+            if (work.genres.length < 1 || work.genres.length > models.MAX_GENRES_PER_FICTION) {
+                throw new BadRequestException(`You must select between 1 and ${models.MAX_GENRES_PER_FICTION} genres.`);
             }
         }
         if (work.category === models.Categories.Poetry) {


### PR DESCRIPTION
- Increase genre limit to 3
- Update new work and edit work forms to use existing constants
- Update way genres are displayed in work cards, to display more than two genres
- Update new work form to use same strings as edit work form