### PR TITLE
Fix issue with author's note showing body text in editor

### DIFF
--- a/libs/client/my-stuff/src/lib/components/section-item/section-item.component.html
+++ b/libs/client/my-stuff/src/lib/components/section-item/section-item.component.html
@@ -93,7 +93,7 @@
                             </div>
                         </div>
 
-                        <dragonfish-editor-lite [formControlName]="'body'"></dragonfish-editor-lite>
+                        <dragonfish-editor-lite [formControlName]="'authorsNote'"></dragonfish-editor-lite>
                     </div>
                 </form>
             </div>


### PR DESCRIPTION
Addresses https://github.com/OffprintStudios/dragonfish/issues/570

Fixes wrong text used in HTML