### PR TITLE
Temporarily fixes going to another page of comments

### DIFF
--- a/libs/client/repository/src/lib/content-view/content-view.service.ts
+++ b/libs/client/repository/src/lib/content-view/content-view.service.ts
@@ -71,6 +71,11 @@ export class ContentViewService {
     }
 
     public fetchNextComments(contentId: string, page: number) {
+        // As a temporary solution, reloads the page; original code below
+        location.reload();
+
+        // Inexplicably, this.network.fetchComments() doesn't return any Observables
+        // Leaving intact to more easily follow the intended flow, but reload() makes the below pointless
         this.contentView.setLoading(true);
         return this.network.fetchComments(contentId, CommentKind.ContentComment, page).pipe(
             tap((value) => {


### PR DESCRIPTION
Addresses ticket #578

## Description
When you click to go to another page of comments, the loading icon appears and doesn't go away. Comments don't load. If you refresh, then comments load correctly.

## Changes
- Reloads the page when you go to another page of comments
- I can't figure out why the current code doesn't work

## Areas Affected
- [ ] Site Navigation
- [ ] Home
- [ ] Sign In/Out
- [ ] Registration
- [ ] Settings

.
- [ ] Profile
- [ ] My Stuff (main page)
- [ ] Editor
- [ ] Browse
- [ ] Work Card

.
- [ ] Work Page
- [ ] Blog Page
- [ ] Collections
- [x] Comments
- [ ] Other Pages

.
- [ ] Account Authentication
- [ ] Dashboard
- [ ] Mobile
