### PR TITLE
Fix #481

### DIFF
--- a/libs/client/ui/src/lib/components/blog-card/blog-card.component.html
+++ b/libs/client/ui/src/lib/components/blog-card/blog-card.component.html
@@ -57,9 +57,14 @@
             </div>
             <div>
                 <a
-                    class="continue-reading"
-                    [routerLink]="['/portfolio', blog.author._id, blog.author.username | slugify, 'blog', blog._id]"
-                >
+                    [routerLink]="[
+                        '/portfolio',
+                        blog.author._id,
+                        blog.author.username | slugify,
+                        'post',
+                        blog._id,
+                        blog.title | slugify,
+                    ]">
                     Continue Reading
                     <i-feather name="chevron-right"></i-feather>
                 </a>


### PR DESCRIPTION
This commit fixes an issue where the "Continue reading" button on portfolio blog pages results in a 404 error due to an incorrect URL