### PR TITLE
Makes parent tag menu explicitly open up

### DIFF
--- a/libs/client/dashboard/src/lib/components/tags-management/tag-form/tag-form.component.html
+++ b/libs/client/dashboard/src/lib/components/tags-management/tag-form/tag-form.component.html
@@ -25,7 +25,7 @@
     <ng-container *ngIf="tagsQuery.all$ | async as tags">
         <div class="offprint-select">
             <label>Parent</label>
-            <ng-select class="custom" [formControlName]="'parent'" [searchable]="false" [placeholder]="'Select Tag'">
+            <ng-select class="custom" [formControlName]="'parent'" [searchable]="false" [placeholder]="'Select Tag'" dropdownPosition="top">
                 <ng-option [value]="NO_PARENT">
                     No Parent
                 </ng-option>


### PR DESCRIPTION
## Description
For most mods, the parent tag menu on the tag creation/editing modal opens down instead of up, making it hard to use.

## Changes
Has it explicitly open up.

## Areas Affected
- [ ] Site Navigation
- [ ] Home
- [ ] Sign In/Out
- [ ] Registration
- [ ] Settings

.
- [ ] Profile
- [ ] My Stuff (main page)
- [ ] Editor
- [ ] Browse
- [ ] Work Card

.
- [ ] Work Page
- [ ] Blog Page
- [ ] Collections
- [ ] Comments
- [ ] Other Pages

.
- [ ] Account Authentication
- [x] Dashboard
- [ ] Mobile
