### PR TITLE
Fix/prose and poetry page display

### DIFF
--- a/packages/client/src/app/pages/content-views/poetry-page/poetry-page.component.html
+++ b/packages/client/src/app/pages/content-views/poetry-page/poetry-page.component.html
@@ -19,7 +19,7 @@
                 <span class="tag">{{ currPoetry.meta.genres | separateGenres }}</span>
                 <div class="view-tools">
                     <button matRipple class="tool left"><i-feather name="thumbs-up"></i-feather><span class="button-text">{{ currPoetry.stats.likes | abbreviate }}</span></button>
-                    <button matRipple class="tool left"><i-feather name="thumbs-down"></i-feather><span class="button-text">{{ currPoetry.stats.likes | abbreviate }}</span></button>
+                    <button matRipple class="tool left"><i-feather name="thumbs-down"></i-feather><span class="button-text">{{ currPoetry.stats.dislikes | abbreviate }}</span></button>
                     <button matRipple class="tool left" [matMenuTriggerFor]="moreMenu"><i-feather name="more-vertical" class="more"></i-feather></button>
                 </div>
             </div>

--- a/packages/client/src/app/pages/content-views/poetry-page/poetry-page.component.less
+++ b/packages/client/src/app/pages/content-views/poetry-page/poetry-page.component.less
@@ -59,21 +59,24 @@ div.view-container {
                 display: flex;
                 flex-direction: row;
                 align-items: center;
-    
-                h2 {
+                div.view-title-info {
                     flex: 1;
-                    position: relative;
-                    top: 0.4rem;
-                    font-weight: 700;
-                    font-size: 36px;
-                    margin-bottom: 0;
-                }
-
-                span.byline {
-                    color: var(--site-text-color);
-                    font-size: 15px;
-                    font-weight: 300;
-                    font-style: italic;
+                    h2 {
+                        position: relative;
+                        top: 0.4rem;
+                        font-weight: 700;
+                        font-size: 42px;
+                        margin-bottom: 0;
+                        display: inline-block;
+                    }
+                    span.byline {
+                        color: var(--site-text-color);
+                        font-size: 15px;
+                        font-weight: 300;
+                        font-style: italic;
+                        display: inline-block;
+                        margin-left: 1rem;
+                    }
                 }
             }
     

--- a/packages/client/src/app/pages/content-views/prose-page/prose-page.component.html
+++ b/packages/client/src/app/pages/content-views/prose-page/prose-page.component.html
@@ -19,7 +19,7 @@
                 <span class="tag">{{ currProse.meta.genres | separateGenres }}</span>
                 <div class="view-tools">
                     <button matRipple class="tool left"><i-feather name="thumbs-up"></i-feather><span class="button-text">{{ currProse.stats.likes | abbreviate }}</span></button>
-                    <button matRipple class="tool left"><i-feather name="thumbs-down"></i-feather><span class="button-text">{{ currProse.stats.likes | abbreviate }}</span></button>
+                    <button matRipple class="tool left"><i-feather name="thumbs-down"></i-feather><span class="button-text">{{ currProse.stats.dislikes | abbreviate }}</span></button>
                     <button matRipple class="tool left" [matMenuTriggerFor]="moreMenu"><i-feather name="more-vertical" class="more"></i-feather></button>
                 </div>
             </div>

--- a/packages/client/src/app/pages/content-views/prose-page/prose-page.component.less
+++ b/packages/client/src/app/pages/content-views/prose-page/prose-page.component.less
@@ -59,21 +59,25 @@ div.view-container {
                 display: flex;
                 flex-direction: row;
                 align-items: center;
-    
-                h2 {
-                    flex: 1;
-                    position: relative;
-                    top: 0.4rem;
-                    font-weight: 700;
-                    font-size: 36px;
-                    margin-bottom: 0;
-                }
 
-                span.byline {
-                    color: var(--site-text-color);
-                    font-size: 15px;
-                    font-weight: 300;
-                    font-style: italic;
+                div.view-title-info {
+                    flex: 1;
+                    h2 {
+                        position: relative;
+                        top: 0.4rem;
+                        font-weight: 700;
+                        font-size: 42px;
+                        margin-bottom: 0;
+                        display: inline-block;
+                    }
+                    span.byline {
+                        color: var(--site-text-color);
+                        font-size: 15px;
+                        font-weight: 300;
+                        font-style: italic;
+                        display: inline-block;
+                        margin-left: 1rem;
+                    }
                 }
             }
     

--- a/packages/client/src/app/shared/constants.ts
+++ b/packages/client/src/app/shared/constants.ts
@@ -1,5 +1,5 @@
 export class Constants {
-    public static siteVersion: string = '0.5.0';
+    public static siteVersion: string = '0.5.2';
 
     public static NOTIFICATIONS: string = "Notifications";
     public static BLOGS: string = "Blogs";


### PR DESCRIPTION
Fixes the following issues with poetry and prose content views:
- Dislike counter using the `likes` stat tracker
- Author byline is now on the same line as the title, just as before

Also bumps the site version to 0.5.2