### PR TITLE
Prevent all markup edits from adding stray line breaks

### DIFF
--- a/packages/client/src/styles.less
+++ b/packages/client/src/styles.less
@@ -229,7 +229,7 @@ div.html-description {
 
     // A little CSS hack to force images at the bottom of content bodies to not break out of their containers.
     // More details here: http://bonrouge.com/br.php?page=floats
-    :last-child:after {
+    > :last-child:after {
         content: ".";
         display: block;
         height: 0;


### PR DESCRIPTION
Now the `:last-child:after` rule will only look at _immediate_ children of section/blog/long desc/author's note bodies.