### PR TITLE
Fixes news comments being cut off

### DIFF
--- a/apps/bettafish/src/app/pages/content-views/news-page/news-page.component.html
+++ b/apps/bettafish/src/app/pages/content-views/news-page/news-page.component.html
@@ -1,41 +1,41 @@
 <ng-container *ngIf="viewState.currContent$ | async as currPost">
-    <div class="sticky top-0 z-40">
-        <div class="news-post-nav shadow-lg relative z-40">
-            <div class="w-11/12 mx-auto py-4 flex flex-row items-center">
-                <button class="go-back border-none rounded-full shadow-none p-2.5" [routerLink]="['/news']">
-                    <rmx-icon name="arrow-left-s-line" class="text-white relative top-0.5 mr-4"></rmx-icon>
-                </button>
-                <div>
-                    <h3 class="text-4xl text-white relative top-1.5 font-semibold">
-                        {{ currPost.title }}
-                    </h3>
-                    <div class="flex flex-row items-center text-white uppercase text-sm">
-                        <span>
-                            by
-                            <a
-                                class="text-white underline"
-                                [routerLink]="['/portfolio', $any(currPost.author)._id, $any(currPost.author).username | slugify]">
-                                {{ $any(currPost.author).username }}
-                            </a>
-                        </span>
-                        <span class="mx-2">//</span>
-                        <span>{{ category[$any(currPost.meta).category] }}</span>
-                        <span class="mx-2">//</span>
-                        <span>{{ currPost.audit.publishedOn | localedate: 'fullDate' }}</span>
+    <ng-scrollbar>
+        <div class="sticky top-0 z-40">
+            <div class="news-post-nav shadow-lg relative z-40">
+                <div class="w-11/12 mx-auto py-4 flex flex-row items-center">
+                    <button class="go-back border-none rounded-full shadow-none p-2.5" [routerLink]="['/news']">
+                        <rmx-icon name="arrow-left-s-line" class="text-white relative top-0.5 mr-4"></rmx-icon>
+                    </button>
+                    <div>
+                        <h3 class="text-4xl text-white relative top-1.5 font-semibold">
+                            {{ currPost.title }}
+                        </h3>
+                        <div class="flex flex-row items-center text-white uppercase text-sm">
+                            <span>
+                                by
+                                <a
+                                    class="text-white underline"
+                                    [routerLink]="['/portfolio', $any(currPost.author)._id, $any(currPost.author).username | slugify]">
+                                    {{ $any(currPost.author).username }}
+                                </a>
+                            </span>
+                            <span class="mx-2">//</span>
+                            <span>{{ category[$any(currPost.meta).category] }}</span>
+                            <span class="mx-2">//</span>
+                            <span>{{ currPost.audit.publishedOn | localedate: 'fullDate' }}</span>
+                        </div>
                     </div>
+                    <div class="flex-1"><!--spacer--></div>
+                    <dragonfish-content-approval
+                        [content]="currPost"
+                        [currRating]="viewState.currRating"
+                        [ratingsDoc]="viewState.ratingsDoc$ | async"
+                        [likes]="viewState.likes"
+                        [dislikes]="viewState.dislikes"
+                    ></dragonfish-content-approval>
                 </div>
-                <div class="flex-1"><!--spacer--></div>
-                <dragonfish-content-approval
-                    [content]="currPost"
-                    [currRating]="viewState.currRating"
-                    [ratingsDoc]="viewState.ratingsDoc$ | async"
-                    [likes]="viewState.likes"
-                    [dislikes]="viewState.dislikes"
-                ></dragonfish-content-approval>
             </div>
         </div>
-    </div>
-    <ng-scrollbar>
         <div class="post-container w-6/12 mx-auto">
             <div class="blog-body" [innerHtml]="currPost.body | safeHtml"></div>
         </div>


### PR DESCRIPTION
## Description
Following up https://github.com/OffprintStudios/dragonfish/pull/620 , which fixed an issue where the bottom of many pages was being cut off on laptop, this also fixes news posts, which weren't addressed before.

The source of the issue is that the header pushes the bottom of the page past what can be scrolled to.

## Changes
Places the header within the ng-scrollbar field.

## Areas Affected
- [ ] Site Navigation
- [ ] Home
- [ ] Sign In/Out
- [ ] Registration
- [ ] Settings

.
- [ ] Profile
- [ ] My Stuff (main page)
- [ ] Editor
- [ ] Browse
- [ ] Work Card

.
- [ ] Work Page
- [ ] Blog Page
- [ ] Collections
- [x] Comments
- [x] Other Pages

.
- [ ] Account Authentication
- [ ] Dashboard
- [ ] Mobile
