### PR TITLE
Remove extra margin on left of section lists

### DIFF
--- a/packages/client/src/app/pages/work-page/work-page.component.less
+++ b/packages/client/src/app/pages/work-page/work-page.component.less
@@ -227,6 +227,7 @@ div.work-box {
             list-style: none;
             border: 1px solid whitesmoke;
             border-radius: 4px;
+            margin-left: 0px;
             li {
                 margin: 0;
                 div.section-box {


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/5133649/96365791-b1509600-114b-11eb-808b-11181073f809.png)

After:
![image](https://user-images.githubusercontent.com/5133649/96365797-bc0b2b00-114b-11eb-8958-35a6b4ac5e30.png)
