### PR TITLE
Fix old prose sections displaying invalid date

### DIFF
--- a/packages/client/src/app/pages/content-views/prose-page/prose-page.component.html
+++ b/packages/client/src/app/pages/content-views/prose-page/prose-page.component.html
@@ -39,7 +39,7 @@
                             <div class="section-info">
                                 <span class="tag" [matTooltip]="'Words'" [matTooltipClass]="'offprint-tooltip'"><i-feather name="pen-tool"></i-feather>{{ section.stats.words | abbreviate }}</span>
                                 <span class="divider">//</span>
-                                <span class="tag" [matTooltip]="'Published On'" [matTooltipClass]="'offprint-tooltip'"><i-feather name="calendar"></i-feather>{{ section.audit.publishedOn | localedate:'mediumDate'}}</span>
+                                <span class="tag" [matTooltip]="'Published On'" [matTooltipClass]="'offprint-tooltip'"><i-feather name="calendar"></i-feather>{{ getPublishedDate(section) | localedate:'mediumDate'}}</span>
                             </div>
                             <div class="section-button">
                                 <button><i-feather name="chevron-right"></i-feather></button>

--- a/packages/client/src/app/pages/content-views/prose-page/prose-page.component.ts
+++ b/packages/client/src/app/pages/content-views/prose-page/prose-page.component.ts
@@ -63,4 +63,15 @@ export class ProsePageComponent implements OnInit {
         this.router.navigate([], {relativeTo: this.route});
         }
     }
+
+    /**
+     * Old prose won't have a publishedOn value, so createdAt is used instead
+     * @param section 
+     */
+    getPublishedDate(section: SectionInfo): Date {
+        if (section.audit.publishedOn === null) {
+            return section.createdAt;
+        }
+        return section.audit.publishedOn;
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/OffprintStudios/pulp-fiction/issues/254
- Uses a section's createdAt value instead of publishedOn if it isn't available
- No changes to handle old poetry, since there won't be any on the site