### PR TITLE
Fix #479

### DIFF
--- a/apps/bettafish/src/app/pages/portfolio/portfolio-collections/portfolio-collections.component.html
+++ b/apps/bettafish/src/app/pages/portfolio/portfolio-collections/portfolio-collections.component.html
@@ -37,6 +37,6 @@
                 </ng-template>
             </div>
         </ng-template>
-        <pagination-controls (pageChange)="onPageChange($event)" previousLabel="" nextLabel=""></pagination-controls>
+        <pagination-controls (pageChange)="onPageChange($event)" previousLabel="" nextLabel="" *ngIf="currPageCollections.docs.length !== 0;"></pagination-controls>
     </ng-template>
 </ng-container>


### PR DESCRIPTION
This commit fixes an issue where pagination buttons appear unnecessarily on collection pages where no collections exist. 

![image](https://user-images.githubusercontent.com/5971630/116767707-c2823580-a9ff-11eb-9593-3e35af4aa239.png)
