### PR TITLE
Displays a comment's post time in addition to date

### DIFF
--- a/libs/client/comments/src/lib/comment-box/comment-box.component.html
+++ b/libs/client/comments/src/lib/comment-box/comment-box.component.html
@@ -14,7 +14,7 @@
         <div class="comment-body">
             <div class="comment-metadata">
                 <dragonfish-role-badge [roles]="$any(comment.user).audit.roles" [isCentered]="false" [isStyled]="true"></dragonfish-role-badge>
-                <div class="timestamp">{{ comment.createdAt | localedate: 'fullDate' }}</div>
+                <div class="timestamp">{{ comment.createdAt | localedate: 'fullDate' }} {{ comment.createdAt | localedate: 'mediumTime' }}</div>
                 <ng-container *ngIf="!editMode">
                     <div class="tools" *ngIf="sessionQuery.currentUser$ | async as currentUser">
                         <ng-container *ngIf="currentUser._id">
@@ -56,7 +56,7 @@
                     </ng-template>
                 </div>
                 <dragonfish-role-badge [roles]="$any(comment.user).audit.roles" [isCentered]="false" [isStyled]="true"></dragonfish-role-badge>
-                <div class="timestamp">{{ comment.createdAt | localedate: 'fullDate' }}</div>
+                <div class="timestamp">{{ comment.createdAt | localedate: 'fullDate' }} {{ comment.createdAt | localedate: 'mediumTime' }}</div>
                 <ng-container *ngIf="!editMode">
                     <div class="tools" *ngIf="sessionQuery.currentUser$ | async as currentUser">
                         <ng-container *ngIf="currentUser._id">


### PR DESCRIPTION
Addresses ticket #602 

## Description
Comments currently display just the post date, and not the post time.

## Changes
Adds the post time after the post date in HTML.

## Areas Affected
- [ ] Site Navigation
- [ ] Home
- [ ] Sign In/Out
- [ ] Registration
- [ ] Settings

.
- [ ] Profile
- [ ] My Stuff (main page)
- [ ] Editor
- [ ] Browse
- [ ] Work Card

.
- [ ] Work Page
- [ ] Blog Page
- [ ] Collections
- [x] Comments
- [ ] Other Pages

.
- [ ] Account Authentication
- [ ] Dashboard
- [ ] Mobile
