### PR TITLE
Enable use of dark mode with Tailwind CSS

### DIFF
--- a/apps/bettafish/src/app/app.component.ts
+++ b/apps/bettafish/src/app/app.component.ts
@@ -23,9 +23,16 @@ export class AppComponent implements OnInit {
         this.theme$.pipe(untilDestroyed(this)).subscribe(theme => {
             const body = document.getElementsByTagName('body')[0];
             const currTheme = body.classList.item(0);
+            const html = document.getElementsByTagName('html')[0];
             console.log(typeof ThemePref[theme]);
             if (ThemePref[theme] !== null && ThemePref[theme] !== undefined) {
-                body.classList.replace(currTheme, ThemePref[theme]);
+                if(ThemePref[theme] == 'dark-aqua' || ThemePref[theme] == 'dark-crimson' || ThemePref[theme] == 'dark-field' || ThemePref[theme] == 'dark-royal' || ThemePref[theme] === 'dusk-autumn') {
+                    body.classList.replace(currTheme, ThemePref[theme]);
+                    html.classList.add('dark');
+                } else {
+                    body.classList.replace(currTheme, ThemePref[theme]);
+                    html.classList.remove('dark');
+                }
             } else {
                 body.classList.replace(currTheme, 'crimson');
             }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -12,7 +12,7 @@ module.exports = {
             './libs/client/alerts/src/lib/**/*.{html,ts}',
         ],
     },
-    darkMode: false, // or 'media' or 'class'
+    darkMode: 'class', // or 'media' or 'class'
     theme: {
         extend: {},
     },


### PR DESCRIPTION
When switching to a dark theme through global settings, the site will now add ``class="dark"`` to the HTML element. This allows our dark themes, such as ``dark-aqua``, ``dark-crimson``, etc., to work correctly with Tailwind CSS's dark mode.