### PR TITLE
Adds ability to scroll in any direction

### DIFF
--- a/apps/bettafish/src/app/app.module.ts
+++ b/apps/bettafish/src/app/app.module.ts
@@ -106,6 +106,7 @@ import { AuthInterceptor } from '@dragonfish/client/repository/session/services'
         DynamicViewModule,
         NgScrollbarModule.withConfig({
             appearance: 'standard',
+            track: 'all',
         }),
     ],
     providers: [

--- a/libs/client/dashboard/src/lib/dashboard.module.ts
+++ b/libs/client/dashboard/src/lib/dashboard.module.ts
@@ -66,6 +66,7 @@ import { ContentReportComponent, UserReportComponent, ReportItemComponent } from
         ReactiveFormsModule,
         NgScrollbarModule.withConfig({
             appearance: 'standard',
+            track: 'all',
         }),
     ],
 })

--- a/libs/client/my-stuff/src/lib/my-stuff.module.ts
+++ b/libs/client/my-stuff/src/lib/my-stuff.module.ts
@@ -74,6 +74,7 @@ import {
         EditorLiteModule,
         NgScrollbarModule.withConfig({
             appearance: 'standard',
+            track: 'all',
         }),
     ],
 })


### PR DESCRIPTION
Addresses ticket #625

## Description
Following the implementation of #620 , mobile use was broken by the fact that you can't scroll horizontally, and text wrapping doesn't work properly. This adds the ability to scroll in any direction, so that content can be accessed. However, I still intend to look into why text wrapping changed.

## Changes
Adds track: 'all' configuration to NgScrollbarModule uses.

## Areas Affected
- [ ] Site Navigation
- [x] Home
- [ ] Sign In/Out
- [ ] Registration
- [ ] Settings

.
- [x] Profile
- [x] My Stuff (main page)
- [x] Editor
- [x] Browse
- [ ] Work Card

.
- [x] Work Page
- [x] Blog Page
- [x] Collections
- [x] Comments
- [x] Other Pages

.
- [ ] Account Authentication
- [x] Dashboard
- [x] Mobile
