### PR TITLE
Adds currently inoperable tag database interactions to Dashboard overview page

### DIFF
--- a/apps/api/src/app/db/tags/tags.controller.ts
+++ b/apps/api/src/app/db/tags/tags.controller.ts
@@ -1,0 +1,22 @@
+import { Controller, UseGuards, Body, Get, Put, Patch, Query, BadRequestException, Inject } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+
+import { RolesGuard } from '../../guards';
+import { Roles } from '@dragonfish/shared/models/users';
+import { isNullOrUndefined } from '../../util';
+import { User } from '../../util/decorators';
+import { JwtPayload } from '@dragonfish/shared/models/auth';
+import { DragonfishTags } from '@dragonfish/shared/models/util';
+import { ITags } from './tags.interface';
+import { TagsForm } from '@dragonfish/shared/models/tags';
+
+@Controller('tags')
+export class TagsController {
+    constructor(@Inject('ITags') private readonly tags: ITags) {}
+
+    @ApiTags(DragonfishTags.Tags)
+    @Put('create-tag')
+    async createTag(@Body() tagInfo: TagsForm) {
+        return await this.tags.create(tagInfo);
+    }
+}

--- a/apps/api/src/app/db/tags/tags.interface.ts
+++ b/apps/api/src/app/db/tags/tags.interface.ts
@@ -1,0 +1,8 @@
+import { PaginateResult } from 'mongoose';
+import { JwtPayload } from '@dragonfish/shared/models/auth';
+import { Tag, TagsForm } from '@dragonfish/shared/models/tags';
+
+export interface ITags {
+    
+    create(tagInfo: TagsForm): Promise<Tag>;
+}

--- a/apps/api/src/app/db/tags/tags.module.ts
+++ b/apps/api/src/app/db/tags/tags.module.ts
@@ -1,0 +1,33 @@
+import { Module } from '@nestjs/common';
+import { MongooseModule } from '@nestjs/mongoose';
+import * as sanitizeHtml from 'sanitize-html';
+import { HookNextFunction } from 'mongoose';
+import { sanitizeOptions } from '@dragonfish/shared/models/util';
+import { TagsDocument, TagsSchema } from './tags.schema';
+import { TagsStore } from './tags.store';
+
+@Module({
+    imports: [
+        MongooseModule.forFeatureAsync([
+            {
+                name: 'Tag',
+                useFactory: () => {
+                    const schema = TagsSchema;
+                    schema.index({ name: 'text' });
+                    schema.plugin(require('mongoose-autopopulate'));
+                    schema.plugin(require('mongoose-paginate-v2'));
+                    schema.pre<TagsDocument>('save', async function (next: HookNextFunction) {
+                        this.set('name', sanitizeHtml(this.name, sanitizeOptions));
+                        this.set('desc', sanitizeHtml(this.desc, sanitizeOptions));
+
+                        return next();
+                    });
+                    return schema;
+                },
+            },
+        ]),
+    ],
+    providers: [TagsStore],
+    exports: [TagsStore],
+})
+export class TagsModule {}

--- a/apps/api/src/app/db/tags/tags.schema.ts
+++ b/apps/api/src/app/db/tags/tags.schema.ts
@@ -1,0 +1,31 @@
+import { Schema, Prop, SchemaFactory, raw } from '@nestjs/mongoose';
+import { Document } from 'mongoose';
+import { nanoid } from 'nanoid';
+import { Tag } from '@dragonfish/shared/models/tags';
+
+@Schema({ timestamps: true, autoIndex: true, collection: 'tags' })
+export class TagsDocument extends Document implements Tag {
+    @Prop({ default: () => nanoid() })
+    readonly _id: string;
+
+    @Prop({ trim: true, required: true })
+    name: string;
+    
+    @Prop({ trim: true, required: false })
+    desc: string;
+    
+    @Prop({ trim: true, required: false })
+    parent: string;
+
+    @Prop({ type: [String], ref: 'Content', default: [], autopopulate: true })
+    children: string[]
+    
+    @Prop()
+    readonly createdAt: Date;
+    
+    @Prop()
+    readonly updatedAt: Date;
+
+}
+
+export const TagsSchema = SchemaFactory.createForClass(TagsDocument);

--- a/apps/api/src/app/db/tags/tags.service.ts
+++ b/apps/api/src/app/db/tags/tags.service.ts
@@ -1,0 +1,16 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { PaginateResult } from 'mongoose';
+
+import { TagsStore } from './tags.store';
+import { Tag, TagsForm } from '@dragonfish/shared/models/tags';
+import { ITags } from './tags.interface';
+
+@Injectable()
+export class TagsService implements ITags {
+
+    constructor(private readonly tags: TagsStore) {}
+
+    async create(tagInfo: TagsForm): Promise<Tag> {
+        return await this.tags.createTag(tagInfo);
+    }
+}

--- a/apps/api/src/app/db/tags/tags.store.ts
+++ b/apps/api/src/app/db/tags/tags.store.ts
@@ -1,0 +1,31 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { PaginateModel, PaginateResult } from 'mongoose';
+import * as sanitizeHtml from 'sanitize-html';
+import { sanitizeOptions } from '@dragonfish/shared/models/util';
+import { JwtPayload } from '@dragonfish/shared/models/auth';
+import { TagsForm } from '@dragonfish/shared/models/tags';
+import { TagsDocument } from './tags.schema';
+import { isNullOrUndefined } from '../../util';
+import { ContentModel } from '@dragonfish/shared/models/content';
+
+@Injectable()
+export class TagsStore {
+    constructor(@InjectModel('Tags') private readonly tagsModel: PaginateModel<TagsDocument>) {}
+
+    /**
+     * Creates a tags and saves it to the database.
+     *
+     * @param collForm The tag's information
+     */
+     async createTag(tagsForm: TagsForm): Promise<TagsDocument> {
+        const newTag = new this.tagsModel({
+            name: sanitizeHtml(tagsForm.name),
+            desc: sanitizeHtml(tagsForm.desc),
+            parent: sanitizeHtml(tagsForm.parent),
+            children: tagsForm.children,
+        });
+
+        return await newTag.save();
+    }
+}

--- a/apps/bettafish/src/app/repo/tags/index.ts
+++ b/apps/bettafish/src/app/repo/tags/index.ts
@@ -1,0 +1,3 @@
+export * from './tags.actions';
+export { TagsState } from './tags.state';
+export { TagsStateModel } from './tags-state.model';

--- a/apps/bettafish/src/app/repo/tags/tags-state.model.ts
+++ b/apps/bettafish/src/app/repo/tags/tags-state.model.ts
@@ -1,0 +1,7 @@
+import { Tag } from '@dragonfish/shared/models/tags';
+
+export interface TagsStateModel {
+    tags: Tag[];
+    loading: boolean;
+    currTag: Tag;
+}

--- a/apps/bettafish/src/app/repo/tags/tags.actions.ts
+++ b/apps/bettafish/src/app/repo/tags/tags.actions.ts
@@ -1,0 +1,6 @@
+import { Tag, TagsForm } from '@dragonfish/shared/models/tags';
+
+export class Create {
+    static readonly type = '[Tags] Create';
+    constructor(public formInfo: TagsForm) {}
+}

--- a/apps/bettafish/src/app/repo/tags/tags.state.ts
+++ b/apps/bettafish/src/app/repo/tags/tags.state.ts
@@ -1,0 +1,40 @@
+import { Injectable } from '@angular/core';
+import { State, Action, Selector, StateContext } from '@ngxs/store';
+import { patch, updateItem, removeItem } from '@ngxs/store/operators';
+import { AlertsService } from '@dragonfish/client/alerts';
+import { Collection } from '@dragonfish/shared/models/collections';
+import { throwError } from 'rxjs';
+import { tap, catchError } from 'rxjs/operators';
+import { NetworkService } from '../../services';
+import { TagsStateModel } from './tags-state.model';
+import { Tag, TagsForm } from '@dragonfish/shared/models/tags';
+import * as Tags from './tags.actions';
+
+@State<TagsStateModel>({
+    name: 'tags',
+    defaults: {
+        tags: [],
+        loading: false,
+        currTag: null,
+    },
+})
+@Injectable()
+export class TagsState {
+    constructor(private network: NetworkService, private alerts: AlertsService) {}
+
+    @Action(Tags.Create)
+    public create({ getState, patchState }: StateContext<TagsStateModel>, { formInfo }: Tags.Create) {
+        return this.network.createTag(formInfo).pipe(
+            tap((tag: Tag) => {
+                this.alerts.success(`Collection created!`);
+                patchState({
+                    tags: [...getState().tags, tag],
+                });
+            }),
+            catchError((err) => {
+                this.alerts.error(err.error.message);
+                return throwError(err);
+            }),
+        );
+    }
+}

--- a/apps/bettafish/src/app/services/network.service.ts
+++ b/apps/bettafish/src/app/services/network.service.ts
@@ -10,6 +10,7 @@ import {
     User,
 } from '@dragonfish/shared/models/users';
 import { Collection, CollectionForm } from '@dragonfish/shared/models/collections';
+import { Tag, TagsForm } from '@dragonfish/shared/models/tags';
 import { ContentComment, CreateComment, EditComment } from '@dragonfish/shared/models/comments';
 import {
     ContentFilter,
@@ -233,6 +234,20 @@ export class NetworkService {
     public createCollection(collInfo: CollectionForm) {
         return handleResponse(
             this.http.put<Collection>(`${this.baseUrl}/collections/create-collection`, collInfo, {
+                observe: 'response',
+                withCredentials: true,
+            }),
+        );
+    }
+
+    /**
+     * Creates a tag in the database.
+     *
+     * @param tagInfo A tag's info
+     */
+    public createTag(tagInfo: TagsForm) {
+        return handleResponse(
+            this.http.put<Tag>(`${this.baseUrl}/tags/create-tag`, tagInfo, {
                 observe: 'response',
                 withCredentials: true,
             }),

--- a/libs/client/dashboard/src/lib/dashboard.module.ts
+++ b/libs/client/dashboard/src/lib/dashboard.module.ts
@@ -28,6 +28,8 @@ import { ApprovalQueueState } from './shared/approval-queue';
 import { ApprovalQueueService } from './shared/approval-queue/services';
 import { UserManagementService } from './shared/user-management/services';
 
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+
 @NgModule({
     declarations: [
         DashboardComponent,
@@ -53,6 +55,8 @@ import { UserManagementService } from './shared/user-management/services';
         NgxPaginationModule,
         PipesModule,
         NgxsModule.forFeature([ApprovalQueueState]),
+        FormsModule,
+        ReactiveFormsModule,
     ],
     providers: [ApprovalQueueService, UserManagementService],
 })

--- a/libs/client/dashboard/src/lib/pages/overview/overview.component.html
+++ b/libs/client/dashboard/src/lib/pages/overview/overview.component.html
@@ -1,5 +1,30 @@
-<div class="empty">
-    <h3>Pardon the dust!</h3>
-    <p>You're here a litte too early.</p>
-    <p>Check the patch notes to see when this feature will be available.</p>
-</div>
+<ng-container>
+    <div class="form-container">
+        <div class="form-header flex flex-row items-center mb-8">
+            <h3 class="text-4xl flex-1">{{ formTitle }}</h3>
+            <button class="form-button shadow-none" (click)="submitForm()">Save</button>
+        </div>
+        <form [formGroup]="proseForm" (ngSubmit)="submitForm()">
+            <dragonfish-text-field
+                [formControlName]="'name'"
+                [name]="'name'"
+                [type]="'text'"
+                [label]="'Name'"
+                [placeholder]="'There\'s Something I Gotta Say...'"
+            ></dragonfish-text-field>
+
+        </form>
+    </div>
+    <div>
+        <ng-container *ngIf="output; else noCode">
+            <span>
+                {{ output }}
+            </span>
+        </ng-container>
+        <ng-template #noCode>
+            <span>
+                No code generated.
+            </span>
+        </ng-template>
+    </div>
+</ng-container>

--- a/libs/client/dashboard/src/lib/pages/overview/overview.component.scss
+++ b/libs/client/dashboard/src/lib/pages/overview/overview.component.scss
@@ -1,0 +1,35 @@
+div.form-container {
+    width: 85%;
+    margin: 0 auto;
+
+    div.form-header {
+        border-bottom: 1px solid var(--borders);
+        margin-bottom: 2rem;
+        button.form-button {
+            &.left {
+                border-right: none;
+                border-top-right-radius: 0;
+                border-bottom-right-radius: 0;
+            }
+
+            &.right {
+                border-top-left-radius: 0;
+                border-bottom-left-radius: 0;
+            }
+
+            &.save {
+                margin-left: 1rem;
+            }
+
+            &.selected {
+                background-color: var(--accent);
+                color: whitesmoke;
+
+                &:hover {
+                    background-color: var(--accent-dark);
+                    color: whitesmoke;
+                }
+            }
+        }
+    }
+}

--- a/libs/client/dashboard/src/lib/pages/overview/overview.component.ts
+++ b/libs/client/dashboard/src/lib/pages/overview/overview.component.ts
@@ -1,8 +1,72 @@
-import { Component } from '@angular/core';
+import { Component, Injectable, OnInit } from '@angular/core';
+import { FormGroup, FormControl, Validators } from '@angular/forms';
+import { Select } from '@ngxs/store';
+import { Observable } from 'rxjs';
+import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
+import { Tag, TagsForm } from '@dragonfish/shared/models/tags';
+import { handleResponse } from '@dragonfish/shared/functions';
 
+import {
+    WorkKind,
+    Genres,
+    ContentRating,
+    WorkStatus,
+    CreateProse,
+    ProseContent,
+    ContentKind,
+} from '@dragonfish/shared/models/content';
+import { AlertsService } from '@dragonfish/client/alerts';
+import { HttpClient } from '@angular/common/http';
+
+@UntilDestroy()
 @Component({
     selector: 'dragonfish-overview',
     templateUrl: './overview.component.html',
     styleUrls: ['./overview.component.scss'],
 })
-export class OverviewComponent {}
+@Injectable()
+export class OverviewComponent implements OnInit {
+    private baseUrl = `/api`;
+    formTitle = `Add Tag`;
+    output: String;
+
+    categories = WorkKind;
+    genres = Genres;
+    ratings = ContentRating;
+    statuses = WorkStatus;
+
+    proseForm = new FormGroup({
+        name: new FormControl('', []),
+    });
+
+    constructor(private readonly http: HttpClient) {}
+
+    ngOnInit(): void {
+    }
+
+    get fields() {
+        return this.proseForm.controls;
+    }
+
+    submitForm() {
+        const tagForm: TagsForm = {
+            name: this.fields.name.value,
+            desc: "Default description",
+            parent: "Default parent",
+            children: null,
+        };
+
+        this.createTag(tagForm).subscribe(() => {
+            this.output = "Sent tag";
+        });
+    }
+
+    public createTag(tagInfo: TagsForm) {
+        return handleResponse(
+            this.http.put<Tag>(`${this.baseUrl}/tags/create-tag`, tagInfo, {
+                observe: 'response',
+                withCredentials: true,
+            }),
+        );
+    }
+}

--- a/libs/shared/src/lib/models/tags/index.ts
+++ b/libs/shared/src/lib/models/tags/index.ts
@@ -1,0 +1,2 @@
+export type { Tag } from './tag.model'
+export type { TagsForm } from './tags-form.model'

--- a/libs/shared/src/lib/models/tags/tag.model.ts
+++ b/libs/shared/src/lib/models/tags/tag.model.ts
@@ -1,0 +1,9 @@
+export interface Tag {
+    readonly _id: string;
+    name: string;
+    desc: string;
+    parent: string;
+    children: string[];
+    readonly createdAt: Date;
+    readonly updatedAt: Date;
+}

--- a/libs/shared/src/lib/models/tags/tags-form.model.ts
+++ b/libs/shared/src/lib/models/tags/tags-form.model.ts
@@ -1,0 +1,6 @@
+export interface TagsForm {
+    readonly name: string;
+    readonly desc: string;
+    readonly parent: string;
+    readonly children: string[];
+}

--- a/libs/shared/src/lib/models/util/dragonfish-tags.enum.ts
+++ b/libs/shared/src/lib/models/util/dragonfish-tags.enum.ts
@@ -9,4 +9,5 @@ export enum DragonfishTags {
     Meta = 'Meta',
     ApprovalQueue = 'Approval Queue',
     Search = 'Search',
+    Tags = 'Tags',
 }


### PR DESCRIPTION
On the Dashboard Overview page, the intention at this point is that you can type in a tag name, and it will add that tag to a "tags" database. However, currently no such thing happens. I added a text box that should update when this action occurs, but that doesn't update either.