### PR TITLE
Fix issue where can't log out if don't have refreshToken cookie, and fixes issue where doesn't log out when token expires

### DIFF
--- a/packages/client/src/app/services/network.service.ts
+++ b/packages/client/src/app/services/network.service.ts
@@ -245,7 +245,7 @@ export class NetworkService {
                 catchError((err) => {
                     if (err.status === 403) {
                         // A 403 means that the refreshToken has expired, or we didn't send one up at all, which is Super Suspicious
-                        return of<string>("expired");
+                        return of<string>(null);
                     }
                     return throwError(err);
                 }),

--- a/packages/client/src/app/services/network.service.ts
+++ b/packages/client/src/app/services/network.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { HttpClient, HttpResponse } from '@angular/common/http';
-import { Observable, throwError } from 'rxjs';
+import { Observable, of, throwError } from 'rxjs';
 import { map, catchError } from 'rxjs/operators';
 
 import { ApprovalQueue } from '@dragonfish/models/approval-queue';
@@ -245,7 +245,7 @@ export class NetworkService {
                 catchError((err) => {
                     if (err.status === 403) {
                         // A 403 means that the refreshToken has expired, or we didn't send one up at all, which is Super Suspicious
-                        return null;
+                        return of<string>("expired");
                     }
                     return throwError(err);
                 }),

--- a/packages/client/src/app/shared/auth/auth.state.ts
+++ b/packages/client/src/app/shared/auth/auth.state.ts
@@ -86,7 +86,7 @@ export class AuthState {
     ): Observable<string> {
         return this.network.refreshToken().pipe(
             tap((result: string | null) => {
-                if (result === "expired") {
+                if (result === null) {
                     dispatch(new User.SetUser(null));
                     patchState({
                         token: null,

--- a/packages/client/src/app/shared/auth/auth.state.ts
+++ b/packages/client/src/app/shared/auth/auth.state.ts
@@ -86,7 +86,7 @@ export class AuthState {
     ): Observable<string> {
         return this.network.refreshToken().pipe(
             tap((result: string | null) => {
-                if (result === null) {
+                if (result === "expired") {
                     dispatch(new User.SetUser(null));
                     patchState({
                         token: null,

--- a/packages/server/src/app/controllers/auth/auth.controller.ts
+++ b/packages/server/src/app/controllers/auth/auth.controller.ts
@@ -67,7 +67,9 @@ export class AuthController {
     @Get('logout')
     async logout(@Request() req: any, @Cookies() cookies: any): Promise<void> {
         const refreshToken = cookies['refreshToken'];
-        await this.auth.clearRefreshToken(req.user.sub, refreshToken);
+        if (refreshToken) {
+            await this.auth.clearRefreshToken(req.user.sub, refreshToken);
+        }
         this.auth.logout(req);
     }
 }


### PR DESCRIPTION
Old:
Partially addresses https://github.com/OffprintStudios/dragonfish/issues/424
Even if the user doesn't have a refreshToken, still logs out
Doesn't address issue where nothing happens when the token expires, and the token isn't refreshed

New:
Now has user log out when the token expires
- Can't handle null Observable, so return string instead