### PR TITLE
Totally fail to fix media embeds, and remove button instead

### DIFF
--- a/packages/client/src/app/components/new-editor/new-editor.component.ts
+++ b/packages/client/src/app/components/new-editor/new-editor.component.ts
@@ -25,7 +25,7 @@ export class NewEditorComponent implements OnInit {
       'bold', 'italic', 'underline', 'strikethrough', '|', 'fontSize', 'fontColor', 'highlight', '|', 
       'bulletedlist', 'numberedlist', '|',
       'alignment', 'indent', 'outdent', '|', 
-      'horizontalline', 'blockquote', 'link', 'insertImage', 'mediaEmbed', '|',
+      'horizontalline', 'blockquote', 'link', 'insertImage', '|',
       'undo', 'redo'],
     placeholder: 'Keeping you on the edge of your seats...',
     heading: {


### PR DESCRIPTION
_womp_. Kicks the can down the road of #214 by removing the button until we can fix it properly.