### PR TITLE
removed buggy style preventing scroll to top behavior from working

### DIFF
--- a/packages/client/src/styles.less
+++ b/packages/client/src/styles.less
@@ -39,7 +39,6 @@
 
 html,body {
     width: 100%;
-    height: 100%;
     margin: 0px;
     padding: 0px;
     overflow-x: hidden; 


### PR DESCRIPTION
Closes #311 

Turns out, setting the `html, body` height to 100% actually makes `scrollPositionRestoration` bug out and not scroll to top on route change like it's supposed to.