### PR TITLE
Mobile optimization - Resize navbar with different screen widths

### DIFF
--- a/packages/client/src/app/app.component.less
+++ b/packages/client/src/app/app.component.less
@@ -119,7 +119,7 @@ nav {
   max-width: 80%;
   margin: 0 auto 0 auto;
 
-  @media (max-width: 1150px) {
+  @media (max-width: 1150px) { //--xlarge
       max-width: 95%;
   }
 
@@ -150,6 +150,22 @@ nav {
           margin-left: 0.25rem;
           margin-right: 0.25rem;
 
+          @media(max-width: 992px) { //--large
+              /* half laptop */
+              font-size: 15px;
+              padding: 5px 8px;
+          }
+
+          @media(max-width: 640px) { //--small
+              font-size: 10px;
+              padding: 5px 5px;
+          }
+
+          @media(max-width: 481px) { //--xsmall
+              font-size: 10px;
+              padding: 5px 5px;
+          }
+
           &:hover {
               color: whitesmoke;
               background-color: var(--site-accent);
@@ -169,6 +185,14 @@ nav {
                   width: 20px;
                   top: 0.25rem;
                   stroke-width: 1;
+              }
+
+              @media(max-width: 640px) { //--small
+                  margin-right: 0.5rem;
+              }
+
+              @media(max-width: 481px) { //--xsmall
+                  margin-right: 0.25rem;
               }
           }
       }

--- a/packages/client/src/styles.less
+++ b/packages/client/src/styles.less
@@ -23,6 +23,12 @@
 
     --site-code-background: #f0f0f0;
 
+    // Breakpoint
+    --xlarge: 1150px;
+    --large: 992px; // half-laptop
+    --small: 640px;
+    --xsmall: 481px;
+
     // Other things
     --dark-theme-background: rgb(39,39,39);
     --alt-blue: rgb(80,154,233);


### PR DESCRIPTION
Change the navbar font size and spacing according to the screen width, which should make it look better on mobile devices.

Note that variables can't be used in media fields, but I choose to include them in styles.less for reference.