### PR TITLE
Fix browser titles

### DIFF
--- a/apps/bettafish/src/app/components/user/settings/global/global-settings.component.ts
+++ b/apps/bettafish/src/app/components/user/settings/global/global-settings.component.ts
@@ -7,6 +7,7 @@ import { ContentFilter } from '@dragonfish/shared/models/content';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { take } from 'rxjs/operators';
 import { FormGroup, FormControl } from '@angular/forms';
+import { Constants, setTwoPartTitle } from '@dragonfish/shared/constants';
 
 @UntilDestroy()
 @Component({
@@ -29,6 +30,8 @@ export class GlobalSettingsComponent implements OnInit {
     constructor(private store: Store) {}
 
     ngOnInit(): void {
+        setTwoPartTitle(Constants.GLOBAL_SETTINGS);
+
         this.global$.pipe(untilDestroyed(this)).subscribe(global => {
             this.selectedTheme = global.theme;
             this.setContentFilterToggles(global.filter);

--- a/apps/bettafish/src/app/pages/browse/browse.component.ts
+++ b/apps/bettafish/src/app/pages/browse/browse.component.ts
@@ -4,6 +4,7 @@ import { FormControl, FormGroup } from '@angular/forms';
 import { AlertsService } from '@dragonfish/client/alerts';
 import { ContentModel } from '@dragonfish/shared/models/content';
 import { NetworkService } from '../../services';
+import { Constants, setTwoPartTitle } from '@dragonfish/shared/constants';
 
 @Component({
     selector: 'dragonfish-browse',
@@ -20,6 +21,7 @@ export class BrowseComponent implements OnInit {
     constructor(public route: ActivatedRoute, private router: Router, private alerts: AlertsService, private network: NetworkService) {}
 
     ngOnInit() {
+        setTwoPartTitle(Constants.BROWSE);
         this.loadFirstNew();
     }
 

--- a/apps/bettafish/src/app/pages/browse/newest-works/newest-works.component.ts
+++ b/apps/bettafish/src/app/pages/browse/newest-works/newest-works.component.ts
@@ -4,6 +4,7 @@ import { ContentKind, ContentModel } from '@dragonfish/shared/models/content';
 import { PaginateResult } from '@dragonfish/shared/models/util';
 import { ActivatedRoute, Router } from '@angular/router';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
+import { Constants, setTwoPartTitle } from '@dragonfish/shared/constants';
 
 @UntilDestroy()
 @Component({
@@ -19,6 +20,7 @@ export class NewestWorksComponent implements OnInit {
     constructor(private network: NetworkService, private route: ActivatedRoute, private router: Router) {}
 
     ngOnInit(): void {
+        setTwoPartTitle(Constants.NEWEST_WORKS);
         this.route.queryParamMap.pipe(untilDestroyed(this)).subscribe(params => {
             if (params.has('page')) {
                 this.pageNum = +params.get('page');

--- a/apps/bettafish/src/app/pages/content-views/poetry-page/poetry-page.component.ts
+++ b/apps/bettafish/src/app/pages/content-views/poetry-page/poetry-page.component.ts
@@ -4,6 +4,7 @@ import { ContentState } from '../../../repo/content';
 import { Observable } from 'rxjs';
 import { PoetryContent } from '@dragonfish/shared/models/content';
 import { ActivatedRoute, Router } from '@angular/router';
+import { setTwoPartTitle } from '@dragonfish/shared/constants';
 
 @Component({
     selector: 'dragonfish-poetry-page',
@@ -17,6 +18,9 @@ export class PoetryPageComponent {
 
     ngOnInit(): void {
         this.fetchData();
+        this.currPoetry$.subscribe((currPoetry) => {
+            setTwoPartTitle(currPoetry.title);
+        })
     }
 
     /**

--- a/apps/bettafish/src/app/pages/content-views/prose-page/prose-page.component.ts
+++ b/apps/bettafish/src/app/pages/content-views/prose-page/prose-page.component.ts
@@ -4,6 +4,7 @@ import { Select } from '@ngxs/store';
 import { Observable } from 'rxjs';
 import { ProseContent } from '@dragonfish/shared/models/content';
 import { ContentState } from '../../../repo/content';
+import { setTwoPartTitle } from '@dragonfish/shared/constants';
 
 @Component({
     selector: 'dragonfish-prose-page',
@@ -17,6 +18,9 @@ export class ProsePageComponent implements OnInit {
 
     ngOnInit(): void {
         this.fetchData();
+        this.currProse$.subscribe((currProse) => {
+            setTwoPartTitle(currProse.title);
+        })
     }
 
     /**

--- a/apps/bettafish/src/app/pages/docs/about-offprint/about-offprint.component.ts
+++ b/apps/bettafish/src/app/pages/docs/about-offprint/about-offprint.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnInit } from '@angular/core';
+import { Constants, setTwoPartTitle } from '@dragonfish/shared/constants';
 
 @Component({
     selector: 'about-offprint',
@@ -7,5 +8,7 @@ import { Component, OnInit } from '@angular/core';
 export class AboutOffprintComponent implements OnInit {
     constructor() {}
 
-    ngOnInit(): void {}
+    ngOnInit(): void {
+        setTwoPartTitle(Constants.ABOUT);
+    }
 }

--- a/apps/bettafish/src/app/pages/docs/code-of-conduct/code-of-conduct.component.ts
+++ b/apps/bettafish/src/app/pages/docs/code-of-conduct/code-of-conduct.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnInit } from '@angular/core';
+import { Constants, setTwoPartTitle } from '@dragonfish/shared/constants';
 
 @Component({
     selector: 'code-of-conduct',
@@ -7,5 +8,7 @@ import { Component, OnInit } from '@angular/core';
 export class CodeOfConductComponent implements OnInit {
     constructor() {}
 
-    ngOnInit(): void {}
+    ngOnInit(): void {
+        setTwoPartTitle(Constants.CODE_OF_CONDUCT);
+    }
 }

--- a/apps/bettafish/src/app/pages/docs/omnibus/omnibus.component.ts
+++ b/apps/bettafish/src/app/pages/docs/omnibus/omnibus.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnInit } from '@angular/core';
+import { Constants, setTwoPartTitle } from '@dragonfish/shared/constants';
 
 @Component({
     selector: 'omnibus',
@@ -7,5 +8,7 @@ import { Component, OnInit } from '@angular/core';
 export class OmnibusComponent implements OnInit {
     constructor() {}
 
-    ngOnInit(): void {}
+    ngOnInit(): void {
+        setTwoPartTitle(Constants.OMNIBUS);
+    }
 }

--- a/apps/bettafish/src/app/pages/docs/site-staff/site-staff.component.ts
+++ b/apps/bettafish/src/app/pages/docs/site-staff/site-staff.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { FrontendUser } from '@dragonfish/shared/models/users';
+import { Constants, setTwoPartTitle } from '@dragonfish/shared/constants';
 
 @Component({
     selector: 'dragonfish-site-staff',
@@ -12,6 +13,8 @@ export class SiteStaffComponent implements OnInit {
     constructor(private route: ActivatedRoute) {}
 
     ngOnInit(): void {
+        setTwoPartTitle(Constants.SITE_STAFF);
+    
         this.staffData = this.route.snapshot.data.staffData as FrontendUser[];
         console.log(this.staffData);
     }

--- a/apps/bettafish/src/app/pages/docs/supporters/supporters.component.ts
+++ b/apps/bettafish/src/app/pages/docs/supporters/supporters.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { FrontendUser } from '@dragonfish/shared/models/users';
+import { Constants, setTwoPartTitle } from '@dragonfish/shared/constants';
 
 @Component({
     selector: 'dragonfish-supporters',
@@ -12,6 +13,8 @@ export class SupportersComponent implements OnInit {
     constructor(private route: ActivatedRoute) {}
 
     ngOnInit(): void {
+        setTwoPartTitle(Constants.SUPPORTERS);
+    
         this.supporters = this.route.snapshot.data.supporterData as FrontendUser[];
     }
 }

--- a/apps/bettafish/src/app/pages/docs/tos/tos.component.ts
+++ b/apps/bettafish/src/app/pages/docs/tos/tos.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnInit } from '@angular/core';
+import { Constants, setTwoPartTitle } from '@dragonfish/shared/constants';
 
 @Component({
     selector: 'tos-component',
@@ -7,5 +8,7 @@ import { Component, OnInit } from '@angular/core';
 export class TosComponent implements OnInit {
     constructor() {}
 
-    ngOnInit(): void {}
+    ngOnInit(): void {
+        setTwoPartTitle(Constants.TOS);
+    }
 }

--- a/apps/bettafish/src/app/pages/home/home.component.ts
+++ b/apps/bettafish/src/app/pages/home/home.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit } from '@angular/core';
-import { Constants } from '@dragonfish/shared/constants';
+import { Constants, setTwoPartTitle } from '@dragonfish/shared/constants';
 import { slogans } from '../../models/site';
 import { NetworkService } from '../../services';
 import { ActivatedRoute } from '@angular/router';
@@ -19,6 +19,8 @@ export class HomeComponent implements OnInit {
     constructor(private network: NetworkService, public route: ActivatedRoute) {}
 
     ngOnInit(): void {
+        setTwoPartTitle(Constants.HOME);
+
         // Load the latest posts
         this.loadingLatest = true;
         this.network.fetchInitialNewsPosts().subscribe(data => {

--- a/apps/bettafish/src/app/pages/messages/messages.component.ts
+++ b/apps/bettafish/src/app/pages/messages/messages.component.ts
@@ -1,8 +1,13 @@
 import { Component } from '@angular/core';
+import { Constants, setTwoPartTitle } from '@dragonfish/shared/constants';
 
 @Component({
     selector: 'dragonfish-messages',
     templateUrl: './messages.component.html',
     styleUrls: ['./messages.component.scss'],
 })
-export class MessagesComponent {}
+export class MessagesComponent {
+    ngOnInit() {
+        setTwoPartTitle(Constants.MESSAGES);
+    }
+}

--- a/apps/bettafish/src/app/pages/notifications/notifications.component.ts
+++ b/apps/bettafish/src/app/pages/notifications/notifications.component.ts
@@ -1,10 +1,10 @@
 import { Component } from '@angular/core';
-import { FormControl, FormGroup } from '@angular/forms';
 import { NotificationSelectModel } from './notification-select.model';
 import { ContentKind } from '@dragonfish/shared/models/content';
 import { AlertsService } from '@dragonfish/client/alerts';
 import { MarkReadRequest } from '@dragonfish/shared/models/notifications';
 import { NotificationsService } from '../../services';
+import { Constants, setTwoPartTitle } from '@dragonfish/shared/constants';
 
 @Component({
     selector: 'dragonfish-notifications',
@@ -21,6 +21,10 @@ export class NotificationsComponent {
     viewRead = false;
 
     constructor(private alerts: AlertsService, private notifications: NotificationsService) {}
+
+    ngOnInit() {
+        setTwoPartTitle(Constants.NOTIFICATIONS);
+    }
 
     switchView(): void {
         this.viewRead = !this.viewRead;

--- a/apps/bettafish/src/app/pages/portfolio/portfolio-collections/portfolio-collection-page/portfolio-collection-page.component.ts
+++ b/apps/bettafish/src/app/pages/portfolio/portfolio-collections/portfolio-collection-page/portfolio-collection-page.component.ts
@@ -12,6 +12,7 @@ import { NetworkService } from '../../../../services';
 import { CollectionFormComponent } from '../../../../components/content/collections/collection-form/collection-form.component';
 import { PopupModel } from '@dragonfish/shared/models/util';
 import { PopupComponent } from '@dragonfish/client/ui';
+import { setTwoPartTitle } from '@dragonfish/shared/constants';
 
 @Component({
     selector: 'dragonfish-portfolio-collection-page',
@@ -34,6 +35,7 @@ export class PortfolioCollectionPageComponent {
     ngOnInit(): void {
         this.route.data.subscribe((data) => {
             this.collData = data.collData as Collection;
+            setTwoPartTitle(this.collData.name);
         });
     }
 

--- a/apps/bettafish/src/app/pages/portfolio/portfolio-collections/portfolio-collections.component.ts
+++ b/apps/bettafish/src/app/pages/portfolio/portfolio-collections/portfolio-collections.component.ts
@@ -9,6 +9,7 @@ import { UserState } from '../../../repo/user';
 import { NetworkService } from '../../../services';
 import { Collection } from '@dragonfish/shared/models/collections';
 import { PortfolioState } from '../../../repo/portfolio';
+import { Constants, setTwoPartTitle, setThreePartTitle } from '@dragonfish/shared/constants';
 
 @UntilDestroy()
 @Component({
@@ -34,8 +35,10 @@ export class PortfolioCollectionsComponent implements OnInit {
                 this.pageNum = params.has('page') ? +params.get('page') : 1;
                 if ((currUser !== null) && (currUser._id === portUser._id)) {
                     this.fetchData(this.pageNum);
+                    setTwoPartTitle(Constants.COLLECTIONS);
                 } else {
                     this.fetchData(this.pageNum, portUser._id);
+                    setThreePartTitle(portUser.username, Constants.COLLECTIONS);
                 }
             });
     }

--- a/apps/bettafish/src/app/pages/portfolio/portfolio-home/portfolio-home.component.ts
+++ b/apps/bettafish/src/app/pages/portfolio/portfolio-home/portfolio-home.component.ts
@@ -1,7 +1,21 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { FrontendUser } from '@dragonfish/shared/models/users';
+import { Constants, setThreePartTitle } from '@dragonfish/shared/constants';
+import { Select } from '@ngxs/store';
+import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
+import { Observable } from 'rxjs';
+import { PortfolioState } from '../../../repo/portfolio';
 
+@UntilDestroy()
 @Component({
     selector: 'dragonfish-portfolio-home',
     templateUrl: './portfolio-home.component.html'
 })
-export class PortfolioHomeComponent {}
+export class PortfolioHomeComponent implements OnInit {
+    @Select(PortfolioState.currPortfolio) portUser$: Observable<FrontendUser>;
+
+    ngOnInit(): void {
+        this.portUser$.pipe(untilDestroyed(this)).subscribe(user => {
+            setThreePartTitle(user.username, Constants.HOME);
+        });
+    }}

--- a/apps/bettafish/src/app/pages/portfolio/portfolio-settings/portfolio-settings.component.ts
+++ b/apps/bettafish/src/app/pages/portfolio/portfolio-settings/portfolio-settings.component.ts
@@ -1,11 +1,11 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { Constants, setTwoPartTitle } from '@dragonfish/shared/constants';
 
 @Component({
     selector: 'dragonfish-portfolio-settings',
     templateUrl: './portfolio-settings.component.html'
 })
-export class PortfolioSettingsComponent {
+export class PortfolioSettingsComponent implements OnInit  {
     ngOnInit() {
         setTwoPartTitle(Constants.SETTINGS);
     }

--- a/apps/bettafish/src/app/pages/portfolio/portfolio-settings/portfolio-settings.component.ts
+++ b/apps/bettafish/src/app/pages/portfolio/portfolio-settings/portfolio-settings.component.ts
@@ -1,7 +1,12 @@
 import { Component } from '@angular/core';
+import { Constants, setTwoPartTitle } from '@dragonfish/shared/constants';
 
 @Component({
     selector: 'dragonfish-portfolio-settings',
     templateUrl: './portfolio-settings.component.html'
 })
-export class PortfolioSettingsComponent {}
+export class PortfolioSettingsComponent {
+    ngOnInit() {
+        setTwoPartTitle(Constants.SETTINGS);
+    }
+}

--- a/apps/bettafish/src/app/pages/portfolio/portfolio.component.ts
+++ b/apps/bettafish/src/app/pages/portfolio/portfolio.component.ts
@@ -1,9 +1,8 @@
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { FrontendUser } from '@dragonfish/shared/models/users';
-import { setTwoPartTitle } from '@dragonfish/shared/constants';
 import { Select } from '@ngxs/store';
-import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
+import { UntilDestroy } from '@ngneat/until-destroy';
 import { Observable } from 'rxjs';
 import { UserState } from '../../repo/user';
 import { PortfolioState } from '../../repo/portfolio';
@@ -20,9 +19,5 @@ export class PortfolioComponent implements OnInit {
 
     constructor(public route: ActivatedRoute) {}
 
-    ngOnInit(): void {
-        this.portUser$.pipe(untilDestroyed(this)).subscribe(user => {
-            setTwoPartTitle(user.username);
-        });
-    }
+    ngOnInit(): void {}
 }

--- a/apps/bettafish/src/app/pages/social/social.component.ts
+++ b/apps/bettafish/src/app/pages/social/social.component.ts
@@ -1,8 +1,13 @@
 import { Component } from '@angular/core';
+import { Constants, setTwoPartTitle } from '@dragonfish/shared/constants';
 
 @Component({
     selector: 'dragonfish-social',
     templateUrl: './social.component.html',
     styleUrls: ['./social.component.scss']
 })
-export class SocialComponent {}
+export class SocialComponent {
+    ngOnInit() {
+        setTwoPartTitle(Constants.SOCIAL);
+    }
+}

--- a/apps/bettafish/src/app/pages/social/social.component.ts
+++ b/apps/bettafish/src/app/pages/social/social.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { Constants, setTwoPartTitle } from '@dragonfish/shared/constants';
 
 @Component({
@@ -6,7 +6,7 @@ import { Constants, setTwoPartTitle } from '@dragonfish/shared/constants';
     templateUrl: './social.component.html',
     styleUrls: ['./social.component.scss']
 })
-export class SocialComponent {
+export class SocialComponent implements OnInit {
     ngOnInit() {
         setTwoPartTitle(Constants.SOCIAL);
     }

--- a/libs/shared/src/lib/constants/constants.ts
+++ b/libs/shared/src/lib/constants/constants.ts
@@ -11,6 +11,7 @@ export class Constants {
 
     public static HOME = 'Home';
     public static INBOX = 'Inbox';
+    public static MESSAGES = 'Messages';
     public static MY_STUFF = 'My Stuff';
     public static NEWS = 'News';
     public static NEW_SECTION = 'New section';

--- a/libs/shared/src/lib/constants/constants.ts
+++ b/libs/shared/src/lib/constants/constants.ts
@@ -14,7 +14,7 @@ export class Constants {
     public static MY_STUFF = 'My Stuff';
     public static NEWS = 'News';
     public static NEW_SECTION = 'New section';
-    public static NEWEST_WORKS = "Newest Works";
+    public static NEWEST_WORKS = 'Newest Works';
 
     public static NOTIFICATIONS = 'Notifications';
     public static OFFPRINT = 'Offprint';
@@ -23,6 +23,7 @@ export class Constants {
     public static SETTINGS = 'Settings';
 
     public static SITE_STAFF = 'Site Staff';
+    public static SOCIAL = 'Social';
     public static WATCHING = 'Watching';
     public static WORKS = 'Works';
 }

--- a/libs/shared/src/lib/constants/constants.ts
+++ b/libs/shared/src/lib/constants/constants.ts
@@ -3,23 +3,25 @@ export class Constants {
 
     public static FIVE_MINUTES = 300000;
 
-    public static HOME = 'Home';
-    public static NOTIFICATIONS = 'Notifications';
     public static BLOGS = 'Blogs';
     public static BROWSE = 'Browse';
     public static COLLECTIONS = 'Collections';
-
     public static GROUPS = 'Groups';
     public static HISTORY = 'History';
+
+    public static HOME = 'Home';
     public static INBOX = 'Inbox';
     public static MY_STUFF = 'My Stuff';
     public static NEWS = 'News';
     public static NEW_SECTION = 'New section';
-    public static OFFPRINT = 'Offprint';
+    public static NEWEST_WORKS = "Newest Works";
 
+    public static NOTIFICATIONS = 'Notifications';
+    public static OFFPRINT = 'Offprint';
     public static REGISTER = 'Register';
     public static SEARCH = 'Search';
     public static SETTINGS = 'Settings';
+
     public static SITE_STAFF = 'Site Staff';
     public static WATCHING = 'Watching';
     public static WORKS = 'Works';

--- a/libs/shared/src/lib/constants/constants.ts
+++ b/libs/shared/src/lib/constants/constants.ts
@@ -3,9 +3,12 @@ export class Constants {
 
     public static FIVE_MINUTES = 300000;
 
+    public static ABOUT = 'About';
     public static BLOGS = 'Blogs';
     public static BROWSE = 'Browse';
+    public static CODE_OF_CONDUCT = 'Code of Conduct';
     public static COLLECTIONS = 'Collections';
+    public static GLOBAL_SETTINGS = "Global Settings";
     public static GROUPS = 'Groups';
     public static HISTORY = 'History';
 
@@ -19,12 +22,15 @@ export class Constants {
 
     public static NOTIFICATIONS = 'Notifications';
     public static OFFPRINT = 'Offprint';
+    public static OMNIBUS = 'Omnibus';
     public static REGISTER = 'Register';
     public static SEARCH = 'Search';
     public static SETTINGS = 'Settings';
 
     public static SITE_STAFF = 'Site Staff';
     public static SOCIAL = 'Social';
+    public static SUPPORTERS = 'Supporters';
+    public static TOS = 'Terms of Service';
     public static WATCHING = 'Watching';
     public static WORKS = 'Works';
 }


### PR DESCRIPTION
Addresses https://github.com/OffprintStudios/dragonfish/issues/483

There is still an issue with prose and poetry's main page. I'm setting the browser title in ngOnInit() and it works. However, if I go to a section (which still correctly sets the title in the live site) and then either back out or click the work title to go to the main page, the browser title still reflects the section I was on.