### PR TITLE
Fixes content loading by adding null check for ratings

### DIFF
--- a/libs/client/repository/src/lib/content-view/content-view.service.ts
+++ b/libs/client/repository/src/lib/content-view/content-view.service.ts
@@ -37,7 +37,7 @@ export class ContentViewService {
                 currContent: value.content,
                 allSections: sections,
                 ratingsDoc: value.ratings,
-                currRating: value.ratings.rating ? value.ratings.rating : RatingOption.NoVote,
+                currRating: (value.ratings && value.ratings.rating) ? value.ratings.rating : RatingOption.NoVote,
                 likes: value.content.stats.likes,
                 dislikes: value.content.stats.dislikes,
             });


### PR DESCRIPTION
Checks that value.ratings is null before checking if value.ratings.rating is null.

Fixes https://github.com/OffprintStudios/dragonfish/issues/534