### PR TITLE
Limit editor height and remove floating toolbar for headers

### DIFF
--- a/libs/client/editor-lite/src/lib/editor-lite.component.html
+++ b/libs/client/editor-lite/src/lib/editor-lite.component.html
@@ -185,31 +185,6 @@
             </button>
         </div>
     </tiptap-bubble-menu>
-    <tiptap-floating-menu [editor]="editor">
-        <div class="line-menu">
-            <button
-                class="shadow-none border-none px-2.5 py-1.5"
-                (click)="chainCommand().toggleHeading({ level: 2 }).run()"
-                [ngClass]="{ 'active': editor.isActive('heading', { level: 2 }) }"
-            >
-                <rmx-icon name="h-1" class="mr-0"></rmx-icon>
-            </button>
-            <button
-                class="shadow-none border-none px-2.5 py-1.5"
-                (click)="chainCommand().toggleHeading({ level: 3 }).run()"
-                [ngClass]="{ 'active': editor.isActive('heading', { level: 3 }) }"
-            >
-                <rmx-icon name="h-2" class="mr-0"></rmx-icon>
-            </button>
-            <button
-                class="shadow-none border-none px-2.5 py-1.5"
-                (click)="chainCommand().toggleHeading({ level: 4 }).run()"
-                [ngClass]="{ 'active': editor.isActive('heading', { level: 4 }) }"
-            >
-                <rmx-icon name="h-3" class="mr-0"></rmx-icon>
-            </button>
-        </div>
-    </tiptap-floating-menu>
 </div>
 
 <mat-menu #alignments="matMenu">

--- a/libs/client/editor-lite/src/lib/editor-lite.component.scss
+++ b/libs/client/editor-lite/src/lib/editor-lite.component.scss
@@ -1,5 +1,7 @@
 div.editor-window {
     min-height: 10rem;
+    max-height: 85vh;
+    overflow-y: scroll;
     @apply block relative rounded-b-md border;
     border-color: var(--borders);
     color: var(--text-color);
@@ -7,6 +9,7 @@ div.editor-window {
     .ProseMirror {
         @apply py-0.5 px-3 bg-transparent mb-0 focus:outline-none;
         min-height: 10rem;
+        max-height: 85vh;
 
         p.is-editor-empty:first-child::before {
             content: attr(data-placeholder);
@@ -96,7 +99,7 @@ button.active {
     }
 }
 
-div.floating-menu, div.line-menu {
+div.floating-menu {
     @apply flex items-center p-0.5 rounded-md shadow-2xl;
     background: var(--background);
     border: 1px solid var(--borders);


### PR DESCRIPTION
Users haven't enjoyed the full-length editor view, so this PR will restrict the height of the editor and include a scroll bar.
This also removes the floating toolbar used for headers, since the header options will already be visible at the top, and this was a common source of confusion for users. The other floating toolbar options will remain.