### PR TITLE
Feature/shared networkservice

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -455,6 +455,28 @@
                     }
                 }
             }
+        },
+        "client-services": {
+            "projectType": "library",
+            "root": "libs/client/services",
+            "sourceRoot": "libs/client/services/src",
+            "prefix": "dragonfish",
+            "architect": {
+                "lint": {
+                    "builder": "@nrwl/linter:eslint",
+                    "options": {
+                        "lintFilePatterns": ["libs/client/services/src/**/*.ts", "libs/client/services/src/**/*.html"]
+                    }
+                },
+                "test": {
+                    "builder": "@nrwl/jest:jest",
+                    "outputs": ["coverage/libs/client/services"],
+                    "options": {
+                        "jestConfig": "libs/client/services/jest.config.js",
+                        "passWithNoTests": true
+                    }
+                }
+            }
         }
     }
 }

--- a/apps/bettafish/src/app/app.module.ts
+++ b/apps/bettafish/src/app/app.module.ts
@@ -59,6 +59,7 @@ import { MaterialModule } from '@dragonfish/client/material';
 import { AlertsModule } from '@dragonfish/client/alerts';
 import { MyStuffModule } from '@dragonfish/client/my-stuff';
 import { DashboardModule } from '@dragonfish/client/dashboard';
+import { ClientServicesModule } from '@dragonfish/client/services';
 
 /* State */
 import { AuthState } from './repo/auth';
@@ -111,6 +112,7 @@ import { environment } from '../environments/environment';
         EditorModule,
         MyStuffModule,
         DashboardModule,
+        ClientServicesModule,
         Ng2FittextModule,
         NgxPaginationModule,
         TabsModule.forRoot(),

--- a/apps/bettafish/src/app/components/content/collections/add-to-collection/add-to-collection.component.ts
+++ b/apps/bettafish/src/app/components/content/collections/add-to-collection/add-to-collection.component.ts
@@ -1,7 +1,7 @@
 import { Component, Inject } from '@angular/core';
 import { ContentModel } from '@dragonfish/shared/models/content';
 import { Collection } from '@dragonfish/shared/models/collections';
-import { NetworkService } from '../../../../services';
+import { DragonfishNetworkService } from '@dragonfish/client/services';
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 
 @Component({
@@ -16,7 +16,7 @@ export class AddToCollectionComponent {
     loading = false;
 
     constructor(
-        private networkService: NetworkService,
+        private networkService: DragonfishNetworkService,
         private dialogRef: MatDialogRef<AddToCollectionComponent>,
         @Inject(MAT_DIALOG_DATA) private data: { content: ContentModel },
     ) {

--- a/apps/bettafish/src/app/components/content/collections/collection-card/collection-card.component.ts
+++ b/apps/bettafish/src/app/components/content/collections/collection-card/collection-card.component.ts
@@ -1,7 +1,7 @@
 import { Component, Input } from '@angular/core';
 import { Collection } from '@dragonfish/shared/models/collections';
 import { MatDialog } from '@angular/material/dialog';
-import { NetworkService } from '../../../../services';
+import { DragonfishNetworkService } from '@dragonfish/client/services';
 import { PopupModel } from '@dragonfish/shared/models/util';
 import { PopupComponent } from '@dragonfish/client/ui';
 import { CollectionFormComponent } from '../collection-form/collection-form.component';
@@ -21,7 +21,7 @@ export class CollectionCardComponent {
     @Input() user: FrontendUser;
     submitting = false;
 
-    constructor(private dialog: MatDialog, private networkService: NetworkService) {}
+    constructor(private dialog: MatDialog, private networkService: DragonfishNetworkService) {}
 
     /**
      * Opens the create collection modal in edit mode.

--- a/apps/bettafish/src/app/components/content/collections/collection-form/collection-form.component.ts
+++ b/apps/bettafish/src/app/components/content/collections/collection-form/collection-form.component.ts
@@ -2,7 +2,7 @@ import { Component, Inject, OnInit } from '@angular/core';
 import { FormGroup, FormControl, Validators } from '@angular/forms';
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 
-import { NetworkService } from '../../../../services';
+import { DragonfishNetworkService } from '@dragonfish/client/services';
 import { CollectionForm, Collection } from '@dragonfish/shared/models/collections';
 import { AlertsService } from '@dragonfish/client/alerts';
 
@@ -22,7 +22,7 @@ export class CollectionFormComponent implements OnInit {
     });
 
     constructor(
-        private networkService: NetworkService,
+        private networkService: DragonfishNetworkService,
         private alerts: AlertsService,
         private dialogRef: MatDialogRef<CollectionFormComponent>,
         @Inject(MAT_DIALOG_DATA) private data: { currColl: Collection },

--- a/apps/bettafish/src/app/components/content/comments/comment-box/comment-box.component.ts
+++ b/apps/bettafish/src/app/components/content/comments/comment-box/comment-box.component.ts
@@ -6,7 +6,7 @@ import { Observable } from 'rxjs';
 import { FrontendUser } from '@dragonfish/shared/models/users';
 import { FormControl, FormGroup, Validators } from '@angular/forms';
 import { AlertsService } from '@dragonfish/client/alerts';
-import { NetworkService } from '../../../../services';
+import { DragonfishNetworkService } from '@dragonfish/client/services';
 import { ReplyCommentModel } from '../models';
 
 @Component({
@@ -25,7 +25,7 @@ export class CommentBoxComponent implements OnInit {
         body: new FormControl('', [Validators.minLength(10), Validators.required])
     })
 
-    constructor(private alerts: AlertsService, private network: NetworkService) {}
+    constructor(private alerts: AlertsService, private network: DragonfishNetworkService) {}
 
     ngOnInit(): void {
         this.editComment.setValue({

--- a/apps/bettafish/src/app/components/content/comments/comments.component.ts
+++ b/apps/bettafish/src/app/components/content/comments/comments.component.ts
@@ -7,7 +7,7 @@ import { FrontendUser } from '@dragonfish/shared/models/users';
 import { PaginateResult } from '@dragonfish/shared/models/util';
 import { Comment, CreateComment, EditComment, UserInfoComments } from '@dragonfish/shared/models/comments';
 import { FormGroup, FormControl, Validators } from '@angular/forms';
-import { NetworkService } from '../../../services';
+import { DragonfishNetworkService } from '@dragonfish/client/services';
 import { AlertsService } from '@dragonfish/client/alerts';
 import { ContentKind } from '@dragonfish/shared/models/content';
 import { findIndex } from 'lodash';
@@ -39,7 +39,7 @@ export class CommentsComponent {
         body: new FormControl('', [Validators.required, Validators.minLength(10)]),
     });
 
-    constructor(private networkService: NetworkService, private alerts: AlertsService) {}
+    constructor(private networkService: DragonfishNetworkService, private alerts: AlertsService) {}
 
     ngOnInit(): void {
         this.fetchData(this.pageNum);

--- a/apps/bettafish/src/app/pages/browse/browse.component.ts
+++ b/apps/bettafish/src/app/pages/browse/browse.component.ts
@@ -2,9 +2,11 @@ import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { FormControl, FormGroup } from '@angular/forms';
 import { AlertsService } from '@dragonfish/client/alerts';
-import { ContentModel } from '@dragonfish/shared/models/content';
-import { NetworkService } from '../../services';
+import { ContentFilter, ContentModel } from '@dragonfish/shared/models/content';
+import { DragonfishNetworkService } from '@dragonfish/client/services';
 import { Constants, setTwoPartTitle } from '@dragonfish/shared/constants';
+import { SelectSnapshot } from '@ngxs-labs/select-snapshot';
+import { GlobalState } from '../../repo/global';
 
 @Component({
     selector: 'dragonfish-browse',
@@ -12,13 +14,15 @@ import { Constants, setTwoPartTitle } from '@dragonfish/shared/constants';
     styleUrls: ['./browse.component.scss']
 })
 export class BrowseComponent implements OnInit {
+    @SelectSnapshot(GlobalState.filter) filter: ContentFilter;
+
     loadingNew = false;
     newWorks: ContentModel[];
     searchForm = new FormGroup({
         query: new FormControl('')
     });
 
-    constructor(public route: ActivatedRoute, private router: Router, private alerts: AlertsService, private network: NetworkService) {}
+    constructor(public route: ActivatedRoute, private router: Router, private alerts: AlertsService, private network: DragonfishNetworkService) {}
 
     ngOnInit() {
         setTwoPartTitle(Constants.BROWSE);
@@ -27,7 +31,7 @@ export class BrowseComponent implements OnInit {
 
     loadFirstNew() {
         this.loadingNew = true;
-        this.network.fetchFirstNew().subscribe(result => {
+        this.network.fetchFirstNew(this.filter).subscribe(result => {
             this.newWorks = result;
             this.loadingNew = false;
         }, () => {

--- a/apps/bettafish/src/app/pages/browse/newest-works/newest-works.component.ts
+++ b/apps/bettafish/src/app/pages/browse/newest-works/newest-works.component.ts
@@ -1,10 +1,12 @@
 import { Component, OnInit } from '@angular/core';
-import { NetworkService } from '../../../services';
-import { ContentKind, ContentModel } from '@dragonfish/shared/models/content';
+import { DragonfishNetworkService } from '@dragonfish/client/services';
+import { ContentFilter, ContentKind, ContentModel } from '@dragonfish/shared/models/content';
 import { PaginateResult } from '@dragonfish/shared/models/util';
 import { ActivatedRoute, Router } from '@angular/router';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { Constants, setTwoPartTitle } from '@dragonfish/shared/constants';
+import { SelectSnapshot } from '@ngxs-labs/select-snapshot';
+import { GlobalState } from '../../../repo/global';
 
 @UntilDestroy()
 @Component({
@@ -13,11 +15,13 @@ import { Constants, setTwoPartTitle } from '@dragonfish/shared/constants';
     styleUrls: ['./newest-works.component.scss'],
 })
 export class NewestWorksComponent implements OnInit {
+    @SelectSnapshot(GlobalState.filter) filter: ContentFilter;
+
     loading = false;
     works: PaginateResult<ContentModel>;
     pageNum = 1;
 
-    constructor(private network: NetworkService, private route: ActivatedRoute, private router: Router) {}
+    constructor(private network: DragonfishNetworkService, private route: ActivatedRoute, private router: Router) { }
 
     ngOnInit(): void {
         setTwoPartTitle(Constants.NEWEST_WORKS);
@@ -37,7 +41,7 @@ export class NewestWorksComponent implements OnInit {
      */
     private fetchData(pageNum: number): void {
         this.loading = true;
-        this.network.fetchAllNew(pageNum, [ContentKind.PoetryContent, ContentKind.ProseContent])
+        this.network.fetchAllNew(pageNum, [ContentKind.PoetryContent, ContentKind.ProseContent], this.filter)
             .subscribe(result => {
                 this.works = result;
                 this.loading = false;

--- a/apps/bettafish/src/app/pages/browse/search/search.component.ts
+++ b/apps/bettafish/src/app/pages/browse/search/search.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { InitialResults } from '@dragonfish/shared/models/util';
-import { NetworkService } from '../../../services';
+import { DragonfishNetworkService } from '@dragonfish/client/services';
 
 @Component({
     selector: 'dragonfish-search',
@@ -12,7 +12,7 @@ export class SearchComponent {
     loading = false;
     searchResults: InitialResults;
 
-    constructor(private network: NetworkService, public route: ActivatedRoute) {}
+    constructor(private network: DragonfishNetworkService, public route: ActivatedRoute) {}
 
     ngOnInit(): void {
         const queryParams = this.route.snapshot.queryParamMap;

--- a/apps/bettafish/src/app/pages/home/home.component.ts
+++ b/apps/bettafish/src/app/pages/home/home.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { Constants, setTwoPartTitle } from '@dragonfish/shared/constants';
 import { slogans } from '../../models/site';
-import { NetworkService } from '../../services';
+import { DragonfishNetworkService } from '@dragonfish/client/services';
 import { ActivatedRoute } from '@angular/router';
 import { NewsContentModel } from '@dragonfish/shared/models/content';
 
@@ -16,7 +16,7 @@ export class HomeComponent implements OnInit {
     loadingLatest = false;
     latestPosts: NewsContentModel[];
 
-    constructor(private network: NetworkService, public route: ActivatedRoute) {}
+    constructor(private network: DragonfishNetworkService, public route: ActivatedRoute) {}
 
     ngOnInit(): void {
         setTwoPartTitle(Constants.HOME);

--- a/apps/bettafish/src/app/pages/home/news-feed/news-feed.component.ts
+++ b/apps/bettafish/src/app/pages/home/news-feed/news-feed.component.ts
@@ -1,10 +1,12 @@
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { PaginateResult } from '@dragonfish/shared/models/util';
-import { NewsContentModel, NewsCategory, ContentKind } from '@dragonfish/shared/models/content';
+import { NewsContentModel, NewsCategory, ContentKind, ContentFilter } from '@dragonfish/shared/models/content';
 import { setTwoPartTitle, Constants} from '@dragonfish/shared/constants';
 import { untilDestroyed, UntilDestroy } from '@ngneat/until-destroy';
-import { NetworkService } from '../../../services';
+import { DragonfishNetworkService } from '@dragonfish/client/services';
+import { SelectSnapshot } from '@ngxs-labs/select-snapshot';
+import { GlobalState } from '../../../repo/global';
 
 @UntilDestroy()
 @Component({
@@ -13,12 +15,14 @@ import { NetworkService } from '../../../services';
     styleUrls: ['./news-feed.component.scss'],
 })
 export class NewsFeedComponent implements OnInit {
+    @SelectSnapshot(GlobalState.filter) filter: ContentFilter;
+
     posts: PaginateResult<NewsContentModel>;
     pageNum = 1;
     category = NewsCategory;
     loading = false;
 
-    constructor(private route: ActivatedRoute, private router: Router, private network: NetworkService) {}
+    constructor(private route: ActivatedRoute, private router: Router, private network: DragonfishNetworkService) {}
 
     ngOnInit(): void {
         this.route.queryParamMap.pipe(untilDestroyed(this)).subscribe(params => {
@@ -39,7 +43,7 @@ export class NewsFeedComponent implements OnInit {
      */
     private fetchData(pageNum: number) {
         this.loading = true;
-        this.network.fetchAllNew(pageNum, [ContentKind.NewsContent])
+        this.network.fetchAllNew(pageNum, [ContentKind.NewsContent], this.filter)
             .subscribe(result => {
                 this.posts = result as PaginateResult<NewsContentModel>;
                 this.loading = false;

--- a/apps/bettafish/src/app/pages/portfolio/portfolio-collections/portfolio-collection-page/portfolio-collection-page.component.ts
+++ b/apps/bettafish/src/app/pages/portfolio/portfolio-collections/portfolio-collection-page/portfolio-collection-page.component.ts
@@ -8,7 +8,7 @@ import { FrontendUser } from '@dragonfish/shared/models/users';
 import { Collection } from '@dragonfish/shared/models/collections';
 import { UserState } from '../../../../repo/user';
 import { PortfolioState } from '../../../../repo/portfolio';
-import { NetworkService } from '../../../../services';
+import { DragonfishNetworkService } from '@dragonfish/client/services';
 import { CollectionFormComponent } from '../../../../components/content/collections/collection-form/collection-form.component';
 import { PopupModel } from '@dragonfish/shared/models/util';
 import { PopupComponent } from '@dragonfish/client/ui';
@@ -27,7 +27,7 @@ export class PortfolioCollectionPageComponent {
     constructor(
         private route: ActivatedRoute,
         private router: Router,
-        private network: NetworkService,
+        private network: DragonfishNetworkService,
         private location: Location,
         private dialog: MatDialog,
     ) {}

--- a/apps/bettafish/src/app/pages/portfolio/portfolio-collections/portfolio-collections.component.ts
+++ b/apps/bettafish/src/app/pages/portfolio/portfolio-collections/portfolio-collections.component.ts
@@ -6,7 +6,7 @@ import { Select } from '@ngxs/store';
 import { Observable, combineLatest } from 'rxjs';
 import { FrontendUser } from '@dragonfish/shared/models/users';
 import { UserState } from '../../../repo/user';
-import { NetworkService } from '../../../services';
+import { DragonfishNetworkService } from '@dragonfish/client/services';
 import { Collection } from '@dragonfish/shared/models/collections';
 import { PortfolioState } from '../../../repo/portfolio';
 import { Constants, setTwoPartTitle, setThreePartTitle } from '@dragonfish/shared/constants';
@@ -25,7 +25,7 @@ export class PortfolioCollectionsComponent implements OnInit {
     loading = false;
     pageNum = 1;
 
-    constructor(public route: ActivatedRoute, private router: Router, private network: NetworkService) {}
+    constructor(public route: ActivatedRoute, private router: Router, private network: DragonfishNetworkService) {}
 
     ngOnInit(): void {
         combineLatest(this.currentUser$, this.portUser$, this.route.queryParamMap)

--- a/apps/bettafish/src/app/pages/portfolio/portfolio-home/portfolio-home.component.ts
+++ b/apps/bettafish/src/app/pages/portfolio/portfolio-home/portfolio-home.component.ts
@@ -5,8 +5,10 @@ import { Select } from '@ngxs/store';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 import { Observable } from 'rxjs';
 import { PortfolioState } from '../../../repo/portfolio';
-import { NetworkService } from '../../../services';
-import { BlogsContentModel, ContentModel } from '@dragonfish/shared/models/content';
+import { DragonfishNetworkService } from '@dragonfish/client/services';
+import { BlogsContentModel, ContentFilter, ContentModel } from '@dragonfish/shared/models/content';
+import { SelectSnapshot } from '@ngxs-labs/select-snapshot';
+import { GlobalState } from '../../../repo/global';
 
 @UntilDestroy()
 @Component({
@@ -15,11 +17,12 @@ import { BlogsContentModel, ContentModel } from '@dragonfish/shared/models/conte
 })
 export class PortfolioHomeComponent implements OnInit {
     @Select(PortfolioState.currPortfolio) portUser$: Observable<FrontendUser>;
+    @SelectSnapshot(GlobalState.filter) filter: ContentFilter;
     loading = false;
     works: ContentModel[];
     blogs: BlogsContentModel[];
 
-    constructor(private network: NetworkService) {}
+    constructor(private network: DragonfishNetworkService) { }
 
     ngOnInit(): void {
         this.portUser$.pipe(untilDestroyed(this)).subscribe(user => {
@@ -30,7 +33,7 @@ export class PortfolioHomeComponent implements OnInit {
 
     private fetchData(userId: string) {
         this.loading = true;
-        this.network.fetchUserProfile(userId).subscribe(data => {
+        this.network.fetchUserProfile(userId, this.filter).subscribe(data => {
             this.works = data.works;
             this.blogs = data.blogs as BlogsContentModel[];
             this.loading = false;

--- a/apps/bettafish/src/app/repo/auth/auth.state.ts
+++ b/apps/bettafish/src/app/repo/auth/auth.state.ts
@@ -3,7 +3,7 @@ import { State, Action, StateContext, Selector } from '@ngxs/store';
 import { tap } from 'rxjs/operators';
 import * as Auth from './auth.actions';
 import { AuthStateModel } from './auth-state.model';
-import { NetworkService } from '../../services';
+import { DragonfishNetworkService } from '@dragonfish/client/services';
 
 import { FrontendUser } from '@dragonfish/shared/models/users';
 import { Observable } from 'rxjs';
@@ -18,7 +18,7 @@ import { AlertsService } from '@dragonfish/client/alerts';
 })
 @Injectable()
 export class AuthState {
-    constructor(private network: NetworkService, private alerts: AlertsService) {}
+    constructor(private network: DragonfishNetworkService, private alerts: AlertsService) {}
 
     /* Selectors */
 

--- a/apps/bettafish/src/app/repo/collections/collections.state.ts
+++ b/apps/bettafish/src/app/repo/collections/collections.state.ts
@@ -6,7 +6,7 @@ import { Collection } from '@dragonfish/shared/models/collections';
 import { throwError } from 'rxjs';
 import { tap, catchError } from 'rxjs/operators';
 import { CollectionsStateModel } from './collections-state.model';
-import { NetworkService } from '../../services';
+import { DragonfishNetworkService } from '@dragonfish/client/services';
 import * as Collections from './collections.actions';
 
 @State<CollectionsStateModel>({
@@ -34,7 +34,7 @@ export class CollectionsState {
         return ctx.currCollection;
     }
 
-    constructor(private network: NetworkService, private alerts: AlertsService) {}
+    constructor(private network: DragonfishNetworkService, private alerts: AlertsService) {}
 
     @Action(Collections.Create)
     public create({ getState, patchState }: StateContext<CollectionsStateModel>, { formInfo }: Collections.Create) {

--- a/apps/bettafish/src/app/repo/content/content.state.ts
+++ b/apps/bettafish/src/app/repo/content/content.state.ts
@@ -3,7 +3,7 @@ import { State, Action, Selector, StateContext, Store } from '@ngxs/store';
 import { Observable, zip, of } from 'rxjs';
 import { tap } from 'rxjs/operators';
 
-import { ContentKind, ContentModel, SectionInfo } from '@dragonfish/shared/models/content';
+import { ContentFilter, ContentKind, ContentModel, SectionInfo } from '@dragonfish/shared/models/content';
 import { RatingOption } from '@dragonfish/shared/models/reading-history';
 import { ReadingHistory } from '@dragonfish/shared/models/reading-history';
 import { FrontendUser } from '@dragonfish/shared/models/users';
@@ -12,8 +12,10 @@ import { Section } from '@dragonfish/shared/models/sections';
 
 import * as Content from './content.actions';
 import { ContentStateModel } from './content-state.model';
-import { NetworkService } from '../../services';
+import { DragonfishNetworkService } from '@dragonfish/client/services';
 import { UserState } from '../user';
+import { SelectSnapshot } from '@ngxs-labs/select-snapshot';
+import { GlobalState } from '../global';
 
 /**
  * ## ContentState
@@ -35,7 +37,9 @@ import { UserState } from '../user';
 })
 @Injectable()
 export class ContentState {
-    constructor(private networkService: NetworkService, private store: Store) {}
+    @SelectSnapshot(GlobalState.filter) filter: ContentFilter;
+
+    constructor(private networkService: DragonfishNetworkService, private store: Store) { }
 
     /* Selectors */
 
@@ -121,7 +125,7 @@ export class ContentState {
 
     @Action(Content.FetchAll)
     fetchAll({ patchState }: StateContext<ContentStateModel>, { pageNum, kinds, userId }: Content.FetchAll) {
-        return this.networkService.fetchAllContent(pageNum, kinds, userId).pipe(
+        return this.networkService.fetchAllContent(pageNum, kinds, this.filter, userId).pipe(
             tap((val: PaginateResult<ContentModel>) => {
                 patchState({
                     currPageContent: val,

--- a/apps/bettafish/src/app/repo/history/history.state.ts
+++ b/apps/bettafish/src/app/repo/history/history.state.ts
@@ -6,7 +6,7 @@ import { tap, catchError } from 'rxjs/operators';
 import { History } from './history.actions';
 import { HistoryStateModel } from './history-state.model';
 import { ReadingHistory } from '@dragonfish/shared/models/reading-history';
-import { NetworkService } from '../../services';
+import { DragonfishNetworkService } from '@dragonfish/client/services';
 import { AlertsService } from '@dragonfish/client/alerts';
 
 @State<HistoryStateModel>({
@@ -28,7 +28,7 @@ export class HistoryState {
     @Selector()
     public static loading(state: HistoryStateModel) { return state.loading; }
 
-    constructor(private network: NetworkService, private alerts: AlertsService) {}
+    constructor(private network: DragonfishNetworkService, private alerts: AlertsService) {}
 
     @Action(History.Fetch)
     public fetch({ patchState }: StateContext<HistoryStateModel>) {

--- a/apps/bettafish/src/app/repo/portfolio/portfolio.state.ts
+++ b/apps/bettafish/src/app/repo/portfolio/portfolio.state.ts
@@ -6,7 +6,7 @@ import { catchError, tap } from 'rxjs/operators';
 import { AlertsService } from '@dragonfish/client/alerts';
 import { FrontendUser } from '@dragonfish/shared/models/users';
 import { Injectable } from '@angular/core';
-import { NetworkService } from '../../services';
+import { DragonfishNetworkService } from '@dragonfish/client/services';
 import { PortfolioStateModel } from './portfolio-state.model';
 import { throwError } from 'rxjs';
 
@@ -23,7 +23,7 @@ export class PortfolioState {
         return ctx.currPortfolio;
     }
 
-    constructor(private network: NetworkService, private alerts: AlertsService) {}
+    constructor(private network: DragonfishNetworkService, private alerts: AlertsService) {}
 
     @Action(Portfolio.FetchCurrentPortfolio)
     public fetchCurrentPortfolio(
@@ -45,7 +45,7 @@ export class PortfolioState {
 
     @Action(Portfolio.UpdateCurrentProfile)
     public updateCurrentProfile(
-        { patchState }: StateContext<PortfolioStateModel>, 
+        { patchState }: StateContext<PortfolioStateModel>,
         { newUserInfo }: Portfolio.UpdateCurrentProfile
     ) {
         patchState({

--- a/apps/bettafish/src/app/repo/user/user.state.ts
+++ b/apps/bettafish/src/app/repo/user/user.state.ts
@@ -7,7 +7,7 @@ import { AlertsService } from '@dragonfish/client/alerts';
 import { FrontendUser } from '@dragonfish/shared/models/users';
 import { HttpError } from '@dragonfish/shared/models/util';
 import { Injectable } from '@angular/core';
-import { NetworkService } from '../../services';
+import { DragonfishNetworkService } from '@dragonfish/client/services';
 import { PortfolioService } from './../portfolio/services';
 import { UserStateModel } from './user-state.model';
 import { throwError } from 'rxjs';
@@ -20,7 +20,7 @@ import { throwError } from 'rxjs';
 })
 @Injectable()
 export class UserState {
-    constructor(private networkService: NetworkService, private alerts: AlertsService, private portfolio: PortfolioService) {}
+    constructor(private networkService: DragonfishNetworkService, private alerts: AlertsService, private portfolio: PortfolioService) {}
 
     /* Selectors */
 
@@ -126,7 +126,7 @@ export class UserState {
                 return throwError(error);
             }),
         );
-    } 
+    }
 
     @Action(User.UpdateTagline)
     updateTagline({ patchState }: StateContext<UserStateModel>, action: User.UpdateTagline) {

--- a/apps/bettafish/src/app/resolvers/home/home-page.resolver.ts
+++ b/apps/bettafish/src/app/resolvers/home/home-page.resolver.ts
@@ -4,11 +4,11 @@ import { Observable } from 'rxjs';
 
 import { NewsContentModel } from '@dragonfish/shared/models/content';
 
-import { NetworkService } from '../../services';
+import { DragonfishNetworkService } from '@dragonfish/client/services';
 
 @Injectable()
 export class HomePageResolver implements Resolve<NewsContentModel[]> {
-    constructor(private networkService: NetworkService) {}
+    constructor(private networkService: DragonfishNetworkService) {}
 
     resolve(route: ActivatedRouteSnapshot, routerState: RouterStateSnapshot): Observable<NewsContentModel[]> {
         return this.networkService.fetchInitialNewsPosts();

--- a/apps/bettafish/src/app/resolvers/portfolio/collection-page.resolver.ts
+++ b/apps/bettafish/src/app/resolvers/portfolio/collection-page.resolver.ts
@@ -5,7 +5,7 @@ import { Select } from '@ngxs/store';
 import { Observable, Subscription } from 'rxjs';
 import { UserState } from '../../repo/user';
 
-import { NetworkService } from '../../services';
+import { DragonfishNetworkService } from '@dragonfish/client/services';
 import { Collection } from '@dragonfish/shared/models/collections';
 
 @Injectable()
@@ -14,7 +14,7 @@ export class CollectionPageResolver implements Resolve<Collection> {
     currentUserSubscription: Subscription;
     currentUser: FrontendUser;
 
-    constructor(private networkService: NetworkService) {
+    constructor(private networkService: DragonfishNetworkService) {
         this.currentUserSubscription = this.currentUser$.subscribe((x) => {
             this.currentUser = x;
         });

--- a/apps/bettafish/src/app/resolvers/portfolio/collections.resolver.ts
+++ b/apps/bettafish/src/app/resolvers/portfolio/collections.resolver.ts
@@ -8,7 +8,7 @@ import { PaginateResult } from '@dragonfish/shared/models/util';
 import { Collection } from '@dragonfish/shared/models/collections';
 
 import { UserState } from '../../repo/user';
-import { NetworkService } from '../../services';
+import { DragonfishNetworkService } from '@dragonfish/client/services';
 
 @Injectable()
 export class CollectionsResolver implements Resolve<PaginateResult<Collection>> {
@@ -18,7 +18,7 @@ export class CollectionsResolver implements Resolve<PaginateResult<Collection>> 
 
     pageNum = 1;
 
-    constructor(private networkService: NetworkService) {
+    constructor(private networkService: DragonfishNetworkService) {
         this.currentUserSubscription = this.currentUser$.subscribe((x) => {
             this.currentUser = x;
         });

--- a/apps/bettafish/src/app/services/index.ts
+++ b/apps/bettafish/src/app/services/index.ts
@@ -1,3 +1,2 @@
-export { NetworkService } from './network.service';
 export { NotificationsService } from './notifications.service';
 export { SidenavService } from './sidenav.service';

--- a/apps/bettafish/src/app/services/notifications.service.ts
+++ b/apps/bettafish/src/app/services/notifications.service.ts
@@ -1,13 +1,13 @@
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { NotificationBase, MarkReadRequest, NotificationSubscription } from '@dragonfish/shared/models/notifications';
-import { NetworkService } from './network.service';
+import { DragonfishNetworkService } from '@dragonfish/client/services';
 
 @Injectable({
     providedIn: 'root',
 })
 export class NotificationsService {
-    constructor(private networkService: NetworkService) {}
+    constructor(private networkService: DragonfishNetworkService) {}
 
     /**
      * Gets all of the current user's notifications.

--- a/jest.config.js
+++ b/jest.config.js
@@ -12,5 +12,6 @@ module.exports = {
         '<rootDir>/libs/client/editor',
         '<rootDir>/libs/client/my-stuff',
         '<rootDir>/libs/client/dashboard',
+        '<rootDir>/libs/client/services',
     ],
 };

--- a/libs/client/services/.eslintrc.json
+++ b/libs/client/services/.eslintrc.json
@@ -1,0 +1,22 @@
+{
+    "extends": ["../../../.eslintrc.json"],
+    "ignorePatterns": ["!**/*"],
+    "overrides": [
+        {
+            "files": ["*.ts"],
+            "extends": ["plugin:@nrwl/nx/angular", "plugin:@angular-eslint/template/process-inline-templates"],
+            "parserOptions": { "project": ["libs/client/services/tsconfig.*?.json"] },
+            "rules": {
+                "@angular-eslint/directive-selector": [
+                    "error",
+                    { "type": "attribute", "prefix": "dragonfish", "style": "camelCase" }
+                ],
+                "@angular-eslint/component-selector": [
+                    "error",
+                    { "type": "element", "prefix": "dragonfish", "style": "kebab-case" }
+                ]
+            }
+        },
+        { "files": ["*.html"], "extends": ["plugin:@nrwl/nx/angular-template"], "rules": {} }
+    ]
+}

--- a/libs/client/services/README.md
+++ b/libs/client/services/README.md
@@ -1,0 +1,7 @@
+# client-services
+
+This library was generated with [Nx](https://nx.dev).
+
+## Running unit tests
+
+Run `nx test client-services` to execute the unit tests.

--- a/libs/client/services/jest.config.js
+++ b/libs/client/services/jest.config.js
@@ -1,0 +1,23 @@
+module.exports = {
+    displayName: 'client-services',
+    preset: '../../../jest.preset.js',
+    setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
+    globals: {
+        'ts-jest': {
+            tsConfig: '<rootDir>/tsconfig.spec.json',
+            stringifyContentPathRegex: '\\.(html|svg)$',
+            astTransformers: {
+                before: [
+                    'jest-preset-angular/build/InlineFilesTransformer',
+                    'jest-preset-angular/build/StripStylesTransformer',
+                ],
+            },
+        },
+    },
+    coverageDirectory: '../../../coverage/libs/client/services',
+    snapshotSerializers: [
+        'jest-preset-angular/build/AngularNoNgAttributesSnapshotSerializer.js',
+        'jest-preset-angular/build/AngularSnapshotSerializer.js',
+        'jest-preset-angular/build/HTMLCommentSerializer.js',
+    ],
+};

--- a/libs/client/services/src/index.ts
+++ b/libs/client/services/src/index.ts
@@ -1,0 +1,1 @@
+export * from './lib/client-services.module';

--- a/libs/client/services/src/lib/client-services.module.ts
+++ b/libs/client/services/src/lib/client-services.module.ts
@@ -1,0 +1,7 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@NgModule({
+    imports: [CommonModule],
+})
+export class ClientServicesModule {}

--- a/libs/client/services/src/lib/client-services.module.ts
+++ b/libs/client/services/src/lib/client-services.module.ts
@@ -3,5 +3,8 @@ import { CommonModule } from '@angular/common';
 
 @NgModule({
     imports: [CommonModule],
+    exports: []
 })
 export class ClientServicesModule {}
+
+export { DragonfishNetworkService } from './dragonfish-network.service';

--- a/libs/client/services/src/lib/dragonfish-network.service.ts
+++ b/libs/client/services/src/lib/dragonfish-network.service.ts
@@ -27,31 +27,26 @@ import { Observable, of, throwError } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
 import { handleResponse, tryParseJsonHttpError } from '@dragonfish/shared/functions';
 
-import { AlertsService } from '@dragonfish/client/alerts';
 import { ApprovalQueue } from '@dragonfish/shared/models/approval-queue';
 import { Decision } from '@dragonfish/shared/models/contrib';
 import { FrontPageStats } from '@dragonfish/shared/models/stats';
-import { GlobalState } from '../repo/global';
 import { HttpError } from '@dragonfish/shared/models/util';
 import { Injectable } from '@angular/core';
 import { ReadingHistory } from '@dragonfish/shared/models/reading-history';
 import { Section } from '@dragonfish/shared/models/works';
-import { SelectSnapshot } from '@ngxs-labs/select-snapshot';
 import { CookieService } from 'ngx-cookie';
 
 /**
- * ## NetworkService
+ * ## DragonfishNetworkService
  *
- * Manages API calls to the backend.
+ * Manages API calls to the Dragonfish backend.
  */
 @Injectable({
     providedIn: 'root',
 })
-export class NetworkService {
-    @SelectSnapshot(GlobalState.filter) filter: ContentFilter;
-
+export class DragonfishNetworkService {
     private baseUrl = `/api`;
-    constructor(private readonly http: HttpClient, private readonly alertsService: AlertsService, private readonly cookieService: CookieService ) {}
+    constructor(private readonly http: HttpClient, private readonly cookieService: CookieService) { }
 
     //#region ---APPROVAL QUEUE---
 
@@ -125,7 +120,7 @@ export class NetworkService {
             ),
             null,
             (_err) => {
-                //this.snackBar.open(`Something went wrong! Try again in a little bit.`);
+
             },
         );
     }
@@ -143,14 +138,10 @@ export class NetworkService {
                 { observe: 'response', withCredentials: true },
             ),
             (resp) => {
-                //this.alertsService.success(`Work successfully submitted!`);
+
             },
             (err) => {
-                // if (err.error.message) {
-                //   this.alertsService.error(`HTTP ${err.status}: ${err.error.message}`);
-                // } else {
-                //   this.alertsService.error(`Something went wrong! Try again in a little bit.\nDetails: HTTP ${err.status}`);
-                // }
+
             },
         );
     }
@@ -407,10 +398,10 @@ export class NetworkService {
                 withCredentials: true,
             }),
             (resp) => {
-                //this.alertsService.success(`Comment added successfully!`);
+
             },
             (err) => {
-                //this.alertsService.error(err.error.message);
+
             },
         );
     }
@@ -423,7 +414,7 @@ export class NetworkService {
             ),
             null,
             (err) => {
-                //this.alertsService.error(err.error.message);
+
             },
         );
     }
@@ -441,10 +432,10 @@ export class NetworkService {
                 withCredentials: true,
             }),
             (resp) => {
-                //this.alertsService.success(`Changes saved!`);
+
             },
             (err) => {
-                //this.alertsService.error(err.error.message);
+
             },
         );
     }
@@ -467,7 +458,7 @@ export class NetworkService {
             ),
             null,
             (err) => {
-                //this.snackBar.open(`Something went wrong fetching this content. Try again in a little bit.`);
+
             },
         );
     }
@@ -487,7 +478,7 @@ export class NetworkService {
             ),
             null,
             (err) => {
-                //this.snackBar.open(err.error.message);
+
             },
         );
     }
@@ -498,11 +489,13 @@ export class NetworkService {
      *
      * @param pageNum The current page
      * @param kinds The kinds of content to include
+     * @param contentFilter The rating filter to apply to the retrieval
      * @param userId (Optional) The author of this content
      */
     public fetchAllContent(
         pageNum: number,
         kinds: ContentKind[],
+        contentFilter: ContentFilter,
         userId?: string,
     ): Observable<PaginateResult<ContentModel>> {
         let route = ``;
@@ -512,16 +505,16 @@ export class NetworkService {
         // which becomes "&kind=Kind1&kind=Kind2", etc.
         const kindFragment = kinds.map((k) => `&kind=${k}`).join('');
         if (userId) {
-            route = `${this.baseUrl}/content/fetch-all-published?filter=${this.filter}&pageNum=${pageNum}&userId=${userId}${kindFragment}`;
+            route = `${this.baseUrl}/content/fetch-all-published?filter=${contentFilter}&pageNum=${pageNum}&userId=${userId}${kindFragment}`;
         } else {
-            route = `${this.baseUrl}/content/fetch-all-published?filter=${this.filter}&pageNum=${pageNum}${kindFragment}`;
+            route = `${this.baseUrl}/content/fetch-all-published?filter=${contentFilter}&pageNum=${pageNum}${kindFragment}`;
         }
 
         return handleResponse(
             this.http.get<PaginateResult<ContentModel>>(route, { observe: 'response', withCredentials: true }),
             null,
             (err) => {
-                //this.snackBar.open(`Something went wrong fetching this content. Try again in a little bit.`);
+
             },
         );
     }
@@ -539,7 +532,7 @@ export class NetworkService {
             }),
             null,
             (err) => {
-                //this.snackBar.open(`Something went wrong fetching this section. Try again in a little bit.`);
+
             },
         );
     }
@@ -557,7 +550,7 @@ export class NetworkService {
             }),
             null,
             (err) => {
-                //this.snackBar.open(err.error.message);
+
             },
         );
     }
@@ -575,7 +568,7 @@ export class NetworkService {
             }),
             null,
             (err) => {
-                //this.snackBar.open(err.error.message);
+
             },
         );
     }
@@ -593,7 +586,7 @@ export class NetworkService {
             }),
             null,
             (err) => {
-                //this.snackBar.open(err.error.message);
+
             },
         );
     }
@@ -611,7 +604,7 @@ export class NetworkService {
         const xsrfHeader = uploader.options.headers.find(x => x.name.toUpperCase() === "XSRF-TOKEN");
         const currentXsrfToken = this.cookieService.get("XSRF-TOKEN") ?? "";
         if (!xsrfHeader) {
-            uploader.options.headers.push({name: "XSRF-TOKEN", value: currentXsrfToken});
+            uploader.options.headers.push({ name: "XSRF-TOKEN", value: currentXsrfToken });
         } else {
             xsrfHeader.value = currentXsrfToken;
         }
@@ -660,7 +653,7 @@ export class NetworkService {
             }),
             null,
             (err) => {
-                this.alertsService.error(err.error.message);
+
             },
         );
     }
@@ -676,7 +669,7 @@ export class NetworkService {
             }),
             null,
             (err) => {
-                this.alertsService.error(err.error.message);
+
             },
         );
     }
@@ -695,7 +688,7 @@ export class NetworkService {
             ),
             null,
             (err) => {
-                this.alertsService.error(err.error.message);
+
             },
         );
     }
@@ -712,11 +705,11 @@ export class NetworkService {
                 { histIds: histIds },
                 { observe: 'response', withCredentials: true },
             ),
-            () => {
-                this.alertsService.success(`Item(s) successfully deleted.`);
+            (resp) => {
+
             },
             (err) => {
-                this.alertsService.error(err.error.message);
+
             },
         );
     }
@@ -792,7 +785,7 @@ export class NetworkService {
             }),
             null,
             (err) => {
-                //this.snackBar.open(`${err.error.message}`);
+
             },
         );
     }
@@ -810,7 +803,7 @@ export class NetworkService {
             }),
             null,
             (err) => {
-                //this.snackBar.open(`${err.error.message}`);
+
             },
         );
     }
@@ -828,7 +821,7 @@ export class NetworkService {
             }),
             null,
             (err) => {
-                //this.snackBar.open(`${err.error.message}`);
+
             },
         );
     }
@@ -920,16 +913,17 @@ export class NetworkService {
 
     /**
      * Fetches the first few new works for the browse page.
+     * @param contentFilter The rating filter to apply to the fetch
      */
-    public fetchFirstNew() {
+    public fetchFirstNew(contentFilter: ContentFilter) {
         return handleResponse(
-            this.http.get<ContentModel[]>(`${this.baseUrl}/browse/fetch-first-new?filter=${this.filter}`, {
+            this.http.get<ContentModel[]>(`${this.baseUrl}/browse/fetch-first-new?filter=${contentFilter}`, {
                 observe: 'response',
                 withCredentials: true,
             }),
             null,
             () => {
-                this.alertsService.error(`Something went wrong! Try again in a little bit.`);
+
             }
         );
     }
@@ -939,16 +933,17 @@ export class NetworkService {
      *
      * @param pageNum The current page
      * @param kinds The kinds of work to fetch
+     * @param contentFilter The mature/explicit/etc. content filter to apply
      */
-    public fetchAllNew(pageNum: number, kinds: ContentKind[]) {
+    public fetchAllNew(pageNum: number, kinds: ContentKind[], contentFilter: ContentFilter) {
         const kindFragment = kinds.map((k) => `&kind=${k}`).join('');
-        const route = `${this.baseUrl}/browse/fetch-all-new?filter=${this.filter}&pageNum=${pageNum}${kindFragment}`;
+        const route = `${this.baseUrl}/browse/fetch-all-new?filter=${contentFilter}&pageNum=${pageNum}${kindFragment}`;
 
         return handleResponse(
             this.http.get<PaginateResult<ContentModel>>(route, { observe: 'response', withCredentials: true }),
             null,
             () => {
-                this.alertsService.error(`Something went wrong fetching this content. Try again in a little bit.`);
+
             },
         );
     }
@@ -965,7 +960,7 @@ export class NetworkService {
             }),
             null,
             (err) => {
-                this.alertsService.error(`Something went wrong! Try again in a little bit.`);
+
             },
         );
     }
@@ -978,7 +973,7 @@ export class NetworkService {
             ),
             null,
             (err) => {
-                this.alertsService.error(`Something went wrong! Try again in a little bit.`);
+
             },
         );
     }
@@ -991,7 +986,7 @@ export class NetworkService {
             ),
             null,
             (err) => {
-                //this.alertsService.error(`Something with wrong! Try again in a little bit.`);
+
             },
         );
     }
@@ -1004,7 +999,7 @@ export class NetworkService {
             ),
             null,
             (err) => {
-                this.alertsService.error(`Something with wrong! Try again in a little bit.`);
+
             },
         );
     }
@@ -1024,7 +1019,7 @@ export class NetworkService {
             }),
             null,
             (err) => {
-                //this.alertsService.error(`Error retrieving frontpage stats.`);
+
             },
         );
     }
@@ -1050,15 +1045,16 @@ export class NetworkService {
     /**
      * Fetches a specified user's profile for the portfolio home page.
      *
-     * @param userId
+     * @param userId The user whose profile should be retrieved
+     * @param contentFilter The rating filter to apply to the user's content
      */
-    public fetchUserProfile(userId: string): Observable<{works: ContentModel[], blogs: ContentModel[]}> {
+    public fetchUserProfile(userId: string, contentFilter: ContentFilter): Observable<{ works: ContentModel[], blogs: ContentModel[] }> {
         return handleResponse(
-            this.http.get<{works: ContentModel[], blogs: ContentModel[]}>(
-                `${this.baseUrl}/user/get-user-profile?userId=${userId}&filter=${this.filter}`, {
-                    observe: 'response',
-                    withCredentials: true,
-                }),
+            this.http.get<{ works: ContentModel[], blogs: ContentModel[] }>(
+                `${this.baseUrl}/user/get-user-profile?userId=${userId}&filter=${contentFilter}`, {
+                observe: 'response',
+                withCredentials: true,
+            }),
         )
     }
 
@@ -1075,7 +1071,7 @@ export class NetworkService {
             }),
             null,
             (err) => {
-                //this.snackBar.open(err.error.message);
+
             },
         );
     }
@@ -1093,7 +1089,7 @@ export class NetworkService {
             }),
             null,
             (err) => {
-                //this.snackBar.open(err.error.message);
+
             },
         );
     }
@@ -1111,7 +1107,7 @@ export class NetworkService {
             }),
             null,
             (err) => {
-                //this.snackBar.open(err.error.message);
+
             },
         );
     }
@@ -1129,7 +1125,7 @@ export class NetworkService {
             }),
             null,
             (err) => {
-                //this.snackBar.open(err.error.message);
+
             },
         );
     }
@@ -1147,7 +1143,7 @@ export class NetworkService {
             }),
             null,
             (err) => {
-                //this.snackBar.open(err.error.message);
+
             },
         );
     }

--- a/libs/client/services/src/test-setup.ts
+++ b/libs/client/services/src/test-setup.ts
@@ -1,0 +1,1 @@
+import 'jest-preset-angular';

--- a/libs/client/services/tsconfig.json
+++ b/libs/client/services/tsconfig.json
@@ -1,0 +1,13 @@
+{
+    "extends": "../../../tsconfig.base.json",
+    "files": [],
+    "include": [],
+    "references": [
+        {
+            "path": "./tsconfig.lib.json"
+        },
+        {
+            "path": "./tsconfig.spec.json"
+        }
+    ]
+}

--- a/libs/client/services/tsconfig.lib.json
+++ b/libs/client/services/tsconfig.lib.json
@@ -1,0 +1,19 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "outDir": "../../../dist/out-tsc",
+        "target": "es2015",
+        "declaration": true,
+        "declarationMap": true,
+        "inlineSources": true,
+        "types": [],
+        "lib": ["dom", "es2018"]
+    },
+    "angularCompilerOptions": {
+        "skipTemplateCodegen": true,
+        "strictMetadataEmit": true,
+        "enableResourceInlining": true
+    },
+    "exclude": ["src/test-setup.ts", "**/*.spec.ts"],
+    "include": ["**/*.ts"]
+}

--- a/libs/client/services/tsconfig.spec.json
+++ b/libs/client/services/tsconfig.spec.json
@@ -1,0 +1,10 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "outDir": "../../../dist/out-tsc",
+        "module": "commonjs",
+        "types": ["jest", "node"]
+    },
+    "files": ["src/test-setup.ts"],
+    "include": ["**/*.spec.ts", "**/*.d.ts"]
+}

--- a/nx.json
+++ b/nx.json
@@ -28,6 +28,7 @@
         "bettafish-native": { "tags": [] },
         "client-editor": { "tags": [] },
         "client-my-stuff": { "tags": [] },
-        "client-dashboard": { "tags": [] }
+        "client-dashboard": { "tags": [] },
+        "client-services": { "tags": [] }
     }
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -23,7 +23,8 @@
             "@dragonfish/client/icons": ["libs/client/icons/src/index.ts"],
             "@dragonfish/client/editor": ["libs/client/editor/src/index.ts"],
             "@dragonfish/client/my-stuff": ["libs/client/my-stuff/src/index.ts"],
-            "@dragonfish/client/dashboard": ["libs/client/dashboard/src/index.ts"]
+            "@dragonfish/client/dashboard": ["libs/client/dashboard/src/index.ts"],
+            "@dragonfish/client/services": ["libs/client/services/src/index.ts"]
         }
     },
     "exclude": ["node_modules", "tmp"]


### PR DESCRIPTION
This creates a new shared clientside library for `services`. I've moved the NetworkSerivce here and renamed it to `DragonfishNetworkService` (to distinguish it from possible future network services that may need to call out to other APIs, 'cause believe me, we're gonna have 'em).

I _did not_ merge My Stuff's NetworkService with the DragonfishNetworkService, because I wanted to minimize the churn in this PR as much as possible.

I also removed all the alerting UI code from DragonfishNetworkService, because we've had a few months to move it out; I'd say it's time to rip off that band-aid.