### PR TITLE
First round of alpha-0.7 fixes

### DIFF
--- a/apps/api/src/app/controllers/content/browse.controller.ts
+++ b/apps/api/src/app/controllers/content/browse.controller.ts
@@ -2,7 +2,6 @@ import { BadRequestException, Controller, Get, Query } from '@nestjs/common';
 import { BrowseStore } from '../../db/content';
 import { ApiTags } from '@nestjs/swagger';
 import { DragonfishTags } from '@dragonfish/shared/models/util';
-import { Cookies } from '@nestjsplus/cookies';
 import { ContentFilter, ContentKind } from '@dragonfish/shared/models/content';
 import { isNullOrUndefined } from '../../util';
 
@@ -12,16 +11,16 @@ export class BrowseController {
     constructor(private readonly browseStore: BrowseStore) {}
 
     @Get('fetch-first-new')
-    async fetchFirstNew(@Cookies('contentFilter') filter: ContentFilter) {
+    async fetchFirstNew(@Query('contentFilter') filter: ContentFilter) {
         return await this.browseStore.fetchFirstNew(filter);
     }
 
     @Get('fetch-all-new')
     async fetchAllNew(
-        @Cookies('contentFilter') filter: ContentFilter,
+        @Query('contentFilter') filter: ContentFilter,
         @Query('pageNum') pageNum: number,
         @Query('userId') userId: string,
-        @Query('kind') kind: ContentKind[]
+        @Query('kind') kind: ContentKind[],
     ) {
         if (isNullOrUndefined(pageNum) && isNullOrUndefined(kind)) {
             throw new BadRequestException(`You must include both the page number and content kind in your request.`);

--- a/apps/api/src/app/controllers/content/content.controller.ts
+++ b/apps/api/src/app/controllers/content/content.controller.ts
@@ -14,9 +14,7 @@ import {
     Inject,
 } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
-import { Cookies } from '@nestjsplus/cookies';
 import { FileInterceptor } from '@nestjs/platform-express';
-
 import { OptionalAuthGuard, RolesGuard } from '../../guards';
 import { ContentFilter, ContentKind, FormType, PubChange, SetRating } from '@dragonfish/shared/models/content';
 import { Roles } from '@dragonfish/shared/models/users';
@@ -70,7 +68,7 @@ export class ContentController {
     @ApiTags(DragonfishTags.Content)
     @Get('fetch-all-published')
     async fetchAllPublished(
-        @Cookies('contentFilter') filter: ContentFilter,
+        @Query('filter') filter: ContentFilter,
         @Query('pageNum') pageNum: number,
         @Query('userId') userId: string,
         @Query('kind') kind: ContentKind[]

--- a/apps/bettafish/src/app/components/content/content-box/content-box.component.html
+++ b/apps/bettafish/src/app/components/content/content-box/content-box.component.html
@@ -44,7 +44,7 @@
                                     </div>
                                 </ng-container>
                             </ng-container>
-                            <div class="separator">//</div>
+                            <div class="mx-1"><!--spacer--></div>
                             <div class="tag">{{ $any(content.currContent.meta).category }}</div>
                             <div class="separator">//</div>
                             <div class="tag">{{ $any(content.currContent.meta).genres | separateGenres }}</div>

--- a/apps/bettafish/src/app/components/user/settings/global/global-settings.component.ts
+++ b/apps/bettafish/src/app/components/user/settings/global/global-settings.component.ts
@@ -7,7 +7,6 @@ import { ContentFilter } from '@dragonfish/shared/models/content';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { take } from 'rxjs/operators';
 import { FormGroup, FormControl } from '@angular/forms';
-import { CookieService } from 'ngx-cookie';
 
 @UntilDestroy()
 @Component({
@@ -21,30 +20,19 @@ export class GlobalSettingsComponent implements OnInit {
     filters = ContentFilter;
 
     selectedTheme: ThemePref;
-    selectedFilter: ContentFilter;
 
     setContentFilter = new FormGroup({
         enableMature: new FormControl(false),
         enableExplicit: new FormControl(false),
     });
 
-    constructor(private store: Store, private cookies: CookieService) {}
+    constructor(private store: Store) {}
 
     ngOnInit(): void {
         this.global$.pipe(untilDestroyed(this)).subscribe(global => {
             this.selectedTheme = global.theme;
-            this.selectedFilter = global.filter;
+            this.setContentFilterToggles(global.filter);
         });
-
-        const contentFilterSetting: ContentFilter = this.cookies.get('contentFilter') as ContentFilter;
-        if (contentFilterSetting !== null && contentFilterSetting !== undefined) {
-            this.setContentFilterToggles(contentFilterSetting);
-        } else {
-            this.setContentFilter.setValue({
-                enableMature: false,
-                enableExplicit: false,
-            });
-        }
     }
 
     get setFilterFields() {
@@ -63,9 +51,7 @@ export class GlobalSettingsComponent implements OnInit {
                     this.setFilterFields.enableExplicit.value,
                 ),
             )
-            .subscribe(() => {
-                location.reload();
-            });
+            .subscribe();
     }
 
     private setContentFilterToggles(contentFilterSetting: ContentFilter) {

--- a/apps/bettafish/src/app/pages/browse/newest-works/newest-works.component.ts
+++ b/apps/bettafish/src/app/pages/browse/newest-works/newest-works.component.ts
@@ -3,7 +3,9 @@ import { NetworkService } from '../../../services';
 import { ContentKind, ContentModel } from '@dragonfish/shared/models/content';
 import { PaginateResult } from '@dragonfish/shared/models/util';
 import { ActivatedRoute, Router } from '@angular/router';
+import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 
+@UntilDestroy()
 @Component({
     selector: 'dragonfish-newest-works',
     templateUrl: './newest-works.component.html',
@@ -17,7 +19,12 @@ export class NewestWorksComponent implements OnInit {
     constructor(private network: NetworkService, private route: ActivatedRoute, private router: Router) {}
 
     ngOnInit(): void {
-        this.fetchData(this.pageNum);
+        this.route.queryParamMap.pipe(untilDestroyed(this)).subscribe(params => {
+            if (params.has('page')) {
+                this.pageNum = +params.get('page');
+            }
+            this.fetchData(this.pageNum);
+        });
     }
 
     /**
@@ -47,8 +54,6 @@ export class NewestWorksComponent implements OnInit {
             relativeTo: this.route,
             queryParams: { page: event },
             queryParamsHandling: 'merge',
-        }).then(() => {
-            this.fetchData(event);
         });
         this.pageNum = event;
     }

--- a/apps/bettafish/src/app/repo/auth/auth.state.ts
+++ b/apps/bettafish/src/app/repo/auth/auth.state.ts
@@ -45,6 +45,7 @@ export class AuthState {
                 patchState({
                     token: result.token,
                 });
+                this.alerts.success(`Welcome back!`);
             }),
         );
     }
@@ -60,6 +61,7 @@ export class AuthState {
                 patchState({
                     token: result.token,
                 });
+                this.alerts.success(`Glad you could make it!`);
             }),
         );
     }
@@ -75,6 +77,7 @@ export class AuthState {
                 patchState({
                     token: null,
                 });
+                this.alerts.success(`See you next time!`);
             }),
         );
     }

--- a/apps/bettafish/src/app/repo/auth/services/auth.guard.ts
+++ b/apps/bettafish/src/app/repo/auth/services/auth.guard.ts
@@ -15,7 +15,7 @@ import { AuthState } from '../auth.state';
 import { JwtPayload } from '@dragonfish/shared/models/auth';
 import { Roles } from '@dragonfish/shared/models/users';
 import { isAllowed, isNullOrUndefined } from '@dragonfish/shared/functions';
-// import { AlertsService } from '@dragonfish/alerts';
+import { AlertsService } from '@dragonfish/client/alerts';
 
 @Injectable({
     providedIn: 'root',
@@ -23,7 +23,7 @@ import { isAllowed, isNullOrUndefined } from '@dragonfish/shared/functions';
 export class AuthGuard implements CanActivate, CanActivateChild, CanLoad {
     helper = new JwtHelperService();
 
-    constructor(private store: Store /* private alerts: AlertsService */) {}
+    constructor(private store: Store, private alerts: AlertsService) {}
 
     /**
      * Verifies that a user can access a protected route. If their JWT is expired, it makes a request to the backend to
@@ -42,14 +42,14 @@ export class AuthGuard implements CanActivate, CanActivateChild, CanLoad {
                 if (isAllowed(decodedToken.roles as Roles[], next.data.roles)) {
                     return true;
                 } else {
-                    //this.alerts.error(`You don't have permission to do that.`);
+                    this.alerts.error(`You don't have permission to do that.`);
                     return false;
                 }
             } else {
                 return true;
             }
         } else {
-            //this.alerts.error(`You don't have permission to do that.`);
+            this.alerts.error(`You don't have permission to do that.`);
             return false;
         }
     }
@@ -70,14 +70,14 @@ export class AuthGuard implements CanActivate, CanActivateChild, CanLoad {
                 if (isAllowed(decodedToken.roles as Roles[], next.data.roles)) {
                     return true;
                 } else {
-                    //this.alerts.error(`You don't have permission to do that.`);
+                    this.alerts.error(`You don't have permission to do that.`);
                     return false;
                 }
             } else {
                 return true;
             }
         } else {
-            //this.alerts.error(`You don't have permission to do that.`);
+            this.alerts.error(`You don't have permission to do that.`);
             return false;
         }
     }
@@ -93,7 +93,7 @@ export class AuthGuard implements CanActivate, CanActivateChild, CanLoad {
                     if (isAllowed(decodedToken.roles as Roles[], route.data.roles)) {
                         return true;
                     } else {
-                        //this.alerts.error(`You don't have permission to do that.`);
+                        this.alerts.error(`You don't have permission to do that.`);
                         return false;
                     }
                 } else {
@@ -103,7 +103,7 @@ export class AuthGuard implements CanActivate, CanActivateChild, CanLoad {
                 return true;
             }
         } else {
-            //this.alerts.error(`You don't have permission to do that.`);
+            this.alerts.error(`You don't have permission to do that.`);
             return false;
         }
     }

--- a/apps/bettafish/src/app/repo/global/global.state.ts
+++ b/apps/bettafish/src/app/repo/global/global.state.ts
@@ -5,6 +5,7 @@ import { GlobalStateModel } from './global-state.model';
 import * as Global from './global.actions';
 import { ContentFilter } from '@dragonfish/shared/models/content';
 import { ThemePref } from '@dragonfish/shared/models/users';
+import { AlertsService } from '@dragonfish/client/alerts';
 
 @State<GlobalStateModel>({
     name: 'global',
@@ -20,16 +21,21 @@ export class GlobalState {
         return state.theme;
     }
 
-    constructor(private globalService: GlobalService) {}
+    @Selector()
+    static filter(state: GlobalStateModel): ContentFilter {
+        return state.filter;
+    }
+
+    constructor(private globalService: GlobalService, private alerts: AlertsService) {}
 
     /* Actions */
     @Action(Global.SetContentFilter)
     public async setContentFilter({ patchState }: StateContext<GlobalStateModel>, action: Global.SetContentFilter) {
-        return await this.globalService.setContentFilter(action.enableMature, action.enableExplicit).then((filter) => {
-            patchState({
-                filter: filter,
-            });
+        const filter = this.globalService.setContentFilter(action.enableMature, action.enableExplicit);
+        patchState({
+            filter: filter,
         });
+        this.alerts.success(`Your content filter has been updated!`);
     }
 
     @Action(Global.SetThemePref)

--- a/apps/bettafish/src/app/repo/global/services/global.service.ts
+++ b/apps/bettafish/src/app/repo/global/services/global.service.ts
@@ -7,29 +7,22 @@ import { ContentFilter } from '@dragonfish/shared/models/content';
     providedIn: 'root',
 })
 export class GlobalService {
-    constructor(private cookies: CookieService) {}
-
     /**
      * Sets the contentFilter cookie based on the values of the two provided booleans.
      *
      * @param enableMature Enable mature check
      * @param enableExplicit Enable explicit check
      */
-    public async setContentFilter(enableMature: boolean, enableExplicit: boolean) {
-        const options: CookieOptions = { expires: new Date(new Date().setFullYear(new Date().getFullYear() + 1)) };
+    public setContentFilter(enableMature: boolean, enableExplicit: boolean) {
         let filterSetting: ContentFilter = ContentFilter.Default;
 
         if (enableMature === true && enableExplicit === false) {
-            this.cookies.put('contentFilter', ContentFilter.MatureEnabled, options);
             filterSetting = ContentFilter.MatureEnabled;
         } else if (enableMature === false && enableExplicit === true) {
-            this.cookies.put('contentFilter', ContentFilter.ExplicitEnabled, options);
             filterSetting = ContentFilter.ExplicitEnabled;
         } else if (enableMature === true && enableExplicit === true) {
-            this.cookies.put('contentFilter', ContentFilter.Everything, options);
             filterSetting = ContentFilter.Everything;
         } else if (enableMature === false && enableExplicit === false) {
-            this.cookies.put('contentFilter', ContentFilter.Default, options);
             filterSetting = ContentFilter.Default;
         }
 

--- a/apps/bettafish/src/styles.scss
+++ b/apps/bettafish/src/styles.scss
@@ -306,6 +306,9 @@ div.offprint-select {
 /* Style changes for prose */
 .prose {
     color: var(--text-color) !important;
+    h1,h2,h3,h4,h5 {
+        color: var(--accent) !important;
+    }
     strong {
         color: var(--text-color) !important;
         font-weight: 700 !important;

--- a/apps/bettafish/src/styles.scss
+++ b/apps/bettafish/src/styles.scss
@@ -365,3 +365,69 @@ div.context-menu {
         border-bottom: 1px solid var(--borders);
     }
 }
+/* Sections, blog bodies, authors notes, and long descriptions.
+ * These go in the main stylesheet because section bodies have
+ * no view encapsulation, and can be (and are) affected by global
+ * styles. Therefore, these must also be global styles.
+ * If we can find a way to have an element with directly-set
+ * innerHtml AND view encapsulation, we can move all this back down to the
+ * component level.
+*/
+div.section-body,
+div.blog-body,
+div.authors-note,
+div.html-description {
+    // Headers and default image style
+    h1 { font-size: 3em; }
+    h2 { font-size: 2em; }
+    h3 { font-size: 1.5em; }
+    h4 { font-size: 1.25em; }
+    h5 { font-size: 1em; font-weight: bold; text-transform: uppercase; }
+    h6 { font-size: 1em; text-transform: uppercase; }
+    img { max-width: 100% }
+
+    // CKEditor-generated image styles
+    .image {
+        display: table;
+        clear: both;
+        text-align: center;
+        margin: 1em auto;
+    }
+
+    .image-style-align-{
+        &left {
+            float: left;
+            margin-right: 1.5em;
+        }
+        &center {
+            margin-left: auto;
+            margin-right: auto;
+        }
+        &right {
+            float: right;
+            margin-left: 1.5em;
+        }
+    }
+
+    // A little CSS hack to force images at the bottom of content bodies to not break out of their containers.
+    // More details here: http://bonrouge.com/br.php?page=floats
+    > :last-child:after {
+        content: ".";
+        display: block;
+        height: 0;
+        overflow: hidden;
+        clear: both;
+        visibility: hidden;
+    }
+
+    // CKEditor-generated font sizes
+    span.text-{
+        &tiny { font-size: 0.7em; }
+        &small { font-size: 0.85em; }
+        &big { font-size: 1.4em; }
+        &huge { font-size: 1.85em; }
+    }
+    ul,ol {
+        margin-left: 2.5rem;
+    }
+}

--- a/libs/client/my-stuff/src/lib/components/content-item/content-item.component.scss
+++ b/libs/client/my-stuff/src/lib/components/content-item/content-item.component.scss
@@ -9,6 +9,7 @@ div.content-box {
     cursor: pointer;
     color: var(--text-color);
     overflow: hidden;
+    user-select: none;
 
     &.selected {
         border: 1px solid var(--accent);

--- a/libs/client/ui/src/lib/components/content-list-item/content-list-item.component.html
+++ b/libs/client/ui/src/lib/components/content-list-item/content-list-item.component.html
@@ -5,8 +5,11 @@
             <dragonfish-rating-icon [rating]="item.content.meta.rating" [size]="'medium'"></dragonfish-rating-icon>
             <div class="flex flex-row">
                 <div>
-                    <button class="h-full border-t-0 border-b-0 border-l-0 rounded-r-none shadow-none" (click)="deleteItem.emit(item._id)">
-                        <i-feather name="trash-2"></i-feather>
+                    <button
+                        class="h-full border-t-0 border-b-0 border-l-0 rounded-r-none shadow-none flex flex-col items-center justify-center"
+                        (click)="deleteItem.emit(item._id)"
+                    >
+                        <i-feather name="trash-2" class="left-icon m-0 relative -top-1"></i-feather>
                     </button>
                 </div>
                 <div *ngIf="item.content.meta.coverArt" class="self-center">
@@ -14,7 +17,10 @@
                 </div>
                 <div class="self-center p-4">
                     <h3 class="text-2xl font-medium">
-                        {{ item.content.title }}
+                        <a
+                            [routerLink]="navigateToContent(item.content.kind, item.content._id, item.content.title, item.content.author._id, item.content.author.username)">
+                            {{ item.content.title }}
+                        </a>
                         <span class="text-base italic font-light">by {{ item.content.author.username }}</span>
                     </h3>
                     <ng-container [ngSwitch]="item.content.kind">

--- a/libs/client/ui/src/lib/components/content-list-item/content-list-item.component.scss
+++ b/libs/client/ui/src/lib/components/content-list-item/content-list-item.component.scss
@@ -29,3 +29,7 @@ div.separator {
     margin-right: 0.5rem;
     display: inline-block;
 }
+
+i-feather.left-icon {
+    width: 1.75rem !important;
+}

--- a/libs/client/ui/src/lib/components/content-list-item/content-list-item.component.ts
+++ b/libs/client/ui/src/lib/components/content-list-item/content-list-item.component.ts
@@ -2,6 +2,7 @@ import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { ContentKind } from '@dragonfish/shared/models/content';
 import { ListKind } from '@dragonfish/shared/models/util';
 import { calculateApprovalRating } from '@dragonfish/shared/functions';
+import { slugify } from 'voca';
 
 @Component({
     selector: 'dragonfish-content-list-item',
@@ -24,5 +25,21 @@ export class ContentListItemComponent {
      */
     calcApprovalRating(likes: number, dislikes: number) {
         return calculateApprovalRating(likes, dislikes);
+    }
+
+    /**
+     * Navigates to the selected content, specific to History.
+     */
+    navigateToContent(kind: ContentKind, id: string, title: string, userId: string, username: string) {
+        switch (kind) {
+            case ContentKind.PoetryContent:
+                return ['/poetry', id, slugify(title)];
+            case ContentKind.ProseContent:
+                return ['/prose', id, slugify(title)];
+            case ContentKind.NewsContent:
+                return ['/news', id, slugify(title)];
+            case ContentKind.BlogContent:
+                return ['/portfolio', userId, slugify(username), 'post', id, slugify(title)];
+        }
     }
 }

--- a/libs/client/ui/src/lib/components/work-card/work-card.component.html
+++ b/libs/client/ui/src/lib/components/work-card/work-card.component.html
@@ -22,14 +22,13 @@
                 <span class="tag" [matTooltip]="'Poetry'" [matTooltipClass]="'offprint-tooltip'"
                     ><i-feather name="feather" class="kind"></i-feather
                 ></span>
-                <span class="divider">//</span>
             </ng-container>
             <ng-container *ngIf="content.kind === contentKind.ProseContent">
                 <span class="tag" [matTooltip]="'Prose'" [matTooltipClass]="'offprint-tooltip'"
                     ><i-feather name="book-open" class="kind"></i-feather
                 ></span>
-                <span class="divider">//</span>
             </ng-container>
+            <span class="mx-1"><!--spacer--></span>
             <span class="tag">{{ content.meta.category }}</span>
             <span class="divider">//</span>
             <span class="tag genres">{{ content.meta.genres | separateGenres }}</span>


### PR DESCRIPTION
- Users can no longer select the text of a content item on the My Stuff page
- Applying a Content Filter no longer uses cookies, or requires refreshing the page (closes #446 )
- Added alerts to the following items to make it more clear what's happening:
	- Setting a Content Filter
	- Logging in
	- Logging out
	- Registering for a new account
	- Validating permission to access a route
- The page number query on the Newest Works page should now actually tell the page to fetch *that specific* set of content. (closes #469 )
- Links on the History page now work (closes #470 )
- The delete button on history list items now looks as intended
- Minor style adjustment for work cards