### PR TITLE
Fix/minor sidenav tweaks

### DIFF
--- a/apps/bettafish/src/app/components/user/history/history-feed/history-feed.component.html
+++ b/apps/bettafish/src/app/components/user/history/history-feed/history-feed.component.html
@@ -29,7 +29,7 @@
                 </p>
             </div>
         </ng-container>
-        <div class="w-11/12 mx-auto">
+        <div class="w-11/12 mx-auto overflow-y-hidden">
             <ng-container *ngFor="let history of state.history">
                 <dragonfish-history-item
                     [document]="history"

--- a/apps/bettafish/src/app/components/user/history/history-feed/history-feed.component.html
+++ b/apps/bettafish/src/app/components/user/history/history-feed/history-feed.component.html
@@ -1,10 +1,18 @@
 <ng-container *ngIf="historyState$ | async as state">
     <div class="relative">
         <div class="controls flex flex-row items-center justify-center sticky">
-            <button (click)="askDelete(state.selectedDocs)">
-                <i-feather name="trash-2"></i-feather>
-                delete
-            </button>
+            <ng-container *ngIf="state.selectedDocs.length === 0; else canDelete">
+                <button class="disabled">
+                    <i-feather name="trash-2"></i-feather>
+                    delete
+                </button>
+            </ng-container>
+            <ng-template #canDelete>
+                <button (click)="askDelete(state.selectedDocs)">
+                    <i-feather name="trash-2"></i-feather>
+                    delete <span class="text-xs relative top-1 ml-0.5">({{ state.selectedDocs.length }})</span>
+                </button>
+            </ng-template>
         </div>
     </div>
     <ng-container *ngIf="state.loading; else notLoading">

--- a/apps/bettafish/src/app/components/user/history/history-feed/history-feed.component.scss
+++ b/apps/bettafish/src/app/components/user/history/history-feed/history-feed.component.scss
@@ -6,5 +6,13 @@ div.controls {
         box-shadow: none;
         border-radius: 0;
         border: none;
+        color: white;
+        &.disabled {
+            color: var(--accent-dark);
+            &:hover {
+                cursor: not-allowed;
+                color: var(--accent-dark);
+            }
+        }
     }
 }

--- a/apps/bettafish/src/app/components/user/history/history-item/history-item.component.html
+++ b/apps/bettafish/src/app/components/user/history/history-item/history-item.component.html
@@ -19,7 +19,13 @@
         <img [src]="$any(document.content).meta.coverArt" />
     </div>
     <div class="work-info self-center py-0.5">
-        <h4 class="text-lg font-medium" [matTooltip]="$any(document.content).title" [matTooltipClass]="'offprint-tooltip'">
+        <h4
+            class="text-lg font-medium"
+            [matTooltip]="$any(document.content).title"
+            [matTooltipClass]="'offprint-tooltip'"
+            [matTooltipDisabled]="$any(document.content).title.length < 30"
+            [matTooltipShowDelay]="1000"
+        >
             <a [routerLink]="goToItem()">
                 {{ $any(document.content).title }}
             </a>

--- a/apps/bettafish/src/app/components/user/history/history-item/history-item.component.html
+++ b/apps/bettafish/src/app/components/user/history/history-item/history-item.component.html
@@ -19,7 +19,7 @@
         <img [src]="$any(document.content).meta.coverArt" />
     </div>
     <div class="work-info self-center py-0.5">
-        <h4 class="text-lg font-medium">
+        <h4 class="text-lg font-medium" [matTooltip]="$any(document.content).title" [matTooltipClass]="'offprint-tooltip'">
             <a [routerLink]="goToItem()">
                 {{ $any(document.content).title }}
             </a>

--- a/apps/bettafish/src/app/components/user/history/history-item/history-item.component.scss
+++ b/apps/bettafish/src/app/components/user/history/history-item/history-item.component.scss
@@ -1,5 +1,6 @@
 div.history-item {
     border: 1px solid var(--borders);
+    width: 350px;
     div.check-box {
         border-right: 1px solid var(--borders);
         &:hover {
@@ -16,6 +17,13 @@ div.history-item {
         object-fit: contain;
         border: 1px solid whitesmoke;
         @apply rounded-md;
+    }
+    h4 {
+        width: 250px;
+        text-overflow: ellipsis;
+        /* Required for text-overflow to do anything */
+        white-space: nowrap;
+        overflow: hidden;
     }
     div.work-info {
         flex: 1;

--- a/apps/bettafish/src/app/components/user/sidenav/sidenav.component.scss
+++ b/apps/bettafish/src/app/components/user/sidenav/sidenav.component.scss
@@ -44,7 +44,7 @@ div.sidenav {
     }
     div.tab-bar {
         background: var(--accent);
-        @apply pb-1 pt-1.5;
+        @apply pb-1 pt-1.5 text-white;
     }
     div.body {
         background: var(--background);

--- a/apps/bettafish/src/material.scss
+++ b/apps/bettafish/src/material.scss
@@ -51,11 +51,11 @@ button.mat-menu-item {
 
 /* Material Tooltip */
 .offprint-tooltip {
-    font-family: Raleway, sans-serif !important;
+    font-family: Inter, sans-serif !important;
     border: 1px solid var(--borders) !important;
     background: var(--background) !important;
     color: var(--text-color) !important;
-    border-radius: 0 !important;
+    border-radius: 0.375rem !important;
     box-shadow: var(--dropshadow);
 }
 


### PR DESCRIPTION
- fixed the tab navigation in the sidenav mistakingly obeying `var(--text-color)`
- properly disabled the Delete button in the History tab (closes #510 )
- implemented a width cutoff for longer work titles in History Items
- added a tooltip that only shows up on longer work titles in History Items