### PR TITLE
bump argon 2 version, remove SSE logic

### DIFF
--- a/apps/api/src/app/controllers/notifications/notifications.controller.ts
+++ b/apps/api/src/app/controllers/notifications/notifications.controller.ts
@@ -21,45 +21,28 @@ import {
     NotificationSubscription,
 } from '@dragonfish/shared/models/notifications';
 import { Roles } from '@dragonfish/shared/models/users';
-import { Observable, from } from 'rxjs';
-import { map } from 'rxjs/operators';
 import { NotificationsService, UnsubscribeResult } from '@dragonfish/api/database/notifications';
 import { RolesGuard } from '../../guards';
 import { isNullOrUndefined } from '@dragonfish/shared/functions';
 
+@UseGuards(RolesGuard([Roles.User]))
 @Controller('notifications')
 export class NotificationsController {
     constructor(private readonly notificationsService: NotificationsService) {}
 
-    @UseGuards(RolesGuard([Roles.User]))
-    @Sse('sse')
-    getNotificationStream(@Request() req: any): Observable<MessageEvent> {
-        const userId: string = req.user.sub;
-        const observeNotif = from(this.notificationsService.getUnreadNotifications(userId));
-
-        return observeNotif.pipe(
-            map((notifData) => {
-                return { data: notifData };
-            }),
-        );
-    }
-
     @Get('all-notifications')
-    @UseGuards(RolesGuard([Roles.User]))
     async getAllNotifications(@Request() req: any): Promise<NotificationBase[]> {
         const userId: string = req.user.sub;
         return await this.notificationsService.getAllNotifications(userId);
     }
 
     @Get('unread-notifications')
-    @UseGuards(RolesGuard([Roles.User]))
     async getUnreadNotifications(@Request() req: any): Promise<NotificationBase[]> {
         const userId: string = req.user.sub;
         return await this.notificationsService.getUnreadNotifications(userId);
     }
 
     @Post('mark-as-read')
-    @UseGuards(RolesGuard([Roles.User]))
     async markAsRead(@Request() req: any, @Body() toMark: MarkReadRequest): Promise<void> {
         const userId: string = req.user.sub;
         if (!toMark.ids) {
@@ -75,14 +58,12 @@ export class NotificationsController {
     }
 
     @Get('subscriptions')
-    @UseGuards(RolesGuard([Roles.User]))
     async getSubscriptions(@Request() req: any): Promise<NotificationSubscription[]> {
         const userId: string = req.user.sub;
         return await this.notificationsService.getSubscriptions(userId);
     }
 
     @Post('subscribe')
-    @UseGuards(RolesGuard([Roles.User]))
     async subscribe(
         @Request() req: any,
         @Query('sourceId') sourceId: string,
@@ -98,7 +79,6 @@ export class NotificationsController {
 
     @Post('unsubscribe')
     @HttpCode(200) // because a successful unsubscribe doesn't "create" anything, don't return Created
-    @UseGuards(RolesGuard([Roles.User]))
     async unsubscribe(
         @Request() req: any,
         @Query('sourceId') sourceId: string,

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "@nrwl/angular": "12.3.5",
     "angular-feather": "^6.1.0",
     "apollo-server-express": "^2.22.2",
-    "argon2": "^0.27.1",
+    "argon2": "^0.28.0",
     "autoprefixer": "^10.2.5",
     "aws-sdk": "^2.860.0",
     "cookie-parser": "^1.4.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4414,10 +4414,10 @@ arg@^4.1.0:
   resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.3.tgz#269fc7ad5b8e42cb63c896d5666017261c144089"
   integrity sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==
 
-argon2@^0.27.1:
-  version "0.27.2"
-  resolved "https://registry.yarnpkg.com/argon2/-/argon2-0.27.2.tgz#f334ca15aee748739ac81f76b85d197841e8cdcc"
-  integrity sha512-evnzS/Q9rj6ahaaCJjLDoJo9ZuXHhVL2BrBz3wFHb5/i9zAJovBuIY+5t2En7tJjhFXs4O3rUZDeGZxBiDOLwQ==
+argon2@^0.28.0:
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/argon2/-/argon2-0.28.0.tgz#b32ea7526457f5593dda51c5a8e542bde3ba2621"
+  integrity sha512-bFgoLJbfNVbceXO9h8wKytoqBWyDsROp0HVlhtpyXCwq/izvMJ7CKZdDQp8y0T4yKAQHKD1vuW0C1INdjYdRsw==
   dependencies:
     "@mapbox/node-pre-gyp" "^1.0.1"
     "@phc/format" "^1.0.0"


### PR DESCRIPTION
- bumps argon2 version (yay for actually compiling on apple silicon now!)
- removes SSE logic from notifications (wasn't being used anyways)
- adds generic SSE function to DragonfishNetworkService for later use