### PR TITLE
Fix typos in manage-sections

### DIFF
--- a/libs/client/my-stuff/src/lib/components/manage-sections/manage-sections.component.html
+++ b/libs/client/my-stuff/src/lib/components/manage-sections/manage-sections.component.html
@@ -51,7 +51,7 @@
                     </div>
                     <form [formGroup]="sectionForm">
                         <dragonfish-text-field
-                            [formControlName]="'title'"t
+                            [formControlName]="'title'"
                             [name]="'title'"
                             [type]="'text'"
                             [label]="'Title'"
@@ -72,7 +72,7 @@
                                     </ng-select>
                                 </div>
                             </div>
-                            <dragonfish-editor-lite [formControlName]="'body'"></dragonfish-editor-lite>
+                            <dragonfish-editor-lite [formControlName]="'authorsNote'"></dragonfish-editor-lite>
                         </div>
                     </form>
                 </div>


### PR DESCRIPTION
Addresses #570 too

These fixed typos appear to be nonfunctional, but I thought it best to fix these to reduce confusion.

