### PR TITLE
Fixes child tag creation by setting desc to '' instead of null by default

### DIFF
--- a/libs/client/dashboard/src/lib/components/tags-management/tag-form/tag-form.component.ts
+++ b/libs/client/dashboard/src/lib/components/tags-management/tag-form/tag-form.component.ts
@@ -41,8 +41,8 @@ export class TagFormComponent implements OnInit {
         } else {
             if (this.data.parentId) {
                 this.tagForm.setValue({
-                    name: null,
-                    desc: null,
+                    name: '',
+                    desc: '',
                     parent: this.data.parentId,
                 })
             }


### PR DESCRIPTION
## Description
On the Dashboard, adding a child tag fails because in that case, it sets the desc to null, causing a NullPointerException when submitting.

## Changes
Sets desc to be an empty string instead, matching its value when not creating a tag as a child.

## Areas Affected
- [ ] Site Navigation
- [ ] Home
- [ ] Sign In/Out
- [ ] Registration
- [ ] Settings

.
- [ ] Profile
- [ ] My Stuff (main page)
- [ ] Editor
- [ ] Browse
- [ ] Work Card

.
- [ ] Work Page
- [ ] Blog Page
- [ ] Collections
- [ ] Comments
- [ ] Other Pages

.
- [ ] Account Authentication
- [x] Dashboard
- [ ] Mobile
