### PR TITLE
Add h3-h6 to the available header styles, and fix in-section header sizes

### DIFF
--- a/packages/client/src/app/components/new-editor/new-editor.component.ts
+++ b/packages/client/src/app/components/new-editor/new-editor.component.ts
@@ -20,9 +20,7 @@ export class NewEditorComponent implements OnInit {
   @Input() controlName: string;
 
   editor = CKEditor;
-  config: Object = {
-    // Todo: configure toolbar properly
-    // https://ckeditor.com/docs/ckeditor5/latest/builds/guides/integration/configuration.html for details
+  config: Object = {    
     toolbar: [ 'heading', '|', 'bold', 'italic', 'underline', 'strikethrough', '|', 'bulletedlist', 'numberedlist', '|',
     'alignment', 'indent', 'outdent', '|', 'horizontalline', 'blockquote', 'link', 'insertImage', 'mediaEmbed', '|',
     'undo', 'redo'],
@@ -30,8 +28,12 @@ export class NewEditorComponent implements OnInit {
     heading: {
       options: [
         { model: 'paragraph', title: 'Paragraph', class: 'ck-heading_paragraph' },
-        { model: 'heading2', view: 'h2', title: 'Heading 1', class: 'ck-heading_heading2' },
-        { model: 'heading3', view: 'h3', title: 'Heading 2', class: 'ck-heading_heading3' }
+        { model: 'heading1', view: 'h1', title: 'Heading 1', class: 'ck-heading_heading1' },
+        { model: 'heading2', view: 'h2', title: 'Heading 2', class: 'ck-heading_heading2' },
+        { model: 'heading3', view: 'h3', title: 'Heading 3', class: 'ck-heading_heading3' },
+        { model: 'heading4', view: 'h4', title: 'Heading 4', class: 'ck-heading_heading4' },
+        { model: 'heading5', view: 'h5', title: 'Heading 5', class: 'ck-heading_heading5' },
+        { model: 'heading6', view: 'h6', title: 'Heading 6', class: 'ck-heading_heading6' }
       ]
     },
     mediaEmbed: {

--- a/packages/client/src/app/pages/work-page/new-section/new-section.component.html
+++ b/packages/client/src/app/pages/work-page/new-section/new-section.component.html
@@ -13,7 +13,7 @@
             </div>
         </div>
         <div class="authors-note">
-            <h3>A word from the author...</h3>
+            <h2 class="authors-note-header">A word from the author...</h2>
             <div class="warning-message" *ngIf="fields.authorsNote.invalid && (fields.authorsNote.dirty || fields.authorsNote.touched)">Author's Notes must be between 5 and 2000 characters.</div>
             <editor [parentForm]="newSectionForm" [controlName]="'authorsNote'"></editor>            
         </div>

--- a/packages/client/src/app/pages/work-page/new-section/new-section.component.less
+++ b/packages/client/src/app/pages/work-page/new-section/new-section.component.less
@@ -42,10 +42,14 @@ div.section-container {
         }
     }
     div.authors-note {
+        @media (max-width: 1150px) {
+            max-width: 95%;
+        }
+
         max-width: 70%;
         margin: 3rem auto 0 auto;
         border-top: 2px solid var(--site-accent);
-        h3 {
+        h2.authors-note-header {
             margin-top: 1rem;
             font-weight: 400;
         }

--- a/packages/client/src/app/pages/work-page/section-page/section-page.component.html
+++ b/packages/client/src/app/pages/work-page/section-page/section-page.component.html
@@ -38,7 +38,7 @@
                 </div>
             </div>
             <div class="authors-note" *ngIf="sectionData.authorsNote">
-                <h3>A word from the author...</h3>
+                <h2 class="authors-note-header">A word from the author...</h2>
                 <ng-container *ngIf="!sectionData.usesNewEditor">
                     <quill-view [content]="sectionData.authorsNote" sanitize="true" format="json"></quill-view>
                 </ng-container>    
@@ -72,7 +72,7 @@
                     </div>
                 </div>
                 <div class="authors-note" *ngIf="sectionData.authorsNote">
-                    <h3>A word from the author...</h3>
+                    <h2 class="authors-note-header">A word from the author...</h2>
                     <ng-container *ngIf="!sectionData.usesNewEditor">
                         <quill-view [content]="sectionData.authorsNote" sanitize="true" format="json"></quill-view>
                     </ng-container>    
@@ -139,7 +139,7 @@
                         </div>
                     </div>
                     <div class="authors-note">
-                        <h3>A word from the author...</h3>
+                        <h2 authors-note-header="authors-note-header">A word from the author...</h2>
                         <div class="warning-message" *ngIf="fields.authorsNote.invalid && (fields.authorsNote.dirty || fields.authorsNote.touched)">Author's Notes must be greater than 3 characters.</div>
                         <ng-container *ngIf="!sectionData.usesNewEditor">                        
                         <quill-editor [styles]="{height: '300px'}" minLength="3" formControlName="authorsNote" (onEditorChanged)="triggerChangeDetection()" (onEditorCreated)="onEditorCreated($event)" [formats]="editorFormats">

--- a/packages/client/src/app/pages/work-page/section-page/section-page.component.less
+++ b/packages/client/src/app/pages/work-page/section-page/section-page.component.less
@@ -75,15 +75,14 @@ div.section-container {
         }
     }
     div.authors-note {
-        max-width: 70%;
-        margin: 3rem auto 0 auto;
-        border-top: 2px solid var(--site-accent);
-
         @media (max-width: 1150px) {
             max-width: 95%;
         }
 
-        h3 {
+        max-width: 70%;
+        margin: 3rem auto 0 auto;
+        border-top: 2px solid var(--site-accent);
+        h2.authors-note-header {
             margin-top: 1rem;
             font-weight: 400;
         }

--- a/packages/client/src/styles.less
+++ b/packages/client/src/styles.less
@@ -164,6 +164,23 @@ blockquote {
     padding-left: 10px;
 }
 
+/* Sections and authors notes. These go in the main stylesheet
+ * because section bodies have no view encapsulation, and can be
+ * (and are) affected by global styles. Therefore, these must also be
+ * global styles.
+ * If we can find a way to have an element with directly-set
+ * innerHtml AND view encapsulation, we can move this back down to the
+ * component level.
+*/
+div.section-body, div.authors-note {    
+    h1 { font-size: 3em; } 
+    h2 { font-size: 2em; }
+    h3 { font-size: 1.5em; }
+    h4 { font-size: 1.25em; }
+    h5 { font-size: 1em; font-weight: bold; text-transform: uppercase; }
+    h6 { font-size: 1em; text-transform: uppercase; }
+}
+
 /* Buttons and Inputs */
 a.button, button,
 input[type=text], input[type=password], 


### PR DESCRIPTION
Closes #168.

An interesting discovery: if we set a component's contents directly by modifying `innerHtml` (as we do for section bodies and authors' notes), Angular's CSS view encapsulation doesn't apply to the contents. It took me forever to figure out why the changes I was making in the `section-page.less` component weren't applying to headers within a section body. Turns out those rules were being stomped by the global header rules, because I guess they get declared later, and our page-local rules weren't being protected by Angular's encapsulation.