### PR TITLE
Fixes display date for old sections, which previously showed 1969

### DIFF
--- a/libs/client/ui/src/lib/components/sections-list/sections-list.component.html
+++ b/libs/client/ui/src/lib/components/sections-list/sections-list.component.html
@@ -21,7 +21,8 @@
                             [matTooltipClass]="'offprint-tooltip'"
                         >
                                 <i-feather name="calendar"></i-feather>
-                            {{ section.audit.publishedOn | localedate: 'mediumDate' }}
+                            <ng-container *ngIf="section.audit.publishedOn; else createdAt"> {{ section.audit.publishedOn | localedate: 'mediumDate' }} </ng-container>
+                            <ng-template #createdAt> {{ section.createdAt | localedate: 'mediumDate' }} </ng-template>
                             </span>
                     </div>
                     <div class="section-button">


### PR DESCRIPTION
## Description
For work sections for works made before the section document entries got redesigned, they displayed the publish date as December 31, 1969. This is true even of new sections of those works.

## Changes
Modifies sections-list.component.html to check if the current publishedOn date is valid, and if not, uses createdAt instead.

## Areas Affected
- [ ] Site Navigation
- [ ] Home
- [ ] Sign In/Out
- [ ] Registration
- [ ] Settings

.
- [ ] Profile
- [ ] My Stuff (main page)
- [ ] Editor
- [ ] Browse
- [ ] Work Card

.
- [x] Work Page
- [ ] Blog Page
- [ ] Collections
- [ ] Comments
- [ ] Other Pages

.
- [ ] Account Authentication
- [ ] Dashboard
- [ ] Mobile