### PR TITLE
Fix/markdown docs

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "ng2-fittext": "^1.2.12",
     "ngx-cookie": "^5.0.0",
     "ngx-image-cropper": "^3.2.1",
+    "ngx-markdown": "^11.0.1",
     "ngx-pagination": "^5.0.0",
     "ngx-quill": "^12.0.1",
     "numeral": "^2.0.6",

--- a/packages/client/src/app/app-routing.module.ts
+++ b/packages/client/src/app/app-routing.module.ts
@@ -12,7 +12,7 @@ import { MyStuffComponent, ProseFormComponent, BlogFormComponent, PoetryFormComp
   
 import { BrowseComponent, PostPageComponent, SocialComponent } from './pages';
   
-import { DocsPageComponent, SiteStaffComponent } from './pages/docs-page';
+import { SiteStaffComponent } from './pages/docs-page';
   
 import { RegisterComponent } from './pages/account';
   
@@ -36,6 +36,7 @@ import { ApprovalQueueComponent, AuditLogComponent, DashComponent, GroupQueueCom
 import { ApprovalQueueResolver } from './pages/dash/approval-queue';
 import { NewsManagementResolver, PostFormComponent, PostFormResolver } from './pages/dash/news-management';
 import { Roles } from '@pulp-fiction/models/users';
+import { AboutOffprintComponent, CodeOfConductComponent, OmnibusComponent, TosComponent } from './pages/docs';
 
 const routes: Routes = [
     {path: '', redirectTo: '/home', pathMatch: 'full'},
@@ -80,8 +81,11 @@ const routes: Routes = [
       {path: 'blogs', component: FindBlogsComponent},
       {path: 'works', component: FindWorksComponent},
     ]},
+    {path: 'terms-of-service', component: TosComponent},
+    {path: 'omnibus', component: OmnibusComponent},
+    {path: 'what-is-offprint', component: AboutOffprintComponent},
+    {path: 'code-of-conduct', component: CodeOfConductComponent},
     {path: 'site-staff', component: SiteStaffComponent},
-    {path: 'docs/:docId', component: DocsPageComponent},
     {path: 'migration', component: MigrationComponent, canActivate: [AuthGuard], resolve: {contentData: MigrationResolver}, runGuardsAndResolvers: 'always', children: [
       {path: 'work/:workId', component: MigrateWorkComponent, canActivate: [AuthGuard], resolve: {workData: MigrateWorkResolver}, runGuardsAndResolvers: 'always'},
       {path: 'blog/:blogId', component: MigrateBlogComponent, canActivate: [AuthGuard], resolve: {blogData: MigrateBlogResolver}, runGuardsAndResolvers: 'always'}

--- a/packages/client/src/app/app.component.html
+++ b/packages/client/src/app/app.component.html
@@ -59,12 +59,11 @@
           <div class="grid-container thirds">
             <div>
               <h1>Help</h1>
-              <p> Here's some useful tips to get you started:</p>
+              <p> Here's some useful things to get you started:</p>
               <ul>
-                <li><a [routerLink]="['/docs/what-is-offprint']">What is Offprint?</a></li>
-                <li><a [routerLink]="['/docs/connect-with-offprint']">Connect with Offprint</a></li>
-                <li><a [routerLink]="['/docs/omnibus']">The Offprint Omnibus</a></li>
-                <li><a [routerLink]="['/docs/code-of-conduct']">Code of Conduct</a></li>
+                <li><a [routerLink]="['/what-is-offprint']">What is Offprint?</a></li>
+                <li><a [routerLink]="['/omnibus']">The Offprint Omnibus</a></li>
+                <li><a [routerLink]="['/code-of-conduct']">Code of Conduct</a></li>
               </ul>
             </div>
             <div>
@@ -77,7 +76,7 @@
                 &copy;2020 Offprint Studios
               </p>
               <ul>
-                <li><a [routerLink]="['/docs/terms-and-privacy']">Terms of Service & Privacy Policy</a></li>
+                <li><a [routerLink]="['/terms-of-service']">Terms of Service & Privacy Policy</a></li>
                 <li><a [routerLink]="['/docs/open-source-licenses']">Open Source Licenses</a></li>
                 <li><a [routerLink]="['/site-staff']">Site Staff</a></li>
                 <li><a [routerLink]="['/supporters']">Patreon Supporters</a></li>

--- a/packages/client/src/app/app.module.ts
+++ b/packages/client/src/app/app.module.ts
@@ -46,6 +46,7 @@ import { ProsePageComponent, PoetryPageComponent, SectionViewComponent } from '.
 import { DashComponent, OverviewComponent, ApprovalQueueComponent, GroupQueueComponent, NewsManagementComponent,
   ReportsComponent, UsersManagementComponent, AuditLogComponent } from './pages/dash';
 import { PostFormComponent } from './pages/dash/news-management';
+import { TosComponent, CodeOfConductComponent, OmnibusComponent, AboutOffprintComponent } from './pages/docs';
 
 import { DocsPageComponent, SiteStaffComponent } from './pages/docs-page';
 
@@ -116,7 +117,7 @@ const toolbarOptions = [
     SectionItemComponent, WorkCardComponent, ProsePageComponent, PoetryPageComponent, SectionViewComponent, LocaleDatePipe,
     MigrationComponent, MigrateWorkComponent, MigrateBlogComponent, ContentApprovalComponent, CollectionPageComponent,
     DashComponent, OverviewComponent, ApprovalQueueComponent, GroupQueueComponent, NewsManagementComponent, 
-    ReportsComponent, UsersManagementComponent, AuditLogComponent, PostFormComponent
+    ReportsComponent, UsersManagementComponent, AuditLogComponent, PostFormComponent, TosComponent, CodeOfConductComponent, OmnibusComponent, AboutOffprintComponent
   ],
   imports: [
     BrowserModule, AppRoutingModule, HttpClientModule, FormsModule, ReactiveFormsModule, IconsModule, 

--- a/packages/client/src/app/app.module.ts
+++ b/packages/client/src/app/app.module.ts
@@ -20,6 +20,7 @@ import { Ng2FittextModule } from 'ng2-fittext';
 import { IconsModule } from '@pulp-fiction/icons';
 import { LoadingBarModule } from '@ngx-loading-bar/core';
 import { LoadingBarHttpClientModule } from '@ngx-loading-bar/http-client';
+import { MarkdownModule } from 'ngx-markdown';
 
 import { SlugifyPipe, PluralizePipe, SeparateGenresPipe, FixCategoriesPipe,
   StringifyMetaPipe, ToLocaleStringPipe, AbbreviateNumbersPipe, SafeHtmlPipe, 
@@ -122,6 +123,7 @@ const toolbarOptions = [
     AlertsModule, FileUploadModule, NgSelectModule, ImageCropperModule, NgxPaginationModule,
     NagBarModule, BrowserAnimationsModule, CKEditorModule, MaterialModule, Ng2FittextModule,
     LoadingBarModule, LoadingBarHttpClientModule,
+    MarkdownModule.forRoot(),
     CookieModule.forRoot(),
     QuillModule.forRoot({
       format: 'json',

--- a/packages/client/src/app/pages/account/register/register.component.html
+++ b/packages/client/src/app/pages/account/register/register.component.html
@@ -67,7 +67,7 @@
 
             <label>
                 <input type="checkbox" formControlName="tosCheck" required>
-                <span class="label-body">I agree to the <a [routerLink]="['/docs/terms-and-privacy']">Offprint Terms of Service and Privacy Policy</a>, and <a [routerLink]="['/docs/code-of-conduct']">Code of Conduct</a>.</span>
+                <span class="label-body">I agree to the <a [routerLink]="['/terms-of-service']">Offprint Terms of Service and Privacy Policy</a>, and <a [routerLink]="['/code-of-conduct']">Code of Conduct</a>.</span>
             </label>
             <label>
                 <input type="checkbox" formControlName="ageCheck" required>

--- a/packages/client/src/app/pages/docs/about-offprint/about-offprint.component.html
+++ b/packages/client/src/app/pages/docs/about-offprint/about-offprint.component.html
@@ -1,0 +1,3 @@
+<div class="doc-container">
+    <markdown [src]="'assets/docs/what-is-offprint.md'"></markdown>
+</div>

--- a/packages/client/src/app/pages/docs/about-offprint/about-offprint.component.less
+++ b/packages/client/src/app/pages/docs/about-offprint/about-offprint.component.less
@@ -1,0 +1,8 @@
+div.doc-container {
+    max-width: 85%;
+    margin: 5rem auto 0 auto;
+
+    @media (max-width: 900px) {
+        max-width: 95%;
+    }
+}

--- a/packages/client/src/app/pages/docs/about-offprint/about-offprint.component.ts
+++ b/packages/client/src/app/pages/docs/about-offprint/about-offprint.component.ts
@@ -1,0 +1,12 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+    selector: 'about-offprint',
+    templateUrl: './about-offprint.component.html',
+    styleUrls: ['./about-offprint.component.less']
+})
+export class AboutOffprintComponent implements OnInit {
+    constructor() {}
+
+    ngOnInit(): void {}
+}

--- a/packages/client/src/app/pages/docs/code-of-conduct/code-of-conduct.component.html
+++ b/packages/client/src/app/pages/docs/code-of-conduct/code-of-conduct.component.html
@@ -1,0 +1,3 @@
+<div class="doc-container">
+    <markdown [src]="'assets/docs/code-of-conduct.md'"></markdown>
+</div>

--- a/packages/client/src/app/pages/docs/code-of-conduct/code-of-conduct.component.less
+++ b/packages/client/src/app/pages/docs/code-of-conduct/code-of-conduct.component.less
@@ -1,0 +1,8 @@
+div.doc-container {
+    max-width: 85%;
+    margin: 5rem auto 0 auto;
+
+    @media (max-width: 900px) {
+        max-width: 95%;
+    }
+}

--- a/packages/client/src/app/pages/docs/code-of-conduct/code-of-conduct.component.ts
+++ b/packages/client/src/app/pages/docs/code-of-conduct/code-of-conduct.component.ts
@@ -1,0 +1,12 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+    selector: 'code-of-conduct',
+    templateUrl: './code-of-conduct.component.html',
+    styleUrls: ['./code-of-conduct.component.less']
+})
+export class CodeOfConductComponent implements OnInit {
+    constructor() {}
+
+    ngOnInit(): void {}
+}

--- a/packages/client/src/app/pages/docs/index.ts
+++ b/packages/client/src/app/pages/docs/index.ts
@@ -1,0 +1,4 @@
+export { TosComponent } from './tos/tos.component';
+export { OmnibusComponent } from './omnibus/omnibus.component';
+export { CodeOfConductComponent } from './code-of-conduct/code-of-conduct.component';
+export { AboutOffprintComponent } from './about-offprint/about-offprint.component';

--- a/packages/client/src/app/pages/docs/omnibus/omnibus.component.html
+++ b/packages/client/src/app/pages/docs/omnibus/omnibus.component.html
@@ -1,0 +1,3 @@
+<div class="doc-container">
+    <markdown [src]="'assets/docs/omnibus.md'"></markdown>
+</div>

--- a/packages/client/src/app/pages/docs/omnibus/omnibus.component.less
+++ b/packages/client/src/app/pages/docs/omnibus/omnibus.component.less
@@ -1,0 +1,8 @@
+div.doc-container {
+    max-width: 85%;
+    margin: 5rem auto 0 auto;
+
+    @media (max-width: 900px) {
+        max-width: 95%;
+    }
+}

--- a/packages/client/src/app/pages/docs/omnibus/omnibus.component.ts
+++ b/packages/client/src/app/pages/docs/omnibus/omnibus.component.ts
@@ -1,0 +1,12 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+    selector: 'omnibus',
+    templateUrl: './omnibus.component.html',
+    styleUrls: ['./omnibus.component.less']
+})
+export class OmnibusComponent implements OnInit {
+    constructor() {}
+
+    ngOnInit(): void {}
+}

--- a/packages/client/src/app/pages/docs/tos/tos.component.html
+++ b/packages/client/src/app/pages/docs/tos/tos.component.html
@@ -1,0 +1,3 @@
+<div class="doc-container">
+    <markdown [src]="'assets/docs/tos.md'"></markdown>
+</div>

--- a/packages/client/src/app/pages/docs/tos/tos.component.less
+++ b/packages/client/src/app/pages/docs/tos/tos.component.less
@@ -1,0 +1,8 @@
+div.doc-container {
+    max-width: 85%;
+    margin: 5rem auto 0 auto;
+
+    @media (max-width: 900px) {
+        max-width: 95%;
+    }
+}

--- a/packages/client/src/app/pages/docs/tos/tos.component.ts
+++ b/packages/client/src/app/pages/docs/tos/tos.component.ts
@@ -1,0 +1,12 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+    selector: 'tos-component',
+    templateUrl: './tos.component.html',
+    styleUrls: ['./tos.component.less']
+})
+export class TosComponent implements OnInit {
+    constructor() {}
+
+    ngOnInit(): void {}
+}

--- a/packages/client/src/assets/docs/code-of-conduct.md
+++ b/packages/client/src/assets/docs/code-of-conduct.md
@@ -1,0 +1,24 @@
+# Code of Conduct
+
+## Scope
+
+The Offprint Code of Conduct applies to all interactions relating to the site. This includes but is not limited to:
+- user blogs
+- published and unpublished prose and poetry
+- comments
+- discussions on the Offprint Discord server
+
+Failure to adhere to these guidelines or to correct behaviour brought to your attention by site staff may result in content removal, temporary/permanent account suspensions, and legal action.
+
+## Guidelines
+
+- Be civil, courteous, and considerate to all Offprint users at all times
+- Refrain from inciting, encouraging, or enacting personal attacks towards other users or real persons in all content related to Offprint
+- All forms of discrimination or bigotry (sexism, racism, homophobia, transphobia, religious persecution, etc.) directed towards users or other persons are forbidden
+- Do not link to, post, or encourage illegal content on Offprint. This includes providing access to pirated software, encouragement of piracy/theft or other criminal actions, or work that is not your own without proper attribution
+- Users may not engage in spam-posting, phishing, or similar behaviours
+- Do not fish for interaction with your work, such as by offering rewards in exchange for following or voting on works
+- Users may not share the private information of others (i.e. home address, legal information, etc.) either on or off-site
+- Ban-evading behaviour is prohibited. Banned/suspended users may not create or use alternate accounts for the duration of their restriction nor attempt to circumvent other security measures put in place by site staff. To appeal a ban, please contact beatriz@offprint.net
+- Users may not create alternate accounts for the purposes of ban evasion or to artificially boost the popularity of other works, nor to attempt to impersonate or attack other users. All other alt accounts are subject to moderator discretion
+- All rules detailed here are subject to moderator discretion, and are subject to change as staff sees necessary

--- a/packages/client/src/assets/docs/omnibus.md
+++ b/packages/client/src/assets/docs/omnibus.md
@@ -1,0 +1,3 @@
+# The Offprint Omnibus
+
+TO BE COMPLETED: The complete guide of How To Post On Offprint, with a base level overview of the site, its tagging system, and how best to align with the Code of Conduct.

--- a/packages/client/src/assets/docs/tos.md
+++ b/packages/client/src/assets/docs/tos.md
@@ -1,0 +1,177 @@
+# Terms of Service & Privacy Policy
+
+## 1. Terms
+
+By accessing the website at https://offprint.net, you are agreeing to be bound by these terms of service, all applicable laws and regulations, and agree that you are responsible for compliance with any applicable local laws. If you do not agree with any of these terms, you are prohibited from using or accessing this site. The materials contained in this website are protected by applicable copyright and trademark law.
+
+## 2. Use License
+
+A.  Permission is granted to temporarily download one copy of the materials (information or software) on Offprint Studios' website for personal, non-commercial transitory viewing only. This is the grant of a license, not a transfer of title, and under this license you may not:
+- modify or copy the materials;
+- use the materials for any commercial purpose, or for any public display (commercial or non-commercial);
+- attempt to decompile or reverse engineer any software contained on Offprint Studios' website;
+- remove any copyright or other proprietary notations from the materials; or
+- transfer the materials to another person or "mirror" the materials on any other server.
+
+B. This license shall automatically terminate if you violate any of these restrictions and may be terminated by Offprint Studios at any time. Upon terminating your viewing of these materials or upon the termination of this license, you must destroy any downloaded materials in your possession whether in electronic or printed format.
+
+## 3. Disclaimer
+
+A. The materials on Offprint Studios' website are provided on an 'as is' basis. Offprint Studios makes no warranties, expressed or implied, and hereby disclaims and negates all other warranties including, without limitation, implied warranties or conditions of merchantability, fitness for a particular purpose, or non-infringement of intellectual property or other violation of rights.
+
+B. Further, Offprint Studios does not warrant or make any representations concerning the accuracy, likely results, or reliability of the use of the materials on its website or otherwise relating to such materials or on any sites linked to this site.
+
+## 4. Limitations
+
+In no event shall Offprint Studios or its suppliers be liable for any damages (including, without limitation, damages for loss of data or profit, or due to business interruption) arising out of the use or inability to use the materials on Offprint Studios' website, even if Offprint Studios or a Offprint Studios authorized representative has been notified orally or in writing of the possibility of such damage. Because some jurisdictions do not allow limitations on implied warranties, or limitations of liability for consequential or incidental damages, these limitations may not apply to you.
+
+## 5. Accuracy of Materials
+
+The materials appearing on Offprint Studios' website could include technical, typographical, or photographic errors. Offprint Studios does not warrant that any of the materials on its website are accurate, complete or current. Offprint Studios may make changes to the materials contained on its website at any time without notice. However Offprint Studios does not make any commitment to update the materials.
+
+## 6. Links
+
+Offprint Studios has not reviewed all of the sites linked to its website and is not responsible for the contents of any such linked site. The inclusion of any link does not imply endorsement by Offprint Studios of the site. Use of any such linked website is at the user's own risk.
+
+## 7. Modifications
+
+Offprint Studios may revise these terms of service for its website at any time without notice. By using this website you are agreeing to be bound by the then current version of these terms of service.
+
+## 8. Governing Law
+
+These terms and conditions are governed by and construed in accordance with the laws of California and you irrevocably submit to the exclusive jurisdiction of the courts in that State or location.
+
+# Privacy Policy
+
+Your privacy is important to us. It is Offprint Studios' policy to respect your privacy regarding any information we may collect from you across our website, https://offprint.net, and other sites we own and operate.
+
+## 1. Information We Collect
+
+### Log Data
+
+When you visit our website, our servers may automatically log the standard data provided by your web browser. It may include your computer’s Internet Protocol (IP) address, your browser type and version, the pages you visit, the time and date of your visit, the time spent on each page, and other details.
+
+### Device Data
+
+We may also collect data about the device you’re using to access our website. This data may include the device type, operating system, unique device identifiers, device settings, and geo-location data. What we collect can depend on the individual settings of your device and software. We recommend checking the policies of your device manufacturer or software provider to learn what information they make available to us.
+
+### Personal Information
+
+We may ask for personal information, such as your:
+- Email
+
+## 2. Legal Bases For Processing
+
+We will process your personal information lawfully, fairly and in a transparent manner. We collect and process information about you only where we have legal bases for doing so.
+
+These legal bases depend on the services you use and how you use them, meaning we collect and use your information only where:
+- it’s necessary for the performance of a contract to which you are a party or to take steps at your request before entering into such a contract (for example, when we provide a service you request from us);
+- it satisfies a legitimate interest (which is not overridden by your data protection interests), such as for research and development, to market and promote our services, and to protect our legal rights and interests;
+- you give us consent to do so for a specific purpose (for example, you might consent to us sending you our newsletter); or
+- we need to process your data to comply with a legal obligation.
+
+Where you consent to our use of information about you for a specific purpose, you have the right to change your mind at any time (but this will not affect any processing that has already taken place).
+
+We don’t keep personal information for longer than is necessary. While we retain this information, we will protect it within commercially acceptable means to prevent loss and theft, as well as unauthorized access, disclosure, copying, use or modification. That said, we advise that no method of electronic transmission or storage is 100% secure and cannot guarantee absolute data security. If necessary, we may retain your personal information for our compliance with a legal obligation or in order to protect your vital interests or the vital interests of another natural person.
+
+## 3. Collection & Use of Information
+
+We may collect, hold, use and disclose information for the following purposes and personal information will not be further processed in a manner that is incompatible with these purposes:
+- to enable you to access and use our website, associated applications and associated social media platforms;to contact and communicate with you;for internal record keeping and administrative purposes; andto comply with our legal obligations and resolve any disputes that we may have.
+
+## 4. Disclosure of Personal Information to Third Parties
+
+We may disclose personal information to:
+- our employees, contractors and/or related entities;
+- courts, tribunals, regulatory authorities and law enforcement officers, as required by law, in connection with any actual or prospective legal proceedings, or in order to establish, exercise or defend our legal rights; and
+- third parties to collect and process data.
+
+## 5. International Transfers of Personal Information
+
+The personal information we collect is stored and processed in United States, or where we or our partners, affiliates and third-party providers maintain facilities. By providing us with your personal information, you consent to the disclosure to these overseas third parties.
+
+We will ensure that any transfer of personal information from countries in the European Economic Area (EEA) to countries outside the EEA will be protected by appropriate safeguards, for example by using standard data protection clauses approved by the European Commission, or the use of binding corporate rules or other legally accepted means.
+
+Where we transfer personal information from a non-EEA country to another country, you acknowledge that third parties in other jurisdictions may not be subject to similar data protection laws to the ones in our jurisdiction. There are risks if any such third party engages in any act or practice that would contravene the data privacy laws in our jurisdiction and this might mean that you will not be able to seek redress under our jurisdiction’s privacy laws.
+
+## 6. Your Rights & Controling Your Personal Information
+
+**Choice and consent**: By providing personal information to us, you consent to us collecting, holding, using and disclosing your personal information in accordance with this privacy policy. If you are under 16 years of age, you must have, and warrant to the extent permitted by law to us, that you have your parent or legal guardian’s permission to access and use the website and they (your parents or guardian) have consented to you providing us with your personal information. You do not have to provide personal information to us, however, if you do not, it may affect your use of this website or the products and/or services offered on or through it.
+
+**Information from third parties**: If we receive personal information about you from a third party, we will protect it as set out in this privacy policy. If you are a third party providing personal information about somebody else, you represent and warrant that you have such person’s consent to provide the personal information to us.
+
+**Restrict**: You may choose to restrict the collection or use of your personal information. If you have previously agreed to us using your personal information for direct marketing purposes, you may change your mind at any time by contacting us using the details below. If you ask us to restrict or limit how we process your personal information, we will let you know how the restriction affects your use of our website or products and services.
+
+**Access and data portability**: You may request details of the personal information that we hold about you. You may request a copy of the personal information we hold about you. Where possible, we will provide this information in CSV format or other easily readable machine format. You may request that we erase the personal information we hold about you at any time. You may also request that we transfer this personal information to another third party.
+
+**Correction**: If you believe that any information we hold about you is inaccurate, out of date, incomplete, irrelevant or misleading, please contact us using the details below. We will take reasonable steps to correct any information found to be inaccurate, incomplete, misleading or out of date.
+
+**Notification of data breaches**: We will comply laws applicable to us in respect of any data breach.
+
+**Complaints**: If you believe that we have breached a relevant data protection law and wish to make a complaint, please contact us using the details below and provide us with full details of the alleged breach. We will promptly investigate your complaint and respond to you, in writing, setting out the outcome of our investigation and the steps we will take to deal with your complaint. You also have the right to contact a regulatory body or data protection authority in relation to your complaint.
+
+**Unsubscribe**: To unsubscribe from our e-mail database or opt-out of communications (including marketing communications), please contact us using the details below or opt-out using the opt-out facilities provided in the communication.
+
+## 7. Cookies
+
+We use “cookies” to collect information about you and your activity across our site. A cookie is a small piece of data that our website stores on your computer, and accesses each time you visit, so we can understand how you use our site. This helps us serve you content based on preferences you have specified. Please refer to our Cookie Policy for more information.
+
+## 8. Business Transfers
+
+If we or our assets are acquired, or in the unlikely event that we go out of business or enter bankruptcy, we would include data among the assets transferred to any parties who acquire us. You acknowledge that such transfers may occur, and that any parties who acquire us may continue to use your personal information according to this policy.
+
+## 9. Limits of Our Policy
+
+Our website may link to external sites that are not operated by us. Please be aware that we have no control over the content and policies of those sites, and cannot accept responsibility or liability for their respective privacy practices.
+
+## 10. Changes to this Policy
+
+At our discretion, we may change our privacy policy to reflect current acceptable practices. We will take reasonable steps to let users know about changes via our website. Your continued use of this site after any changes to this policy will be regarded as acceptance of our practices around privacy and personal information.
+
+If we make a significant change to this privacy policy, for example changing a lawful basis on which we process your personal information, we will ask you to re-consent to the amended privacy policy.
+
+Offprint Studios Data Controller
+Alyx Mote
+figments@offprint.net
+
+This policy is effective as of August 13, 2020.
+
+# Cookie Policy
+
+We use cookies to help improve your experience of https://offprint.net. This cookie policy is part of Offprint Studios' privacy policy, and covers the use of cookies between your device and our site.
+
+If you don’t wish to accept cookies from us, you should instruct your browser to refuse cookies from https://offprint.net, with the understanding that we may be unable to provide you with some of your desired content and services.
+
+## What is a cookie?
+
+A cookie is a small piece of data that a website stores on your device when you visit, typically containing information about the website itself, a unique identifier that allows the site to recognize your web browser when you return, additional data that serves the purpose of the cookie, and the lifespan of the cookie itself.
+
+Cookies are used to enable certain features (eg. logging in), to track site usage (eg. analytics), to store your user settings (eg. timezone, notification preferences), and to personalize your content (eg. advertising, language).
+
+Cookies set by the website you are visiting are normally referred to as “first-party cookies”, and typically only track your activity on that particular site. Cookies set by other sites and companies (ie. third parties) are called “third-party cookies”, and can be used to track you on other websites that use the same third-party service.
+
+## Types of Cookies & How We Use Them
+
+### Essential Cookies
+
+Essential cookies are crucial to your experience of a website, enabling core features like user logins, account management, shopping carts and payment processing. We use essential cookies to enable certain functions on our website.
+
+### Performance Cookies
+
+Performance cookies are used in the tracking of how you use a website during your visit, without collecting personal information about you. Typically, this information is anonymous and aggregated with information tracked across all site users, to help companies understand visitor usage patterns, identify and diagnose problems or errors their users may encounter, and make better strategic decisions in improving their audience’s overall website experience. These cookies may be set by the website you’re visiting (first-party) or by third-party services. We use performance cookies on our site.
+
+### Functionality Cookies
+
+Functionality cookies are used in collecting information about your device and any settings you may configure on the website you’re visiting (like language and time zone settings). With this information, websites can provide you with customized, enhanced or optimized content and services. These cookies may be set by the website you’re visiting (first-party) or by third-party service. We use functionality cookies for selected features on our site.
+
+### Targeting/Advertising Cookies
+
+Targeting/advertising cookies are used in determining what promotional content is more relevant and appropriate to you and your interests. Websites may use them to deliver targeted advertising or to limit the number of times you see an advertisement. This helps companies improve the effectiveness of their campaigns and the quality of content presented to you. These cookies may be set by the website you’re visiting (first-party) or by third-party services. Targeting/advertising cookies set by third-parties may be used to track you on other websites that use the same third-party service. We do not use this type of cookie on our site.
+
+## How you can control or opt out of Cookies
+
+If you do not wish to accept cookies from us, you can instruct your browser to refuse cookies from our website. Most browsers are configured to accept cookies by default, but you can update these settings to either refuse cookies altogether, or to notify you when a website is trying to set or update a cookie.
+
+If you browse websites from multiple devices, you may need to update your settings on each individual device.
+
+Although some cookies can be blocked with little impact on your experience of a website, blocking all cookies may mean you are unable to access certain features and content across the sites you visit.

--- a/packages/client/src/assets/docs/what-is-offprint.md
+++ b/packages/client/src/assets/docs/what-is-offprint.md
@@ -1,0 +1,5 @@
+# What is Offprint?
+
+Offprint is a community-focused writing site for fanfiction, original stories, and blog posts. Our goal is to provide a place where authors can form communities for their readers, promote themselves, and collaborate with other authors. We are constantly building up features to encourage this, and quickly respond to user feedback. Offprint aims to be a safe and welcoming space, and as such is committed to excluding exceptionally harmful content and users.
+
+Offprint is built on open source software, hosted on Github, and welcomes contributions. The site is funded entirely by donations, and there are no advertisements.

--- a/workspace.json
+++ b/workspace.json
@@ -29,7 +29,8 @@
               "packages/client/src/custom-style.scss",
               "packages/client/src/styles.less"
             ],
-            "allowedCommonJsDependencies": ["lodash", "numeral"]
+            "allowedCommonJsDependencies": ["lodash", "numeral"],
+            "scripts": ["node_modules/marked/lib/marked.js"]
           },
           "configurations": {
             "production": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3042,6 +3042,11 @@
     "@types/linkify-it" "*"
     "@types/mdurl" "*"
 
+"@types/marked@^1.1.0":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@types/marked/-/marked-1.2.1.tgz#9864ecc10d0edb72e7be4e94acb5fcc607c15eed"
+  integrity sha512-d5adCgRHB+NAme23hkiTkvpfZUDqoNtL2Sr2nZBJqSj3zyHLxsfFWsGQ2sK2z9aX6L1xkJzon2c0jTPcsEjpaQ==
+
 "@types/mdurl@*":
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@types/mdurl/-/mdurl-1.0.2.tgz#e2ce9d83a613bacf284c7be7d491945e39e1f8e9"
@@ -5154,6 +5159,15 @@ cli-width@^3.0.0:
   resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-3.0.0.tgz#a2f48437a2caa9a22436e794bf071ec9e61cedf6"
   integrity sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==
 
+clipboard@^2.0.0:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/clipboard/-/clipboard-2.0.6.tgz#52921296eec0fdf77ead1749421b21c968647376"
+  integrity sha512-g5zbiixBRk/wyKakSwCKd7vQXDjFnAMGHoEyBogG/bw9kTD9GvdAvaoRR1ALcEzt3pVKxZR0pViekPMIS0QyGg==
+  dependencies:
+    good-listener "^1.2.2"
+    select "^1.1.2"
+    tiny-emitter "^2.0.0"
+
 cliui@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/cliui/-/cliui-5.0.0.tgz#deefcfdb2e800784aa34f46fa08e06851c7bbbc5"
@@ -5319,7 +5333,7 @@ command-exists@^1.2.7:
   resolved "https://registry.yarnpkg.com/command-exists/-/command-exists-1.2.9.tgz#c50725af3808c8ab0260fd60b01fbfa25b954f69"
   integrity sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w==
 
-commander@^2.11.0, commander@^2.12.1, commander@^2.20.0, commander@^2.20.3:
+commander@^2.11.0, commander@^2.12.1, commander@^2.19.0, commander@^2.20.0, commander@^2.20.3:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
@@ -6074,6 +6088,11 @@ delayed-stream@~1.0.0:
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
   integrity sha1-3zrhmayt+31ECqrgsp4icrJOxhk=
 
+delegate@^3.1.2:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/delegate/-/delegate-3.2.0.tgz#b66b71c3158522e8ab5744f720d8ca0c2af59166"
+  integrity sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw==
+
 delegates@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
@@ -6359,6 +6378,11 @@ emoji-regex@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
   integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
+
+emoji-toolkit@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/emoji-toolkit/-/emoji-toolkit-6.0.1.tgz#7dec51f79dd44863d86c647a805ebc41cea82a5a"
+  integrity sha512-QZZq0beHg753JxcBt89UBFqzwYNuMtXhNO+jY3viSAndewmn9biTE5glaro1RA0uWJ4hKqw4k1Mboe1M6sGkMA==
 
 emojis-list@^2.0.0:
   version "2.1.0"
@@ -7520,6 +7544,13 @@ globby@^6.1.0:
     object-assign "^4.0.1"
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
+
+good-listener@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/good-listener/-/good-listener-1.2.2.tgz#d53b30cdf9313dffb7dc9a0d477096aa6d145c50"
+  integrity sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=
+  dependencies:
+    delegate "^3.1.2"
 
 graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.4:
   version "4.2.4"
@@ -9209,6 +9240,13 @@ karma-source-map-support@1.4.0:
   dependencies:
     source-map-support "^0.5.5"
 
+katex@^0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/katex/-/katex-0.12.0.tgz#2fb1c665dbd2b043edcf8a1f5c555f46beaa0cb9"
+  integrity sha512-y+8btoc/CK70XqcHqjxiGWBOeIL8upbS0peTPXTvgrh21n1RiWWcIpSWM+4uXq+IAgNh9YYQWdc7LVDPDAEEAg==
+  dependencies:
+    commander "^2.19.0"
+
 killable@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/killable/-/killable-1.0.1.tgz#4c8ce441187a061c7474fb87ca08e2a638194892"
@@ -9661,6 +9699,11 @@ markdown-it@^11.0.0:
     linkify-it "^3.0.1"
     mdurl "^1.0.1"
     uc.micro "^1.0.5"
+
+marked@^1.2.0:
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-1.2.7.tgz#6e14b595581d2319cdcf033a24caaf41455a01fb"
+  integrity sha512-No11hFYcXr/zkBvL6qFmAp1z6BKY3zqLMHny/JN/ey+al7qwCM2+CMBL9BOgqMxZU36fz4cCWfn2poWIf7QRXA==
 
 md5.js@^1.3.4:
   version "1.3.5"
@@ -10205,6 +10248,18 @@ ngx-image-cropper@^3.2.1:
     tslib "^1.9.0"
   optionalDependencies:
     hammerjs "^2.0.8"
+
+ngx-markdown@^11.0.1:
+  version "11.0.1"
+  resolved "https://registry.yarnpkg.com/ngx-markdown/-/ngx-markdown-11.0.1.tgz#e6977d52feb4a7487fbfb253e2dc824fdc10a6d3"
+  integrity sha512-/abng+e19947ZAhEzFl7n1J+KZbrrO2O6gSUtyT3x5I5CHXQPZxZ0SawlZ2Yyu8UNjI75xmemU+7pArKyrOtOg==
+  dependencies:
+    "@types/marked" "^1.1.0"
+    emoji-toolkit "^6.0.1"
+    katex "^0.12.0"
+    marked "^1.2.0"
+    prismjs "^1.22.0"
+    tslib "^2.0.0"
 
 ngx-pagination@^5.0.0:
   version "5.0.0"
@@ -11449,6 +11504,13 @@ pretty-format@^26.0.0, pretty-format@^26.4.2:
     ansi-styles "^4.0.0"
     react-is "^16.12.0"
 
+prismjs@^1.22.0:
+  version "1.23.0"
+  resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.23.0.tgz#d3b3967f7d72440690497652a9d40ff046067f33"
+  integrity sha512-c29LVsqOaLbBHuIbsTxaKENh1N2EQBOHaWv7gkHN4dgRbxSREqDnDbtFJYdpPauS4YCplMSNCABQ6Eeor69bAA==
+  optionalDependencies:
+    clipboard "^2.0.0"
+
 process-nextick-args@~2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
@@ -12292,6 +12354,11 @@ select-hose@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/select-hose/-/select-hose-2.0.0.tgz#625d8658f865af43ec962bfc376a37359a4994ca"
   integrity sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo=
+
+select@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/select/-/select-1.1.2.tgz#0e7350acdec80b1108528786ec1d4418d11b396d"
+  integrity sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0=
 
 selfsigned@^1.10.7:
   version "1.10.7"
@@ -13343,6 +13410,11 @@ timsort@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/timsort/-/timsort-0.3.0.tgz#405411a8e7e6339fe64db9a234de11dc31e02bd4"
   integrity sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=
+
+tiny-emitter@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/tiny-emitter/-/tiny-emitter-2.1.0.tgz#1d1a56edfc51c43e863cbb5382a72330e3555423"
+  integrity sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==
 
 tmp@0.0.33, tmp@^0.0.33:
   version "0.0.33"


### PR DESCRIPTION
This begins work on migrating all site docs to markdown files in the assets folder, to enable easier collaboration and clientside styling.

Closes #295 