### PR TITLE
Fix issue where can't log out

### DIFF
--- a/apps/api/src/app/controllers/auth/auth.controller.ts
+++ b/apps/api/src/app/controllers/auth/auth.controller.ts
@@ -67,7 +67,9 @@ export class AuthController {
     @Get('logout')
     async logout(@Request() req: any, @Cookies() cookies: any): Promise<void> {
         const refreshToken = cookies['refreshToken'];
-        await this.auth.clearRefreshToken(req.user.sub, refreshToken);
+        if (refreshToken) {
+            await this.auth.clearRefreshToken(req.user.sub, refreshToken);
+        }
         this.auth.logout(req);
     }
 }

--- a/apps/bettafish/src/app/services/network.service.ts
+++ b/apps/bettafish/src/app/services/network.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { HttpClient, HttpResponse } from '@angular/common/http';
-import { Observable, throwError } from 'rxjs';
+import { Observable, of, throwError } from 'rxjs';
 import { map, catchError } from 'rxjs/operators';
 
 import { ApprovalQueue } from '@dragonfish/shared/models/approval-queue';
@@ -204,7 +204,7 @@ export class NetworkService {
                 catchError((err) => {
                     if (err.status === 403) {
                         // A 403 means that the refreshToken has expired, or we didn't send one up at all, which is Super Suspicious
-                        return null;
+                        return of<string>(null);
                     }
                     return throwError(err);
                 }),


### PR DESCRIPTION
Addresses #424
Even if the user doesn't have a refreshToken, still logs out
Has user log out when the token expires

- Can't handle null Observable, so return string instead
