### PR TITLE
Update Browse page to use Content API

### DIFF
--- a/packages/client/src/app/app.module.ts
+++ b/packages/client/src/app/app.module.ts
@@ -19,10 +19,12 @@ import { CookieModule } from 'ngx-cookie';
 import { Ng2FittextModule } from 'ng2-fittext';
 import { IconsModule } from '@pulp-fiction/icons';
 
-import { SlugifyPipe, PluralizePipe, SeparateEntitiesPipe, FixCategoriesPipe,
-  StringifyMetaPipe, ToLocaleStringPipe, AbbreviateNumbersPipe, SafeHtmlPipe, TruncatePipe, LocaleDatePipe } from './pipes';
+import { SlugifyPipe, PluralizePipe, SeparateGenresPipe, FixCategoriesPipe,
+  StringifyMetaPipe, ToLocaleStringPipe, AbbreviateNumbersPipe, SafeHtmlPipe, 
+  TruncatePipe, LocaleDatePipe, JoinStringsPipe } from './pipes';
 import { AlertsModule, NagBarModule } from './modules';
-import { Divider, dividerHandler, TextSoftBreakBlot, shiftEnterHandler, brMatcher, textNodeMatcher } from './util/quill';
+import { Divider, dividerHandler, TextSoftBreakBlot, shiftEnterHandler, 
+  brMatcher, textNodeMatcher } from './util/quill';
 
 import { HomeComponent, LatestComponent, WatchingPageComponent } from './pages/home';
 
@@ -97,7 +99,7 @@ const toolbarOptions = [
     BlogsComponent, WorksComponent, SettingsComponent, UserMenuComponent,
     SearchMenuComponent, HistoryPageComponent, PortfolioComponent, PortHomeComponent, PortBlogPageComponent, 
     NewWorkComponent, EditWorkComponent, WorkPageComponent, 
-    SectionPageComponent, SeparateEntitiesPipe, FixCategoriesPipe, NewSectionComponent, UploadAvatarComponent, 
+    SectionPageComponent, SeparateGenresPipe, JoinStringsPipe, FixCategoriesPipe, NewSectionComponent, UploadAvatarComponent, 
     BeatrizHeroComponent, UploadCoverartComponent, SearchComponent, FindUsersComponent,
     FindWorksComponent, FindBlogsComponent, StringifyMetaPipe, ToLocaleStringPipe, NetworkInputComponent,
     DocsPageComponent, SiteStaffComponent, CreateCollectionComponent,

--- a/packages/client/src/app/components/rating-icon/rating-icon.component.ts
+++ b/packages/client/src/app/components/rating-icon/rating-icon.component.ts
@@ -9,7 +9,7 @@ import { ContentRating } from '@pulp-fiction/models/content';
 })
 export class RatingIconComponent implements OnInit {
     @Input() rating: ContentRating;
-    @Input() size: string;
+    @Input() size: string = 'small'; // default to small if unset or set imporoperly
 
     constructor() {}
 

--- a/packages/client/src/app/components/site-sidenav/history/history.component.html
+++ b/packages/client/src/app/components/site-sidenav/history/history.component.html
@@ -8,7 +8,7 @@
                 <h4>
                     <a [routerLink]="['/work', $any(item.work)._id, $any(item.work).title | slugify]">{{ $any(item.work).title }}</a>
                 </h4>
-                <h5>{{ $any(item.work).meta.category | fixCategories }}</h5><span>//</span><h5>{{ $any(item.work).meta.genres | separateEntities:$any(item.work).meta.category }}</h5>
+                <h5>{{ $any(item.work).meta.category | fixCategories }}</h5><span>//</span><h5>{{ $any(item.work).meta.genres | separateGenres }}</h5>
             </div>
             <div class="viewed-on">
                 <span>{{ item.viewedOn | localedate: 'shortDate' }}</span>

--- a/packages/client/src/app/components/work-card/work-card.component.html
+++ b/packages/client/src/app/components/work-card/work-card.component.html
@@ -8,7 +8,7 @@
             <span class="divider">//</span>
             <span class="tag">{{ content.meta.category }}</span>
             <span class="divider">//</span>
-            <span class="tag">{{ content.meta.genres | separateEntities }}</span>
+            <span class="tag">{{ content.meta.genres | separateGenres }}</span>
             <span class="tag end"><i-feather name="heart"></i-feather>{{ calcApprovalRating(content.stats.likes, content.stats.dislikes) }}%</span>
         </div>
     </div>

--- a/packages/client/src/app/pages/browse/browse.component.html
+++ b/packages/client/src/app/pages/browse/browse.component.html
@@ -20,14 +20,14 @@
             <div class="work-container">
                 <!--Header-->
                 <div class="work-header">
-                    <rating-icon [rating]="work.meta.rating" [size]="small"/>                          
+                    <rating-icon [rating]="work.meta.rating" [size]="small"></rating-icon>                          
                     <h1><a [routerLink]="['/work', work._id, work.title | slugify]">{{ work.title }}</a></h1>                            
                     <h2>by <a [routerLink]="['/portfolio', work.author._id, work.author.username | slugify]">{{ work.author.username }}</a></h2>
                     <div class="approval" title="Approval Rating">
                         <i-feather name="heart"></i-feather>{{ calcApprovalRating(work.stats.likes, work.stats.dislikes) }}%
                     </div>
                     <div class="category-genre">
-                        {{ work.meta.category | fixCategories }}<span>//</span>{{ work.meta.genres | separateEntities }}<ng-container *ngIf="work.meta.fandoms.length > 0"><span>//</span>{{ work.meta.fandoms | separateEntities }}</ng-container>
+                        {{ work.meta.category | fixCategories }}<span>//</span>{{ work.meta.genres | separateGenres }}<ng-container *ngIf="work.meta.fandoms.length > 0"><span>//</span>{{ work.meta.fandoms | joinStrings }}</ng-container>
                     </div>                            
                 </div>
 
@@ -37,7 +37,7 @@
                         <img class="cover-art bordered-cover-art" [src]="work.meta.coverArt">
                     </div>
                     <div>
-                        {{ work.shortDesc }}
+                        {{ work.desc }}
                     </div>
                 </div>
 
@@ -45,7 +45,7 @@
                 <div class="work-stats">
                     <i-feather name="bar-chart-2" title="Views"></i-feather>{{ work.stats.views | abbreviate }}<span>//</span>
                     <i-feather name="message-circle" title="Comments"></i-feather>{{ work.stats.comments | abbreviate }}<span>//</span>
-                    <i-feather name="pen-tool" title="Words"></i-feather>{{ work.stats.totWords | abbreviate }}<span>//</span>
+                    <i-feather name="pen-tool" title="Words"></i-feather>{{ work.stats.words | abbreviate }}<span>//</span>
                     <i-feather name="calendar" title="Published On"></i-feather>{{ work.audit.publishedOn | localedate: 'mediumDate' }}<span>//</span>
                     {{ work.meta.status }}
                 </div>

--- a/packages/client/src/app/pages/browse/browse.component.html
+++ b/packages/client/src/app/pages/browse/browse.component.html
@@ -20,8 +20,11 @@
             <div class="work-container">
                 <!--Header-->
                 <div class="work-header">
-                    <rating-icon [rating]="work.meta.rating" [size]="small"></rating-icon>                          
-                    <h1><a [routerLink]="['/work', work._id, work.title | slugify]">{{ work.title }}</a></h1>                            
+                    <rating-icon [rating]="work.meta.rating" [size]="'small'"></rating-icon>                          
+                    <h1 [ngSwitch]="work.kind">
+                        <a *ngSwitchCase="'ProseContent'" [routerLink]="['/prose', work._id, work.title | slugify]">{{ work.title }}</a>
+                        <a *ngSwitchCase="'PoetryContent'" [routerLink]="['/poetry', work._id, work.title | slugify]">{{ work.title }}</a>
+                    </h1>                            
                     <h2>by <a [routerLink]="['/portfolio', work.author._id, work.author.username | slugify]">{{ work.author.username }}</a></h2>
                     <div class="approval" title="Approval Rating">
                         <i-feather name="heart"></i-feather>{{ calcApprovalRating(work.stats.likes, work.stats.dislikes) }}%

--- a/packages/client/src/app/pages/browse/browse.component.html
+++ b/packages/client/src/app/pages/browse/browse.component.html
@@ -20,19 +20,14 @@
             <div class="work-container">
                 <!--Header-->
                 <div class="work-header">
-                    <ng-container [ngSwitch]="work.meta.rating">
-                        <div matTooltip="Everyone" matTooltipClass="offprint-tooltip" class="rating everyone small" *ngSwitchDefault>E</div>
-                        <div matTooltip="Teen" matTooltipClass="offprint-tooltip" class="rating teen small" *ngSwitchCase="'Teen'">T</div>
-                        <div matTooltip="Mature" matTooltipClass="offprint-tooltip" class="rating mature small" *ngSwitchCase="'Mature'">M</div>
-                        <div matTooltip="Explicit" matTooltipClass="offprint-tooltip" class="rating explicit small" *ngSwitchCase="'Explicit'">X</div>                                
-                    </ng-container>                            
+                    <rating-icon [rating]="work.meta.rating" [size]="small"/>                          
                     <h1><a [routerLink]="['/work', work._id, work.title | slugify]">{{ work.title }}</a></h1>                            
                     <h2>by <a [routerLink]="['/portfolio', work.author._id, work.author.username | slugify]">{{ work.author.username }}</a></h2>
                     <div class="approval" title="Approval Rating">
                         <i-feather name="heart"></i-feather>{{ calcApprovalRating(work.stats.likes, work.stats.dislikes) }}%
                     </div>
                     <div class="category-genre">
-                        {{ work.meta.category | fixCategories }}<span>//</span>{{ work.meta.genres | separateEntities:work.meta.category }}<ng-container *ngIf="work.meta.fandoms.length > 0"><span>//</span>{{ work.meta.fandoms | separateEntities }}</ng-container>
+                        {{ work.meta.category | fixCategories }}<span>//</span>{{ work.meta.genres | separateEntities }}<ng-container *ngIf="work.meta.fandoms.length > 0"><span>//</span>{{ work.meta.fandoms | separateEntities }}</ng-container>
                     </div>                            
                 </div>
 

--- a/packages/client/src/app/pages/browse/browse.component.ts
+++ b/packages/client/src/app/pages/browse/browse.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { Router, ActivatedRoute } from '@angular/router';
 
-import { ProseContent } from '@pulp-fiction/models/content';
+import { ContentModel, ProseContent } from '@pulp-fiction/models/content';
 import { PaginateResult } from '@pulp-fiction/models/util';
 
 import { calculateApprovalRating } from '../../util/functions';
@@ -13,7 +13,7 @@ import { Constants, Title } from '../../shared';
   styleUrls: ['./browse.component.less']
 })
 export class BrowseComponent implements OnInit {
-  works: PaginateResult<ProseContent>;
+  works: PaginateResult<ContentModel>;
 
   pageNum = 1;
 
@@ -21,7 +21,7 @@ export class BrowseComponent implements OnInit {
 
   ngOnInit(): void {
     Title.setTwoPartTitle(Constants.BROWSE);  
-    this.route.data.subscribe(data => {
+    this.route.data.subscribe(data => {      
       this.works = data.feedData;
     });
   }

--- a/packages/client/src/app/pages/browse/browse.component.ts
+++ b/packages/client/src/app/pages/browse/browse.component.ts
@@ -1,13 +1,11 @@
 import { Component, OnInit } from '@angular/core';
 import { Router, ActivatedRoute } from '@angular/router';
 
-import { Work } from '@pulp-fiction/models/works';
+import { ProseContent } from '@pulp-fiction/models/content';
 import { PaginateResult } from '@pulp-fiction/models/util';
+
 import { calculateApprovalRating } from '../../util/functions';
-
 import { Constants, Title } from '../../shared';
-
-type LoadingState = 'notstarted' | 'loading' | 'success' | 'failure';
 
 @Component({
   selector: 'app-browse',
@@ -15,7 +13,7 @@ type LoadingState = 'notstarted' | 'loading' | 'success' | 'failure';
   styleUrls: ['./browse.component.less']
 })
 export class BrowseComponent implements OnInit {
-  works: PaginateResult<Work>;
+  works: PaginateResult<ProseContent>;
 
   pageNum = 1;
 

--- a/packages/client/src/app/pages/content-views/poetry-page/poetry-page.component.html
+++ b/packages/client/src/app/pages/content-views/poetry-page/poetry-page.component.html
@@ -16,7 +16,7 @@
                 <span class="divider">//</span>
                 <span class="tag">{{ currPoetry.meta.category }}</span>
                 <span class="divider">//</span>
-                <span class="tag">{{ currPoetry.meta.genres | separateEntities }}</span>
+                <span class="tag">{{ currPoetry.meta.genres | separateGenres }}</span>
                 <div class="view-tools">
                     <button matRipple class="tool left"><i-feather name="thumbs-up"></i-feather><span class="button-text">{{ currPoetry.stats.likes | abbreviate }}</span></button>
                     <button matRipple class="tool left"><i-feather name="thumbs-down"></i-feather><span class="button-text">{{ currPoetry.stats.likes | abbreviate }}</span></button>

--- a/packages/client/src/app/pages/content-views/prose-page/prose-page.component.html
+++ b/packages/client/src/app/pages/content-views/prose-page/prose-page.component.html
@@ -16,7 +16,7 @@
                 <span class="divider">//</span>
                 <span class="tag">{{ currProse.meta.category }}</span>
                 <span class="divider">//</span>
-                <span class="tag">{{ currProse.meta.genres | separateEntities }}</span>
+                <span class="tag">{{ currProse.meta.genres | separateGenres }}</span>
                 <div class="view-tools">
                     <button matRipple class="tool left"><i-feather name="thumbs-up"></i-feather><span class="button-text">{{ currProse.stats.likes | abbreviate }}</span></button>
                     <button matRipple class="tool left"><i-feather name="thumbs-down"></i-feather><span class="button-text">{{ currProse.stats.likes | abbreviate }}</span></button>

--- a/packages/client/src/app/pages/my-stuff/views/view-poetry/view-poetry.component.html
+++ b/packages/client/src/app/pages/my-stuff/views/view-poetry/view-poetry.component.html
@@ -80,7 +80,7 @@
                 <span class="divider">//</span>
                 <span class="tag">{{ myPoetry.meta.category }}</span>
                 <span class="divider">//</span>
-                <span class="tag">{{ myPoetry.meta.genres | separateEntities }}</span>
+                <span class="tag">{{ myPoetry.meta.genres | separateGenres }}</span>
             </div>
             <div class="view-description">
                 <ng-container *ngIf="myPoetry.meta.collection; else normalDescription">

--- a/packages/client/src/app/pages/my-stuff/views/view-prose/view-prose.component.html
+++ b/packages/client/src/app/pages/my-stuff/views/view-prose/view-prose.component.html
@@ -80,7 +80,7 @@
                 <span class="divider">//</span>
                 <span class="tag">{{ myProse.meta.category }}</span>
                 <span class="divider">//</span>
-                <span class="tag">{{ myProse.meta.genres | separateEntities }}</span>
+                <span class="tag">{{ myProse.meta.genres | separateGenres }}</span>
             </div>
             <div class="view-description">
                 <div class="html-description" [innerHtml]="myProse.body | safeHtml"></div>

--- a/packages/client/src/app/pages/portfolio/history/history.component.html
+++ b/packages/client/src/app/pages/portfolio/history/history.component.html
@@ -29,8 +29,8 @@
                             <h4 class="author-byline">by <a [routerLink]="['/portfolio', $any(doc.work).author._id, $any(doc.work).author.username | slugify]">{{ $any(doc.work).author.username }}</a></h4>
                             <br>
                             <h4>{{ $any(doc.work).meta.category | fixCategories }}</h4><span>//</span>
-                            <h4>{{ $any(doc.work).meta.genres | separateEntities:$any(doc.work).meta.category }}</h4><span *ngIf="$any(doc.work).meta.fandoms.length > 0">//</span>
-                            <h4 *ngIf="$any(doc.work).meta.fandoms.length > 0">{{ $any(doc.work).meta.fandoms | separateEntities }}</h4>
+                            <h4>{{ $any(doc.work).meta.genres | separateGenres }}</h4><span *ngIf="$any(doc.work).meta.fandoms.length > 0">//</span>
+                            <h4 *ngIf="$any(doc.work).meta.fandoms.length > 0">{{ $any(doc.work).meta.fandoms | joinStrings }}</h4>
                             <div class="stats">                                
                                 <h4>{{ $any(doc.work).meta.status }}</h4><span>//</span>
                                 <h4 title="Approval Rating"><i-feather name="heart"></i-feather>{{ calcApprovalRating($any(doc.work).stats.likes, $any(doc.work).stats.dislikes) }}%</h4><span>//</span>

--- a/packages/client/src/app/pages/portfolio/port-collection-page/port-collection-page.component.html
+++ b/packages/client/src/app/pages/portfolio/port-collection-page/port-collection-page.component.html
@@ -34,9 +34,9 @@
                                     </div>
                                     <div class="category-genre">
                                         {{ entry.work.meta.category | fixCategories }}<span>//</span>
-                                        {{ entry.work.meta.genres | separateEntities:entry.work.meta.category }}
+                                        {{ entry.work.meta.genres | separateGenres }}
                                         <ng-container *ngIf="entry.work.meta.fandoms.length > 0">
-                                            <span>//</span>{{ entry.work.meta.fandoms | separateEntities }}
+                                            <span>//</span>{{ entry.work.meta.fandoms | joinStrings }}
                                         </ng-container>
                                     </div>                            
                                 </div>
@@ -104,9 +104,9 @@
                                 </div>
                                 <div class="category-genre">
                                     {{ entry.work.meta.category | fixCategories }}<span>//</span>
-                                    {{ entry.work.meta.genres | separateEntities:entry.work.meta.category }}
+                                    {{ entry.work.meta.genres | separateGenres }}
                                     <ng-container *ngIf="entry.work.meta.fandoms.length > 0">
-                                        <span>//</span>{{ entry.work.meta.fandoms | separateEntities }}
+                                        <span>//</span>{{ entry.work.meta.fandoms | joinStrings }}
                                     </ng-container>
                                 </div>                            
                             </div>

--- a/packages/client/src/app/pages/search/find-works/find-works.component.html
+++ b/packages/client/src/app/pages/search/find-works/find-works.component.html
@@ -37,7 +37,7 @@
                             <i-feather name="heart"></i-feather>{{ calcApprovalRating(work.stats.likes, work.stats.dislikes) }}%
                         </div>
                         <div class="category-genre">
-                            {{ work.meta.category | fixCategories }}<span>//</span>{{ work.meta.genres | separateEntities:work.meta.category }}<ng-container *ngIf="work.meta.fandoms.length > 0"><span>//</span>{{ work.meta.fandoms | separateEntities }}</ng-container>
+                            {{ work.meta.category | fixCategories }}<span>//</span>{{ work.meta.genres | separateGenres }}<ng-container *ngIf="work.meta.fandoms.length > 0"><span>//</span>{{ work.meta.fandoms | joinStrings }}</ng-container>
                         </div>                            
                     </div>
 

--- a/packages/client/src/app/pages/search/search.component.html
+++ b/packages/client/src/app/pages/search/search.component.html
@@ -51,7 +51,7 @@
                                             <i-feather name="heart"></i-feather>{{ calcApprovalRating(work.stats.likes, work.stats.dislikes) }}%
                                         </div>
                                         <div class="category-genre">
-                                            {{ work.meta.category | fixCategories }}<span>//</span>{{ work.meta.genres | separateEntities:work.meta.category }}<ng-container *ngIf="work.meta.fandoms.length > 0"><span>//</span>{{ work.meta.fandoms | separateEntities }}</ng-container>
+                                            {{ work.meta.category | fixCategories }}<span>//</span>{{ work.meta.genres | separateGenres }}<ng-container *ngIf="work.meta.fandoms.length > 0"><span>//</span>{{ work.meta.fandoms | joinStrings }}</ng-container>
                                         </div>                            
                                     </div>
             

--- a/packages/client/src/app/pages/work-page/work-page.component.html
+++ b/packages/client/src/app/pages/work-page/work-page.component.html
@@ -23,11 +23,11 @@
                         {{ workData.meta.category | fixCategories }}<span>//</span>
                     </div>
                     <div>
-                        {{ workData.meta.genres | separateEntities:workData.meta.category }}
+                        {{ workData.meta.genres | separateGenres }}
                     </div>
                     <div>
                         <ng-container *ngIf="workData.meta.fandoms.length > 0">
-                            <span>//</span>{{ workData.meta.fandoms | separateEntities }}
+                            <span>//</span>{{ workData.meta.fandoms | joinStrings }}
                         </ng-container>
                     </div>
                     <div class="approval">

--- a/packages/client/src/app/pipes/fix-categories.pipe.ts
+++ b/packages/client/src/app/pipes/fix-categories.pipe.ts
@@ -1,9 +1,14 @@
 import { Pipe, PipeTransform } from '@angular/core';
+import { WorkKind } from '@pulp-fiction/models/content';
 import { Categories } from '@pulp-fiction/models/works';
 
-@Pipe({name: 'fixCategories'})
+@Pipe({ name: 'fixCategories' })
 export class FixCategoriesPipe implements PipeTransform {
-    transform(value: Categories) {
-        return Categories[value];
+    transform(value: Categories | WorkKind) {        
+        if (value in Categories) {
+            return Categories[value];
+        } else if (value in WorkKind) {
+            return WorkKind[value];
+        }
     }
 }

--- a/packages/client/src/app/pipes/index.ts
+++ b/packages/client/src/app/pipes/index.ts
@@ -1,6 +1,7 @@
 export { SlugifyPipe } from './slugify.pipe';
 export { PluralizePipe } from './pluralize.pipe';
-export { SeparateEntitiesPipe } from './separate-entities.pipe';
+export { SeparateGenresPipe } from './separate-genres.pipe';
+export { JoinStringsPipe } from './join-strings.pipe';
 export { FixCategoriesPipe } from './fix-categories.pipe';
 export { StringifyMetaPipe } from './stringify-meta.pipe';
 export { ToLocaleStringPipe } from './to-locale-string.pipe';

--- a/packages/client/src/app/pipes/join-strings.pipe.ts
+++ b/packages/client/src/app/pipes/join-strings.pipe.ts
@@ -1,0 +1,12 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({name: 'joinStrings'})
+export class JoinStringsPipe implements PipeTransform {
+    transform(value: string[]) {
+        if (value.length === 1) {
+            return value[0];
+        } else {
+            return value.join(", ");
+        }        
+    }
+}

--- a/packages/client/src/app/pipes/separate-genres.pipe.ts
+++ b/packages/client/src/app/pipes/separate-genres.pipe.ts
@@ -1,8 +1,8 @@
 import { Pipe, PipeTransform } from '@angular/core';
 import { Genres } from '@pulp-fiction/models/content';
 
-@Pipe({name: 'separateEntities'})
-export class SeparateEntitiesPipe implements PipeTransform {
+@Pipe({name: 'separateGenres'})
+export class SeparateGenresPipe implements PipeTransform {
     transform(value: Genres[]) {
         if (value.length === 1) {
             return Genres[value[0]];
@@ -10,6 +10,6 @@ export class SeparateEntitiesPipe implements PipeTransform {
             let theseGenres: string[] = new Array();
             value.forEach(genre => { theseGenres.push(Genres[genre]) });
             return theseGenres.join(', ');
-        }
+        }        
     }
 }

--- a/packages/client/src/app/resolvers/browse-feed.resolver.ts
+++ b/packages/client/src/app/resolvers/browse-feed.resolver.ts
@@ -3,22 +3,22 @@ import { Resolve, ActivatedRouteSnapshot, RouterStateSnapshot } from '@angular/r
 import { Observable } from 'rxjs';
 
 import { PaginateResult } from '@pulp-fiction/models/util';
-import { Work } from '@pulp-fiction/models/works';
-import { BrowseService } from '../services/content';
+import { ContentService } from '../services/content';
+import { ContentKind, ProseContent } from '@pulp-fiction/models/content';
 
 @Injectable()
-export class BrowseFeedResolver implements Resolve<PaginateResult<Work>> {
+export class BrowseFeedResolver implements Resolve<PaginateResult<ProseContent>> {
     pageNum: number = 1;
 
-    constructor (private browseService: BrowseService) { }
+    constructor(private contentService: ContentService) { }
 
-    resolve(route: ActivatedRouteSnapshot, routerState: RouterStateSnapshot): Observable<PaginateResult<Work>> {
+    resolve(route: ActivatedRouteSnapshot, routerState: RouterStateSnapshot): Observable<PaginateResult<ProseContent>> {
         const pageNum = +route.queryParamMap.get('page');
 
         if (pageNum) {
             this.pageNum = pageNum;
         }
 
-        return this.browseService.fetchAllPublishedWorks(this.pageNum);
+        return this.contentService.fetchAllPublished(this.pageNum, ContentKind.ProseContent, null);
     }
 }

--- a/packages/client/src/app/resolvers/browse-feed.resolver.ts
+++ b/packages/client/src/app/resolvers/browse-feed.resolver.ts
@@ -4,21 +4,21 @@ import { Observable } from 'rxjs';
 
 import { PaginateResult } from '@pulp-fiction/models/util';
 import { ContentService } from '../services/content';
-import { ContentKind, ProseContent } from '@pulp-fiction/models/content';
+import { ContentKind, ContentModel } from '@pulp-fiction/models/content';
 
 @Injectable()
-export class BrowseFeedResolver implements Resolve<PaginateResult<ProseContent>> {
+export class BrowseFeedResolver implements Resolve<PaginateResult<ContentModel>> {
     pageNum: number = 1;
 
     constructor(private contentService: ContentService) { }
 
-    resolve(route: ActivatedRouteSnapshot, routerState: RouterStateSnapshot): Observable<PaginateResult<ProseContent>> {
+    resolve(route: ActivatedRouteSnapshot, routerState: RouterStateSnapshot): Observable<PaginateResult<ContentModel>> {
         const pageNum = +route.queryParamMap.get('page');
 
         if (pageNum) {
             this.pageNum = pageNum;
         }
 
-        return this.contentService.fetchAllPublished(this.pageNum, ContentKind.ProseContent, null);
+        return this.contentService.fetchAllPublished(this.pageNum, [ContentKind.PoetryContent, ContentKind.ProseContent], null);
     }
 }

--- a/packages/client/src/app/resolvers/port-blogs.resolver.ts
+++ b/packages/client/src/app/resolvers/port-blogs.resolver.ts
@@ -20,6 +20,6 @@ export class PortBlogsResolver implements Resolve<PaginateResult<BlogsContentMod
             this.pageNum = pageNum;
         }
 
-        return this.contentService.fetchAllPublished(this.pageNum, ContentKind.BlogContent, userId) as Observable<PaginateResult<BlogsContentModel>>;
+        return this.contentService.fetchAllPublished(this.pageNum, [ContentKind.BlogContent], userId) as Observable<PaginateResult<BlogsContentModel>>;
     }
 }

--- a/packages/client/src/app/resolvers/port-works.resolver.ts
+++ b/packages/client/src/app/resolvers/port-works.resolver.ts
@@ -24,8 +24,8 @@ export class PortWorksResolver implements Resolve<PortWorks> {
             this.pageNum = pageNum;
         }
 
-        const proseList = this.contentService.fetchAllPublished(this.pageNum, ContentKind.ProseContent, userId);
-        const poetryList = this.contentService.fetchAllPublished(this.pageNum, ContentKind.PoetryContent, userId);
+        const proseList = this.contentService.fetchAllPublished(this.pageNum, [ContentKind.ProseContent], userId);
+        const poetryList = this.contentService.fetchAllPublished(this.pageNum, [ContentKind.PoetryContent], userId);
 
         return zip(proseList, poetryList).pipe(map(value => {
             const portWorks: PortWorks = {

--- a/packages/client/src/app/resolvers/work-page.resolver.ts
+++ b/packages/client/src/app/resolvers/work-page.resolver.ts
@@ -8,6 +8,9 @@ import { WorkPageData } from '../models/site';
 import { AuthService } from '../services/auth';
 import { HistoryService, LocalSectionsService, WorksService } from '../services/content';
 
+
+// This resolver is obsolete. 
+// TODO: Delete.
 @Injectable()
 export class WorkPageResolver implements Resolve<WorkPageData> {
     currentUser: FrontendUser;

--- a/packages/client/src/styles.less
+++ b/packages/client/src/styles.less
@@ -134,7 +134,7 @@ div.rating {
         height: 24px;
         width: 24px;
     }
-    &.large {
+    &.medium {
         border: 3px solid #000000;
         font-size: 32px;
         line-height: 32px;

--- a/packages/dashboard/src/app/pipes/fix-categories.pipe.ts
+++ b/packages/dashboard/src/app/pipes/fix-categories.pipe.ts
@@ -1,9 +1,14 @@
 import { Pipe, PipeTransform } from '@angular/core';
+import { WorkKind } from '@pulp-fiction/models/content';
 import { Categories } from '@pulp-fiction/models/works';
 
 @Pipe({name: 'fixCategories'})
 export class FixCategoriesPipe implements PipeTransform {
-    transform(value: Categories) {
-        return Categories[value];
+    transform(value: Categories | WorkKind) {        
+        if (value in Categories) {
+            return Categories[value];
+        } else if (value in WorkKind) {
+            return WorkKind[value];
+        }        
     }
 }

--- a/packages/server/src/app/api/content/content.controller.ts
+++ b/packages/server/src/app/api/content/content.controller.ts
@@ -38,7 +38,7 @@ export class ContentController {
     }
 
     @Get('fetch-all-published')
-    async fetchAllPublished(@Request() req: any, @Query('pageNum') pageNum: number, @Query('userId') userId: string, @Query('kind') kind: ContentKind) {
+    async fetchAllPublished(@Request() req: any, @Query('pageNum') pageNum: number, @Query('userId') userId: string, @Query('kind') kind: ContentKind[]) {
         if (isNullOrUndefined(pageNum) && isNullOrUndefined(kind)) {
             throw new BadRequestException(`You must include both the page number and content kind in your request.`);
         }

--- a/packages/server/src/app/api/content/news/news.controller.ts
+++ b/packages/server/src/app/api/content/news/news.controller.ts
@@ -10,7 +10,7 @@ export class NewsController {
 
     @Get('news-feed/:pageNum')
     async getNewsFeed(@Param('pageNum') pageNum: number) {
-        return await this.contentService.fetchAllPublished(pageNum, ContentKind.NewsContent);
+        return await this.contentService.fetchAllPublished(pageNum, [ContentKind.NewsContent]);
     }
 
     @UseGuards(OptionalAuthGuard)

--- a/packages/server/src/app/db/content/content.service.ts
+++ b/packages/server/src/app/db/content/content.service.ts
@@ -80,10 +80,10 @@ export class ContentService {
      * Fetches all published documents based on kind, limited by page number.
      * 
      * @param pageNum The current page
-     * @param kind The kind of document to fetch
+     * @param kinds The kind of document to fetch
      */
-    async fetchAllPublished(pageNum: number, kind: ContentKind, userId?: string): Promise<PaginateResult<ContentDocument>> {
-        let query = {'kind': kind, 'audit.isDeleted': false, 'audit.published': PubStatus.Published};
+    async fetchAllPublished(pageNum: number, kinds: ContentKind[], userId?: string): Promise<PaginateResult<ContentDocument>> {
+        let query = {'kind': {$in: kinds}, 'audit.isDeleted': false, 'audit.published': PubStatus.Published};
         let paginateOptions = {sort: {'audit.publishedOn': -1}, page: pageNum, limit: 15};
         
         if (userId) {


### PR DESCRIPTION
Also updated the `separateEntites` pipe. It's just used for separating Genres now, so it's been renamed. We also needed a way to turn a `string[]` of fandoms into a comma-separated string, so I introduced a general `JoinStringsPipe` that does just that for any array of strings.

EDIT: Part 2 - Done! Had to do some backend work to make the `get-all-published` understand how to handle a client asking for an array for `ContentKind`s, but it was a small change, and makes the client logic significantly simpler. Also had to do a bit of cleanup around category pipes and such.

Request to @Figments: can you double check the component that Browse page links take users to? I'm pretty sure it's the right one, but I'm not 100% what your plan is there.

Status: Ready for review!