### PR TITLE
Implements fandom tag pages and fixes Dashboard issues

### DIFF
--- a/apps/api/src/app/controllers/search/search.controller.ts
+++ b/apps/api/src/app/controllers/search/search.controller.ts
@@ -51,4 +51,14 @@ export class SearchController {
     ): Promise<PaginateResult<ContentModel>> {
         return await this.searchService.searchContent(query, pageNum, contentFilter);
     }
+
+    @ApiTags(DragonfishTags.Search)
+    @Get('get-fandom-tag-content')
+    async getFandomTagContent(
+        @Query('tagId') tagId: string,
+        @Query('pageNum') pageNum: number,
+        @Cookies('contentFilter') contentFilter: ContentFilter
+    ): Promise<PaginateResult<ContentModel>> {
+        return await this.searchService.searchFandomTagContent(tagId, pageNum, contentFilter);
+    }
 }

--- a/apps/api/src/app/controllers/search/search.controller.ts
+++ b/apps/api/src/app/controllers/search/search.controller.ts
@@ -53,12 +53,12 @@ export class SearchController {
     }
 
     @ApiTags(DragonfishTags.Search)
-    @Get('get-fandom-tag-content')
-    async getFandomTagContent(
+    @Get('get-content-by-fandom-tag')
+    async getContentByFandomTag(
         @Query('tagId') tagId: string,
         @Query('pageNum') pageNum: number,
         @Cookies('contentFilter') contentFilter: ContentFilter
     ): Promise<PaginateResult<ContentModel>> {
-        return await this.searchService.searchFandomTagContent(tagId, pageNum, contentFilter);
+        return await this.searchService.getContentByFandomTag(tagId, pageNum, contentFilter);
     }
 }

--- a/apps/api/src/app/services/search/search.service.ts
+++ b/apps/api/src/app/services/search/search.service.ts
@@ -12,19 +12,28 @@ import { ContentKind, ContentModel } from '@dragonfish/shared/models/content';
 
 @Injectable()
 export class SearchService implements ISearch {
+    INITIAL_PAGE = 1;
+    INITIAL_MAX_PER_PAGE = 6;
+    MAX_PER_PAGE = 15;
+
     constructor(private readonly usersStore: UsersStore, private readonly contentStore: BrowseStore) {}
 
     async fetchInitialResults(query: string, contentFilter: ContentFilter): Promise<InitialResults> {
         const parsedQuery = `"${sanitizeHtml(query)}"`;
 
         const [initialUsers, initialBlogs, initialContent] = await Promise.all([
-            this.usersStore.findRelatedUsers(parsedQuery, 1, 6),
-            this.contentStore.findRelatedContent(parsedQuery, [ContentKind.BlogContent], 1, 6, contentFilter),
+            this.usersStore.findRelatedUsers(parsedQuery, this.INITIAL_PAGE, this.INITIAL_MAX_PER_PAGE),
+            this.contentStore.findRelatedContent(parsedQuery,
+                [ContentKind.BlogContent],
+                this.INITIAL_PAGE,
+                this.INITIAL_MAX_PER_PAGE,
+                contentFilter
+            ),
             this.contentStore.findRelatedContent(
                 parsedQuery,
                 [ContentKind.PoetryContent, ContentKind.ProseContent],
-                1,
-                6,
+                this.INITIAL_PAGE,
+                this.INITIAL_MAX_PER_PAGE,
                 contentFilter
             ),
         ]);
@@ -39,7 +48,7 @@ export class SearchService implements ISearch {
 
     async searchUsers(query: string, pageNum: number): Promise<PaginateResult<User>> {
         const parsedQuery = `"${sanitizeHtml(query)}"`;
-        return await this.usersStore.findRelatedUsers(parsedQuery, pageNum, 15);
+        return await this.usersStore.findRelatedUsers(parsedQuery, pageNum, this.MAX_PER_PAGE);
     }
 
     async searchBlogs(
@@ -52,7 +61,7 @@ export class SearchService implements ISearch {
             parsedQuery,
             [ContentKind.BlogContent],
             pageNum,
-            15,
+            this.MAX_PER_PAGE,
             contentFilter
         );
     }
@@ -67,8 +76,22 @@ export class SearchService implements ISearch {
             parsedQuery,
             [ContentKind.PoetryContent, ContentKind.ProseContent],
             pageNum,
-            15,
+            this.MAX_PER_PAGE,
             contentFilter
         );
+    }
+
+    async searchFandomTagContent(
+        tagId: string,
+        pageNum: number,
+        contentFilter: ContentFilter
+    ): Promise<PaginateResult<ContentModel>> {
+        return await this.contentStore.findFandomTagContent(
+            tagId,
+            [ContentKind.PoetryContent, ContentKind.ProseContent],
+            pageNum,
+            this.MAX_PER_PAGE,
+            contentFilter
+        )
     }
 }

--- a/apps/api/src/app/services/search/search.service.ts
+++ b/apps/api/src/app/services/search/search.service.ts
@@ -12,9 +12,9 @@ import { ContentKind, ContentModel } from '@dragonfish/shared/models/content';
 
 @Injectable()
 export class SearchService implements ISearch {
-    INITIAL_PAGE = 1;
-    INITIAL_MAX_PER_PAGE = 6;
-    MAX_PER_PAGE = 15;
+    readonly INITIAL_PAGE = 1;
+    readonly INITIAL_MAX_PER_PAGE = 6;
+    readonly MAX_PER_PAGE = 15;
 
     constructor(private readonly usersStore: UsersStore, private readonly contentStore: BrowseStore) {}
 
@@ -81,12 +81,12 @@ export class SearchService implements ISearch {
         );
     }
 
-    async searchFandomTagContent(
+    async getContentByFandomTag(
         tagId: string,
         pageNum: number,
         contentFilter: ContentFilter
     ): Promise<PaginateResult<ContentModel>> {
-        return await this.contentStore.findFandomTagContent(
+        return await this.contentStore.getContentByFandomTag(
             tagId,
             [ContentKind.PoetryContent, ContentKind.ProseContent],
             pageNum,

--- a/apps/api/src/app/shared/search/search.interface.ts
+++ b/apps/api/src/app/shared/search/search.interface.ts
@@ -38,4 +38,12 @@ export interface ISearch {
      * @param contentFilter
      */
     searchContent(query: string, pageNum: number, contentFilter: ContentFilter): Promise<PaginateResult<ContentModel>>;
+
+    /**
+     * Finds content tagged with the given fandom tag.
+     * @param tagId Tag that searching for in content.
+     * @param pageNum The current results page
+     * @param contentFilter The content filter to apply to returned results.
+     */
+    searchFandomTagContent(tagId: string, pageNum: number, contentFilter: ContentFilter): Promise<PaginateResult<ContentModel>>;
 }

--- a/apps/api/src/app/shared/search/search.interface.ts
+++ b/apps/api/src/app/shared/search/search.interface.ts
@@ -45,5 +45,5 @@ export interface ISearch {
      * @param pageNum The current results page
      * @param contentFilter The content filter to apply to returned results.
      */
-    searchFandomTagContent(tagId: string, pageNum: number, contentFilter: ContentFilter): Promise<PaginateResult<ContentModel>>;
+    getContentByFandomTag(tagId: string, pageNum: number, contentFilter: ContentFilter): Promise<PaginateResult<ContentModel>>;
 }

--- a/apps/bettafish/src/app/app-routing.module.ts
+++ b/apps/bettafish/src/app/app-routing.module.ts
@@ -22,6 +22,7 @@ import { Resolvers } from './resolvers';
 /* Util */
 import { Roles } from '@dragonfish/shared/models/users';
 import { AuthGuard } from '@dragonfish/client/repository/session/services';
+import { TagRoutes } from './pages/tags';
 
 const routes: Routes = [
     ...HomeRoutes,
@@ -33,6 +34,7 @@ const routes: Routes = [
     ...ContentViewRoutes,
     ...SettingsRoutes,
     ...RegistrationRoutes,
+    ...TagRoutes,
     {
         path: 'my-stuff',
         canLoad: [AuthGuard],

--- a/apps/bettafish/src/app/app.module.ts
+++ b/apps/bettafish/src/app/app.module.ts
@@ -55,6 +55,7 @@ import { CommentsModule } from '@dragonfish/client/comments';
 /* Util */
 import { environment } from '../environments/environment';
 import { AuthInterceptor } from '@dragonfish/client/repository/session/services';
+import { TagPages } from './pages/tags';
 
 @NgModule({
     declarations: [
@@ -73,6 +74,7 @@ import { AuthInterceptor } from '@dragonfish/client/repository/session/services'
         ...ErrorPages,
         ...SettingsPages,
         ...RegistrationPages,
+        ...TagPages,
     ],
     imports: [
         BrowserModule,

--- a/apps/bettafish/src/app/components/content/content-box/content-box.component.html
+++ b/apps/bettafish/src/app/components/content/content-box/content-box.component.html
@@ -60,8 +60,17 @@
                             <div class="tag">{{ $any(content.currContent.meta).genres | separateGenres }}</div>
                         </div>
                         <ng-container *ngIf="content.currContent.tags !== null && content.currContent.tags.length > 0">
-                            <div class="flex flex-row items-center uppercase text-sm">
-                                <span class="tag tags">{{ content.currContent.tags | displayTags }}</span>
+                            <div class="content-tags flex flex-row items-center uppercase text-sm">
+                                <span class="tag tags">
+                                    <ng-container *ngFor="let tag of content.currContent.tags; let i = index">   
+                                        <a [routerLink]="['/tag']">
+                                            {{ tag | displayTags }}
+                                        </a>
+                                        <ng-container *ngIf="i < content.currContent.tags.length - 1">
+                                            , 
+                                        </ng-container>
+                                    </ng-container>
+                                </span>
                             </div>
                         </ng-container>
                     </div>

--- a/apps/bettafish/src/app/components/content/content-box/content-box.component.html
+++ b/apps/bettafish/src/app/components/content/content-box/content-box.component.html
@@ -62,7 +62,7 @@
                         <ng-container *ngIf="content.currContent.tags !== null && content.currContent.tags.length > 0">
                             <div class="content-tags flex flex-row items-center uppercase text-sm">
                                 <span class="tag tags">
-                                    <ng-container *ngFor="let tag of content.currContent.tags; let i = index">   
+                                    <ng-container *ngFor="let tag of content.currContent.tags; let i = index">
                                         <a [routerLink]="['/tag', tag._id, tag.name | slugify]">
                                             {{ tag | displayTags }}
                                         </a>

--- a/apps/bettafish/src/app/components/content/content-box/content-box.component.html
+++ b/apps/bettafish/src/app/components/content/content-box/content-box.component.html
@@ -61,7 +61,7 @@
                         </div>
                         <ng-container *ngIf="content.currContent.tags !== null && content.currContent.tags.length > 0">
                             <div class="flex flex-row items-center uppercase text-sm">
-                                <span class="tag tags">{{ content.currContent.tags | displayTags }}</span>
+                                <span class="tag tags" [innerHtml]="content.currContent.tags | displayTags | safeHtml"></span>
                             </div>
                         </ng-container>
                     </div>

--- a/apps/bettafish/src/app/components/content/content-box/content-box.component.html
+++ b/apps/bettafish/src/app/components/content/content-box/content-box.component.html
@@ -63,7 +63,7 @@
                             <div class="content-tags flex flex-row items-center uppercase text-sm">
                                 <span class="tag tags">
                                     <ng-container *ngFor="let tag of content.currContent.tags; let i = index">   
-                                        <a [routerLink]="['/tag']">
+                                        <a [routerLink]="['/tag', tag._id, tag.name | slugify]">
                                             {{ tag | displayTags }}
                                         </a>
                                         <ng-container *ngIf="i < content.currContent.tags.length - 1">

--- a/apps/bettafish/src/app/components/content/content-box/content-box.component.scss
+++ b/apps/bettafish/src/app/components/content/content-box/content-box.component.scss
@@ -37,4 +37,13 @@ div.content-box {
             }
         }
     }
+    div.content-tags {
+        a {
+            cursor: pointer;
+            color: whitesmoke;
+            &:hover {
+                background: var(--accent-dark);
+            }
+        }
+    }
 }

--- a/apps/bettafish/src/app/pages/content-views/news-page/news-page.component.ts
+++ b/apps/bettafish/src/app/pages/content-views/news-page/news-page.component.ts
@@ -26,7 +26,7 @@ export class NewsPageComponent implements OnInit {
     ) {}
 
     ngOnInit(): void {
-        combineLatest(this.viewState.currContent$, this.route.queryParamMap)
+        combineLatest([this.viewState.currContent$, this.route.queryParamMap])
             .pipe(untilDestroyed(this))
             .subscribe((x) => {
                 const [content, queryParams] = x;

--- a/apps/bettafish/src/app/pages/content-views/poetry-page/poetry-page.component.ts
+++ b/apps/bettafish/src/app/pages/content-views/poetry-page/poetry-page.component.ts
@@ -22,7 +22,7 @@ export class PoetryPageComponent implements OnInit {
     ) {}
 
     ngOnInit(): void {
-        combineLatest(this.viewQuery.currContent$, this.route.queryParamMap)
+        combineLatest([this.viewQuery.currContent$, this.route.queryParamMap])
             .pipe(untilDestroyed(this))
             .subscribe((value) => {
                 const [content, queryParams] = value;

--- a/apps/bettafish/src/app/pages/content-views/prose-page/prose-page.component.ts
+++ b/apps/bettafish/src/app/pages/content-views/prose-page/prose-page.component.ts
@@ -22,7 +22,7 @@ export class ProsePageComponent implements OnInit {
     ) {}
 
     ngOnInit(): void {
-        combineLatest(this.viewQuery.currContent$, this.route.queryParamMap)
+        combineLatest([this.viewQuery.currContent$, this.route.queryParamMap])
             .pipe(untilDestroyed(this))
             .subscribe((value) => {
                 const [content, queryParams] = value;

--- a/apps/bettafish/src/app/pages/portfolio/portfolio-blog/portfolio-blog-page/portfolio-blog-page.component.ts
+++ b/apps/bettafish/src/app/pages/portfolio/portfolio-blog/portfolio-blog-page/portfolio-blog-page.component.ts
@@ -24,7 +24,7 @@ export class PortfolioBlogPageComponent implements OnInit {
     ) {}
 
     ngOnInit(): void {
-        combineLatest(this.viewQuery.currContent$, this.route.queryParamMap)
+        combineLatest([this.viewQuery.currContent$, this.route.queryParamMap])
             .pipe(untilDestroyed(this))
             .subscribe((x) => {
                 const [content, queryParams] = x;

--- a/apps/bettafish/src/app/pages/portfolio/portfolio-collections/portfolio-collections.component.ts
+++ b/apps/bettafish/src/app/pages/portfolio/portfolio-collections/portfolio-collections.component.ts
@@ -29,7 +29,7 @@ export class PortfolioCollectionsComponent implements OnInit {
     ) {}
 
     ngOnInit(): void {
-        combineLatest(this.sessionQuery.currentUser$, this.route.queryParamMap)
+        combineLatest([this.sessionQuery.currentUser$, this.route.queryParamMap])
             .pipe(untilDestroyed(this))
             .subscribe(value => {
                 const [currUser, params] = value;

--- a/apps/bettafish/src/app/pages/tags/index.ts
+++ b/apps/bettafish/src/app/pages/tags/index.ts
@@ -1,0 +1,10 @@
+import { Routes } from '@angular/router';
+import { TagPageComponent } from './tag-page.component';
+
+export const TagPages = [
+    TagPageComponent
+];
+
+export const TagRoutes: Routes = [
+    { path: 'tag', component: TagPageComponent },
+];

--- a/apps/bettafish/src/app/pages/tags/index.ts
+++ b/apps/bettafish/src/app/pages/tags/index.ts
@@ -6,5 +6,5 @@ export const TagPages = [
 ];
 
 export const TagRoutes: Routes = [
-    { path: 'tag', component: TagPageComponent },
+    { path: 'tag/:tagId/:tagName', component: TagPageComponent },
 ];

--- a/apps/bettafish/src/app/pages/tags/tag-page.component.html
+++ b/apps/bettafish/src/app/pages/tags/tag-page.component.html
@@ -4,3 +4,46 @@
         <h3>{{ tagId }}</h3>
     </div>
 </dragonfish-topbar>
+
+<ng-container *ngIf="tagsQuery.loading$ | async else notLoading">
+    <div class="flex flex-row items-center justify-center h-72">
+        <mat-spinner></mat-spinner>
+    </div>
+</ng-container>
+
+<ng-template #notLoading>
+    <ng-container *ngIf="tagsQuery.all$ | async as tags">
+        <ng-container *ngIf="tags.length === 0; else notEmpty">
+            <div class="empty">
+                <h3>Looks like there something missing here...</h3>
+                <p>If you think this is an error, contact your system administrator.</p>
+            </div>
+        </ng-container>
+        <ng-template #notEmpty>
+            <div class="w-8/12 mx-auto my-8">
+                <mat-accordion>
+                    <ng-container *ngFor="let tag of tags">
+                        <mat-expansion-panel>
+                            <mat-expansion-panel-header>
+                                <mat-panel-title>
+                                    {{ tag.name }}
+                                </mat-panel-title>
+                                <mat-panel-description>
+                                    {{ tag.desc }}
+                                </mat-panel-description>
+                            </mat-expansion-panel-header>
+                            <div class="my-2"><!--spacer--></div>
+                            <ul>
+                                <ng-container *ngFor="let child of tag.children">
+                                    <li class="py-2 px-1 border-t" style="border-color: var(--borders);">
+                                        <dragonfish-child-tag-item [parentId]="tag._id" [tag]="child"></dragonfish-child-tag-item>
+                                    </li>
+                                </ng-container>
+                            </ul>
+                        </mat-expansion-panel>
+                    </ng-container>
+                </mat-accordion>
+            </div>
+        </ng-template>
+    </ng-container>
+</ng-template>

--- a/apps/bettafish/src/app/pages/tags/tag-page.component.html
+++ b/apps/bettafish/src/app/pages/tags/tag-page.component.html
@@ -21,28 +21,16 @@
         </ng-container>
         <ng-template #notEmpty>
             <div class="w-8/12 mx-auto my-8">
-                <mat-accordion>
-                    <ng-container *ngFor="let tag of tags">
-                        <mat-expansion-panel>
-                            <mat-expansion-panel-header>
-                                <mat-panel-title>
-                                    {{ tag.name }}
-                                </mat-panel-title>
-                                <mat-panel-description>
-                                    {{ tag.desc }}
-                                </mat-panel-description>
-                            </mat-expansion-panel-header>
-                            <div class="my-2"><!--spacer--></div>
-                            <ul>
-                                <ng-container *ngFor="let child of tag.children">
-                                    <li class="py-2 px-1 border-t" style="border-color: var(--borders);">
-                                        <dragonfish-child-tag-item [parentId]="tag._id" [tag]="child"></dragonfish-child-tag-item>
-                                    </li>
-                                </ng-container>
-                            </ul>
-                        </mat-expansion-panel>
+                <h3>
+                    <ng-container *ngIf="tags[0].parent">
+                        <a [routerLink]="['/tag', tags[0].parent._id, tags[0].parent.name | slugify]">
+                            {{ tags[0].parent.name }}
+                        </a>
+                        &nbsp;— 
                     </ng-container>
-                </mat-accordion>
+                    {{ tags[0].name }}
+                </h3>
+                <p>{{ tags[0].desc }}</p>
             </div>
         </ng-template>
     </ng-container>

--- a/apps/bettafish/src/app/pages/tags/tag-page.component.html
+++ b/apps/bettafish/src/app/pages/tags/tag-page.component.html
@@ -1,6 +1,6 @@
 <dragonfish-topbar>
     <div class="topbar-header">
         <rmx-icon name="compass-3-line"></rmx-icon>
-        <h3>Tags</h3>
+        <h3>{{ tagId }}</h3>
     </div>
 </dragonfish-topbar>

--- a/apps/bettafish/src/app/pages/tags/tag-page.component.html
+++ b/apps/bettafish/src/app/pages/tags/tag-page.component.html
@@ -1,40 +1,59 @@
-<dragonfish-topbar>
-    <div class="topbar-header">
-        <rmx-icon name="compass-3-line"></rmx-icon>
-        <h3>{{ tagId }}</h3>
-    </div>
-</dragonfish-topbar>
-
-<ng-container *ngIf="tagsQuery.loading$ | async else notLoading">
-    <div class="flex flex-row items-center justify-center h-72">
-        <mat-spinner></mat-spinner>
-    </div>
-</ng-container>
-
-<ng-template #notLoading>
-    <ng-container *ngIf="tagsQuery.all$ | async as tags">
-        <ng-container *ngIf="tags.length === 0; else notEmpty">
-            <div class="empty">
-                <h3>Looks like there something missing here...</h3>
-                <p>If you think this is an error, contact your system administrator.</p>
-            </div>
-        </ng-container>
-        <ng-template #notEmpty>
-            <div class="w-8/12 mx-auto my-8">
-                <h3>
-                    <ng-container *ngIf="tags[0].parent">
-                        <a
-                            [routerLink]="['/tag', tags[0].parent._id, tags[0].parent.name | slugify]"
-                            [innerHtml]="tags[0].parent.name | safeHtml"
-                        ></a>
-                        &nbsp;— 
-                    </ng-container>
-                    <span [innerHtml]="tags[0].name | safeHtml"></span>
-                </h3>
-                <p>
-                    <span [innerHtml]="tags[0].desc | safeHtml"></span>
-                </p>
-            </div>
-        </ng-template>
+<dragonfish-topbar></dragonfish-topbar>
+<ng-scrollbar>
+    <ng-container *ngIf="tagsQuery.loading$ | async else notLoading">
+        <div class="flex flex-row items-center justify-center h-72">
+            <mat-spinner></mat-spinner>
+        </div>
     </ng-container>
-</ng-template>
+
+    <ng-template #notLoading>
+        <ng-container *ngIf="tagsQuery.all$ | async as tags">
+            <ng-container *ngIf="tags.length === 0; else notEmpty">
+                <div class="empty">
+                    <h3>Looks like there something missing here...</h3>
+                    <p>If you think this is an error, contact your system administrator.</p>
+                </div>
+            </ng-container>
+            <ng-template #notEmpty>
+                <div class="w-11/12 mx-auto my-6">
+                    <h3>
+                        <ng-container *ngIf="tags[0].parent">
+                            <a
+                                [routerLink]="['/tag', tags[0].parent._id, tags[0].parent.name | slugify]"
+                                [innerHtml]="tags[0].parent.name | safeHtml"
+                            ></a>
+                            &nbsp;— 
+                        </ng-container>
+                        <span [innerHtml]="tags[0].name | safeHtml"></span>
+                    </h3>
+                    <ng-container *ngIf="tags[0].children && tags[0].children.length > 0">
+                        Child Tags: 
+                        <ng-container *ngFor="let child of tags[0].children; let i = index">
+                            <a
+                                [routerLink]="['/tag', child._id, child.name | slugify]"
+                                [innerHtml]="child.name | safeHtml"
+                            ></a>
+                            <ng-container *ngIf="i < tags[0].children.length - 1">
+                                , 
+                            </ng-container>
+                        </ng-container>
+                    </ng-container>
+                    <p>
+                        <span [innerHtml]="tags[0].desc | safeHtml"></span>
+                    </p>
+                    <ng-container *ngIf="searchResults && searchResults.totalDocs > 0; else noResults">
+                        <div class="grid grid-cols-3 gap-4">
+                                <ng-container *ngFor="let result of searchResults.docs | paginate: {itemsPerPage: searchResults.limit, currentPage: 1, totalItems: searchResults.totalDocs}">
+                                    <dragonfish-work-card [content]="result" [showAuthor]="false"></dragonfish-work-card>
+                                </ng-container>
+                        </div>
+                        <pagination-controls (pageChange)="onPageChange($event)" previousLabel="" nextLabel=""></pagination-controls>
+                    </ng-container>
+                    <ng-template #noResults>
+                        <p>There are no stories with this tag.</p>
+                    </ng-template>
+                </div>
+            </ng-template>
+        </ng-container>
+    </ng-template>
+</ng-scrollbar>

--- a/apps/bettafish/src/app/pages/tags/tag-page.component.html
+++ b/apps/bettafish/src/app/pages/tags/tag-page.component.html
@@ -1,5 +1,5 @@
-<dragonfish-topbar></dragonfish-topbar>
 <ng-scrollbar>
+    <dragonfish-topbar></dragonfish-topbar>
     <ng-container *ngIf="tagsQuery.loading$ | async else notLoading">
         <div class="flex flex-row items-center justify-center h-72">
             <mat-spinner></mat-spinner>
@@ -43,7 +43,7 @@
                     </p>
                     <div class="grid grid-cols-3 gap-4">
                         <ng-container *ngIf="searchResults">
-                            <ng-container *ngFor="let result of searchResults.docs | paginate: {itemsPerPage: searchResults.limit, currentPage: 1, totalItems: searchResults.totalDocs}">
+                            <ng-container *ngFor="let result of searchResults.docs | paginate: {itemsPerPage: searchResults.limit, currentPage: pageNum, totalItems: searchResults.totalDocs}">
                                 <dragonfish-work-card [content]="result" [showAuthor]="false"></dragonfish-work-card>
                             </ng-container>
                         </ng-container>

--- a/apps/bettafish/src/app/pages/tags/tag-page.component.html
+++ b/apps/bettafish/src/app/pages/tags/tag-page.component.html
@@ -41,18 +41,15 @@
                     <p>
                         <span [innerHtml]="tags[0].desc | safeHtml"></span>
                     </p>
-                    <ng-container *ngIf="searchResults && searchResults.totalDocs > 0; else noResults">
-                        <div class="grid grid-cols-3 gap-4">
-                                <ng-container *ngFor="let result of searchResults.docs | paginate: {itemsPerPage: searchResults.limit, currentPage: 1, totalItems: searchResults.totalDocs}">
-                                    <dragonfish-work-card [content]="result" [showAuthor]="false"></dragonfish-work-card>
-                                </ng-container>
-                        </div>
-                        <pagination-controls (pageChange)="onPageChange($event)" previousLabel="" nextLabel=""></pagination-controls>
-                    </ng-container>
-                    <ng-template #noResults>
-                        <p>There are no stories with this tag.</p>
-                    </ng-template>
+                    <div class="grid grid-cols-3 gap-4">
+                        <ng-container *ngIf="searchResults">
+                            <ng-container *ngFor="let result of searchResults.docs | paginate: {itemsPerPage: searchResults.limit, currentPage: 1, totalItems: searchResults.totalDocs}">
+                                <dragonfish-work-card [content]="result" [showAuthor]="false"></dragonfish-work-card>
+                            </ng-container>
+                        </ng-container>
+                    </div>
                 </div>
+                <pagination-controls (pageChange)="onPageChange($event)" previousLabel="" nextLabel=""></pagination-controls>
             </ng-template>
         </ng-container>
     </ng-template>

--- a/apps/bettafish/src/app/pages/tags/tag-page.component.html
+++ b/apps/bettafish/src/app/pages/tags/tag-page.component.html
@@ -23,14 +23,17 @@
             <div class="w-8/12 mx-auto my-8">
                 <h3>
                     <ng-container *ngIf="tags[0].parent">
-                        <a [routerLink]="['/tag', tags[0].parent._id, tags[0].parent.name | slugify]">
-                            {{ tags[0].parent.name }}
-                        </a>
+                        <a
+                            [routerLink]="['/tag', tags[0].parent._id, tags[0].parent.name | slugify]"
+                            [innerHtml]="tags[0].parent.name | safeHtml"
+                        ></a>
                         &nbsp;— 
                     </ng-container>
-                    {{ tags[0].name }}
+                    <span [innerHtml]="tags[0].name | safeHtml"></span>
                 </h3>
-                <p>{{ tags[0].desc }}</p>
+                <p>
+                    <span [innerHtml]="tags[0].desc | safeHtml"></span>
+                </p>
             </div>
         </ng-template>
     </ng-container>

--- a/apps/bettafish/src/app/pages/tags/tag-page.component.html
+++ b/apps/bettafish/src/app/pages/tags/tag-page.component.html
@@ -1,0 +1,6 @@
+<dragonfish-topbar>
+    <div class="topbar-header">
+        <rmx-icon name="compass-3-line"></rmx-icon>
+        <h3>Tags</h3>
+    </div>
+</dragonfish-topbar>

--- a/apps/bettafish/src/app/pages/tags/tag-page.component.ts
+++ b/apps/bettafish/src/app/pages/tags/tag-page.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit } from "@angular/core";
 import { ActivatedRoute } from "@angular/router";
 import { TagsQuery, TagsService } from "@dragonfish/client/repository/tags";
 import { setTwoPartTitle } from "@dragonfish/shared/constants";
+import { htmlDecode } from "@dragonfish/shared/functions";
 import { TagsModel } from "@dragonfish/shared/models/content";
 
 @Component({
@@ -23,10 +24,10 @@ export class TagPageComponent implements OnInit {
             this.tagId = params.get("tagId");
             this.tagsService.fetchDescendants(this.tagId).subscribe((tagsTree) => {
                 if (tagsTree.parent) {
-                    setTwoPartTitle((tagsTree.parent as TagsModel).name + " — " + tagsTree.name);
+                    setTwoPartTitle(htmlDecode((tagsTree.parent as TagsModel).name + " — " + tagsTree.name));
                 }
                 else {
-                    setTwoPartTitle(tagsTree.name);
+                    setTwoPartTitle(htmlDecode(tagsTree.name));
                 }
             });
         });

--- a/apps/bettafish/src/app/pages/tags/tag-page.component.ts
+++ b/apps/bettafish/src/app/pages/tags/tag-page.component.ts
@@ -6,7 +6,10 @@ import { setTwoPartTitle } from "@dragonfish/shared/constants";
 import { htmlDecode } from "@dragonfish/shared/functions";
 import { ContentModel, TagsModel } from "@dragonfish/shared/models/content";
 import { PaginateResult } from "@dragonfish/shared/models/util";
+import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
+import { combineLatest } from "rxjs";
 
+@UntilDestroy()
 @Component({
     selector: 'dragonfish-tag-page',
     templateUrl: './tag-page.component.html',
@@ -26,15 +29,16 @@ export class TagPageComponent implements OnInit {
     ) {}
 
     ngOnInit(): void {
-        this.route.paramMap.subscribe((params) => {
-            this.tagId = params.get("tagId");
-            console.log(params.keys);
-            //TODO: Not detecting page
-            if (params.has('page')) {
-                this.pageNum = +params.get('page');
-            }
-            this.fetchData(this.tagId, this.pageNum);
-        });
+        combineLatest([this.route.paramMap, this.route.queryParamMap])
+            .pipe(untilDestroyed(this))
+            .subscribe((value) => {
+                const [params, queryParams] = value;
+                this.tagId = params.get("tagId");
+                if (queryParams.has('page')) {
+                    this.pageNum = +params.get('page');
+                }
+                this.fetchData(this.tagId, this.pageNum);
+            });
     }
 
     private fetchData(tagId: string, pageNum: number): void {

--- a/apps/bettafish/src/app/pages/tags/tag-page.component.ts
+++ b/apps/bettafish/src/app/pages/tags/tag-page.component.ts
@@ -1,9 +1,11 @@
 import { Component, OnInit } from "@angular/core";
-import { ActivatedRoute } from "@angular/router";
+import { ActivatedRoute, Router } from "@angular/router";
 import { TagsQuery, TagsService } from "@dragonfish/client/repository/tags";
+import { DragonfishNetworkService } from "@dragonfish/client/services";
 import { setTwoPartTitle } from "@dragonfish/shared/constants";
 import { htmlDecode } from "@dragonfish/shared/functions";
-import { TagsModel } from "@dragonfish/shared/models/content";
+import { ContentModel, TagsModel } from "@dragonfish/shared/models/content";
+import { PaginateResult } from "@dragonfish/shared/models/util";
 
 @Component({
     selector: 'dragonfish-tag-page',
@@ -12,24 +14,56 @@ import { TagsModel } from "@dragonfish/shared/models/content";
 export class TagPageComponent implements OnInit {
     tagId = "";
     tagName = "";
+    pageNum = 1;
+    searchResults: PaginateResult<ContentModel>;
 
     constructor(
         public route: ActivatedRoute,
+        private router: Router,
         public tagsQuery: TagsQuery,
         private tagsService: TagsService,
+        private network: DragonfishNetworkService,
     ) {}
 
     ngOnInit(): void {
         this.route.paramMap.subscribe((params) => {
             this.tagId = params.get("tagId");
-            this.tagsService.fetchDescendants(this.tagId).subscribe((tagsTree) => {
-                if (tagsTree.parent) {
-                    setTwoPartTitle(htmlDecode((tagsTree.parent as TagsModel).name + " — " + tagsTree.name));
-                }
-                else {
-                    setTwoPartTitle(htmlDecode(tagsTree.name));
-                }
-            });
+            console.log(params.keys);
+            //TODO: Not detecting page
+            if (params.has('page')) {
+                this.pageNum = +params.get('page');
+            }
+            this.fetchData(this.tagId, this.pageNum);
         });
+    }
+
+    private fetchData(tagId: string, pageNum: number): void {
+        this.tagsService.fetchDescendants(tagId).subscribe((tagsTree) => {
+            if (tagsTree.parent) {
+                setTwoPartTitle(htmlDecode((tagsTree.parent as TagsModel).name + " — " + tagsTree.name));
+            }
+            else {
+                setTwoPartTitle(htmlDecode(tagsTree.name));
+            }
+        });
+        this.network.searchFandomTagContent(tagId, pageNum).subscribe((results) => {
+            this.searchResults = results;
+        })
+    }
+
+    /**
+     * Handles page changing
+     *
+     * @param event The new page
+     */
+     onPageChange(event: number) {
+        this.router.navigate([], {
+            relativeTo: this.route,
+            queryParams: { page: event },
+            queryParamsHandling: 'merge',
+        }).then(() => {
+            this.fetchData(this.tagId, event);
+        });
+        this.pageNum = event;
     }
 }

--- a/apps/bettafish/src/app/pages/tags/tag-page.component.ts
+++ b/apps/bettafish/src/app/pages/tags/tag-page.component.ts
@@ -50,7 +50,7 @@ export class TagPageComponent implements OnInit {
                 setTwoPartTitle(htmlDecode(tagsTree.name));
             }
         });
-        this.network.searchFandomTagContent(tagId, pageNum).subscribe((results) => {
+        this.network.getContentByFandomTag(tagId, pageNum).subscribe((results) => {
             this.searchResults = results;
         })
     }

--- a/apps/bettafish/src/app/pages/tags/tag-page.component.ts
+++ b/apps/bettafish/src/app/pages/tags/tag-page.component.ts
@@ -19,6 +19,7 @@ export class TagPageComponent implements OnInit {
     ngOnInit(): void {
         this.route.paramMap.subscribe((params) => {
             this.tagId = params.get("tagId");
+            this.tagsService.fetchDescendants(this.tagId).subscribe();
         });
     }
 }

--- a/apps/bettafish/src/app/pages/tags/tag-page.component.ts
+++ b/apps/bettafish/src/app/pages/tags/tag-page.component.ts
@@ -1,6 +1,8 @@
 import { Component, OnInit } from "@angular/core";
 import { ActivatedRoute } from "@angular/router";
 import { TagsQuery, TagsService } from "@dragonfish/client/repository/tags";
+import { setTwoPartTitle } from "@dragonfish/shared/constants";
+import { TagsModel } from "@dragonfish/shared/models/content";
 
 @Component({
     selector: 'dragonfish-tag-page',
@@ -19,7 +21,14 @@ export class TagPageComponent implements OnInit {
     ngOnInit(): void {
         this.route.paramMap.subscribe((params) => {
             this.tagId = params.get("tagId");
-            this.tagsService.fetchDescendants(this.tagId).subscribe();
+            this.tagsService.fetchDescendants(this.tagId).subscribe((tagsTree) => {
+                if (tagsTree.parent) {
+                    setTwoPartTitle((tagsTree.parent as TagsModel).name + " — " + tagsTree.name);
+                }
+                else {
+                    setTwoPartTitle(tagsTree.name);
+                }
+            });
         });
     }
 }

--- a/apps/bettafish/src/app/pages/tags/tag-page.component.ts
+++ b/apps/bettafish/src/app/pages/tags/tag-page.component.ts
@@ -1,0 +1,10 @@
+import { Component, OnInit } from "@angular/core";
+
+@Component({
+    selector: 'dragonfish-tag-page',
+    templateUrl: './tag-page.component.html',
+})
+export class TagPageComponent implements OnInit {
+    ngOnInit(): void {
+    }
+}

--- a/apps/bettafish/src/app/pages/tags/tag-page.component.ts
+++ b/apps/bettafish/src/app/pages/tags/tag-page.component.ts
@@ -1,10 +1,24 @@
 import { Component, OnInit } from "@angular/core";
+import { ActivatedRoute } from "@angular/router";
+import { TagsQuery, TagsService } from "@dragonfish/client/repository/tags";
 
 @Component({
     selector: 'dragonfish-tag-page',
     templateUrl: './tag-page.component.html',
 })
 export class TagPageComponent implements OnInit {
+    tagId = "";
+    tagName = "";
+
+    constructor(
+        public route: ActivatedRoute,
+        public tagsQuery: TagsQuery,
+        private tagsService: TagsService,
+    ) {}
+
     ngOnInit(): void {
+        this.route.paramMap.subscribe((params) => {
+            this.tagId = params.get("tagId");
+        });
     }
 }

--- a/apps/bettafish/src/app/pages/tags/tag-page.component.ts
+++ b/apps/bettafish/src/app/pages/tags/tag-page.component.ts
@@ -33,23 +33,29 @@ export class TagPageComponent implements OnInit {
             .pipe(untilDestroyed(this))
             .subscribe((value) => {
                 const [params, queryParams] = value;
-                this.tagId = params.get("tagId");
                 if (queryParams.has('page')) {
-                    this.pageNum = +params.get('page');
+                    this.pageNum = +queryParams.get('page');
                 }
-                this.fetchData(this.tagId, this.pageNum);
+                else {
+                    this.pageNum = 1;
+                }
+                this.fetchData(params.get("tagId"), this.pageNum);
             });
     }
 
     private fetchData(tagId: string, pageNum: number): void {
-        this.tagsService.fetchDescendants(tagId).subscribe((tagsTree) => {
-            if (tagsTree.parent) {
-                setTwoPartTitle(htmlDecode((tagsTree.parent as TagsModel).name + " — " + tagsTree.name));
-            }
-            else {
-                setTwoPartTitle(htmlDecode(tagsTree.name));
-            }
-        });
+        if (this.tagId != tagId) {
+            this.tagId = tagId;
+            this.tagsService.fetchDescendants(tagId).subscribe((tagsTree) => {
+                if (tagsTree.parent) {
+                    setTwoPartTitle(htmlDecode((tagsTree.parent as TagsModel).name + " — " + tagsTree.name));
+                }
+                else {
+                    setTwoPartTitle(htmlDecode(tagsTree.name));
+                }
+            });
+        }
+        
         this.network.getContentByFandomTag(tagId, pageNum).subscribe((results) => {
             this.searchResults = results;
         })

--- a/apps/bettafish/src/material.scss
+++ b/apps/bettafish/src/material.scss
@@ -86,35 +86,6 @@ button.mat-menu-item {
     border: 1px solid var(--borders) !important;
 }
 
-.mat-expansion-panel-header-description, .mat-expansion-indicator {
-    position: relative !important;
-    top: -0.25rem;
-    &::after {
-        color: var(--text-color) !important;
-        font-size: 0.875rem !important;
-    }
-}
-
-.mat-expansion-panel-header {
-    font-family: 'Inter', sans-serif !important;
-    font-size: 1rem !important;
-    border-radius: 0.375rem !important;
-}
-
-.mat-expansion-panel-header-title {
-    color: var(--accent) !important;
-    font-family: 'Josefin Sans', sans-serif !important;
-    font-size: 1.15rem !important;
-    font-weight: 500 !important;
-}
-
-/* Mat Expansion Panel */
-.mat-expansion-panel {
-    background: var(--background) !important;
-    color: var(--text-color) !important;
-    border: 1px solid var(--borders) !important;
-}
-
 .mat-expansion-panel-header-description, .mat-expansion-indicator::after {
     color: var(--text-color) !important;
     font-size: 0.875rem !important;

--- a/libs/api/database/src/lib/content/schemas/content.schema.ts
+++ b/libs/api/database/src/lib/content/schemas/content.schema.ts
@@ -79,7 +79,7 @@ export class ContentDocument extends Document implements ContentModel {
             select: '_id name desc parent kind createdAt updatedAt',
         },
     }] })
-    tags?: TagsModel[];
+    tags?: string[] | TagsModel[];
 
     @Prop()
     readonly createdAt: Date;

--- a/libs/api/database/src/lib/content/stores/browse.store.ts
+++ b/libs/api/database/src/lib/content/stores/browse.store.ts
@@ -212,7 +212,7 @@ export class BrowseStore {
      * @param filter The content filter to apply to returned results.
      * @returns 
      */
-    public async findFandomTagContent(
+    public async getContentByFandomTag(
         tagId: string,
         kinds: ContentKind[],
         pageNum: number,
@@ -220,6 +220,7 @@ export class BrowseStore {
         filter: ContentFilter,
     ): Promise<PaginateResult<ContentDocument>> {
         const paginateOptions: PaginateOptions = {
+            sort: { 'audit.publishedOn': -1 },
             page: pageNum,
             limit: maxPerPage,
         };

--- a/libs/api/database/src/lib/content/stores/browse.store.ts
+++ b/libs/api/database/src/lib/content/stores/browse.store.ts
@@ -175,7 +175,7 @@ export class BrowseStore {
     //#region ---SEARCH---
 
     /**
-     * Finds content related to the the user's query.
+     * Finds content related to the user's query.
      * @param query The string the user searched for.
      * @param kinds The kind of document to fetch.
      * @param pageNum The page of results to retrieve.
@@ -198,6 +198,36 @@ export class BrowseStore {
             'audit.published': PubStatus.Published,
             'audit.isDeleted': false,
             kind: { $in: kinds },
+        };
+        await BrowseStore.determineContentFilter(paginateQuery, filter);
+        return await this.content.paginate(paginateQuery, paginateOptions);
+    }
+
+    /**
+     * Finds content tagged with the given fandom tag.
+     * @param tagId Tag that searching for in content.
+     * @param kinds The kind of document to fetch.
+     * @param pageNum The page of results to retrieve.
+     * @param maxPerPage The maximum number of results per page.
+     * @param filter The content filter to apply to returned results.
+     * @returns 
+     */
+    public async findFandomTagContent(
+        tagId: string,
+        kinds: ContentKind[],
+        pageNum: number,
+        maxPerPage: number,
+        filter: ContentFilter,
+    ): Promise<PaginateResult<ContentDocument>> {
+        const paginateOptions: PaginateOptions = {
+            page: pageNum,
+            limit: maxPerPage,
+        };
+        const paginateQuery = {
+            'audit.published': PubStatus.Published,
+            'audit.isDeleted': false,
+            kind: { $in: kinds },
+            tags: tagId,
         };
         await BrowseStore.determineContentFilter(paginateQuery, filter);
         return await this.content.paginate(paginateQuery, paginateOptions);

--- a/libs/client/dashboard/src/lib/components/tags-management/child-tag-item/child-tag-item.component.html
+++ b/libs/client/dashboard/src/lib/components/tags-management/child-tag-item/child-tag-item.component.html
@@ -3,7 +3,11 @@
         class="text-lg font-medium"
         style="font-family: 'Josefin Sans', sans-serif; color: var(--accent);"
     >
-        <div class="tag-name" [innerHtml]="tag.name | safeHtml"></div>
+        <a
+            class="tag-name"
+            [routerLink]="['/tag', tag._id, tag.name | slugify]"
+            [innerHtml]="tag.name | safeHtml"
+        ></a>
     </div>
     <div class="flex-1 text-center mx-2 relative -top-0.5">
         <div class="tag-desc" [innerHtml]="tag.desc | safeHtml"></div>

--- a/libs/client/dashboard/src/lib/components/tags-management/child-tag-item/child-tag-item.component.html
+++ b/libs/client/dashboard/src/lib/components/tags-management/child-tag-item/child-tag-item.component.html
@@ -3,10 +3,10 @@
         class="text-lg font-medium"
         style="font-family: 'Josefin Sans', sans-serif; color: var(--accent);"
     >
-        {{ tag.name }}
+        <div class="tag-name" [innerHtml]="tag.name | safeHtml"></div>
     </div>
     <div class="flex-1 text-center mx-2 relative -top-0.5">
-        {{ tag.desc }}
+        <div class="tag-desc" [innerHtml]="tag.desc | safeHtml"></div>
     </div>
     <button class="py-1.5 px-2.5 rounded-full border-none shadow-none" (click)="editTag()">
         <i-feather name="edit-3" class="mr-0"></i-feather>

--- a/libs/client/dashboard/src/lib/components/tags-management/tag-form/tag-form.component.html
+++ b/libs/client/dashboard/src/lib/components/tags-management/tag-form/tag-form.component.html
@@ -30,7 +30,7 @@
                     No Parent
                 </ng-option>
                 <ng-option *ngFor="let tag of tags" [value]="tag._id">
-                    <div class="tag-name" [innerHtml]="tag.name | safeHtml"></div>
+                    <span class="tag-name" [innerHtml]="tag.name | safeHtml"></span>
                 </ng-option>
             </ng-select>
         </div>

--- a/libs/client/dashboard/src/lib/components/tags-management/tag-form/tag-form.component.html
+++ b/libs/client/dashboard/src/lib/components/tags-management/tag-form/tag-form.component.html
@@ -30,7 +30,7 @@
                     No Parent
                 </ng-option>
                 <ng-option *ngFor="let tag of tags" [value]="tag._id">
-                    {{ tag.name }}
+                    <div class="tag-name" [innerHtml]="tag.name | safeHtml"></div>
                 </ng-option>
             </ng-select>
         </div>

--- a/libs/client/dashboard/src/lib/components/tags-management/tag-form/tag-form.component.ts
+++ b/libs/client/dashboard/src/lib/components/tags-management/tag-form/tag-form.component.ts
@@ -4,6 +4,7 @@ import { TagsQuery, TagsService } from '@dragonfish/client/repository/tags';
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { TagKind, TagsForm, TagsModel } from '@dragonfish/shared/models/content/tags';
 import { AlertsService } from '@dragonfish/client/alerts';
+import { htmlDecode } from '@dragonfish/shared/functions';
 
 @Component({
     selector: 'dragonfish-tag-form',
@@ -32,8 +33,8 @@ export class TagFormComponent implements OnInit {
     ngOnInit(): void {
         if (this.data.tag) {
             this.tagForm.setValue({
-                name: this.htmlDecode(this.data.tag.name),
-                desc: this.htmlDecode(this.data.tag.desc),
+                name: htmlDecode(this.data.tag.name),
+                desc: htmlDecode(this.data.tag.desc),
                 parent: (this.data.tag.parent || this.NO_PARENT),
             });
             this.editMode = true;
@@ -81,10 +82,5 @@ export class TagFormComponent implements OnInit {
                 this.dialogRef.close();
             });
         }
-    }
-
-    htmlDecode(input: string) {
-        var doc = new DOMParser().parseFromString(input, "text/html");
-        return doc.documentElement.textContent;
     }
 }

--- a/libs/client/dashboard/src/lib/components/tags-management/tag-form/tag-form.component.ts
+++ b/libs/client/dashboard/src/lib/components/tags-management/tag-form/tag-form.component.ts
@@ -32,8 +32,8 @@ export class TagFormComponent implements OnInit {
     ngOnInit(): void {
         if (this.data.tag) {
             this.tagForm.setValue({
-                name: this.data.tag.name,
-                desc: this.data.tag.desc,
+                name: this.htmlDecode(this.data.tag.name),
+                desc: this.htmlDecode(this.data.tag.desc),
                 parent: (this.data.tag.parent || this.NO_PARENT),
             });
             this.editMode = true;
@@ -81,5 +81,10 @@ export class TagFormComponent implements OnInit {
                 this.dialogRef.close();
             });
         }
+    }
+
+    htmlDecode(input: string) {
+        var doc = new DOMParser().parseFromString(input, "text/html");
+        return doc.documentElement.textContent;
     }
 }

--- a/libs/client/dashboard/src/lib/pages/tags-management/tags-management.component.html
+++ b/libs/client/dashboard/src/lib/pages/tags-management/tags-management.component.html
@@ -28,7 +28,11 @@
                         <mat-expansion-panel [expanded]="(tag._id === openPanelId)? true : false" (opened)="onOpen(tag._id)">
                             <mat-expansion-panel-header>
                                 <mat-panel-title>
-                                    <div class="tag-name" [innerHtml]="tag.name | safeHtml"></div>
+                                    <a
+                                        class="tag-name"
+                                        [routerLink]="['/tag', tag._id, tag.name | slugify]"
+                                        [innerHtml]="tag.name | safeHtml"
+                                    ></a>
                                 </mat-panel-title>
                             </mat-expansion-panel-header>
                             <div class="tag-desc" [innerHtml]="tag.desc | safeHtml"></div>

--- a/libs/client/dashboard/src/lib/pages/tags-management/tags-management.component.html
+++ b/libs/client/dashboard/src/lib/pages/tags-management/tags-management.component.html
@@ -28,12 +28,13 @@
                         <mat-expansion-panel>
                             <mat-expansion-panel-header>
                                 <mat-panel-title>
-                                    {{ tag.name }}
+                                    <div class="tag-name" [innerHtml]="tag.name | safeHtml"></div>
                                 </mat-panel-title>
-                                <mat-panel-description>
-                                    {{ tag.desc }}
-                                </mat-panel-description>
+                                <!-- <mat-panel-description>
+                                    <div class="tag-desc" [innerHtml]="tag.desc | safeHtml"></div>
+                                </mat-panel-description> -->
                             </mat-expansion-panel-header>
+                            <div class="tag-desc" [innerHtml]="tag.desc | safeHtml"></div>
                             <div class="flex flex-row items-center">
                                 <button (click)="addChild(tag._id)"><i-feather name="plus"></i-feather>Child</button>
                                 <div class="mx-1"><!--spacer--></div>

--- a/libs/client/dashboard/src/lib/pages/tags-management/tags-management.component.html
+++ b/libs/client/dashboard/src/lib/pages/tags-management/tags-management.component.html
@@ -25,14 +25,11 @@
             <div class="w-8/12 mx-auto my-8">
                 <mat-accordion>
                     <ng-container *ngFor="let tag of tags">
-                        <mat-expansion-panel>
+                        <mat-expansion-panel [expanded]="(tag._id === openPanelId)? true : false" (opened)="onOpen(tag._id)">
                             <mat-expansion-panel-header>
                                 <mat-panel-title>
                                     <div class="tag-name" [innerHtml]="tag.name | safeHtml"></div>
                                 </mat-panel-title>
-                                <!-- <mat-panel-description>
-                                    <div class="tag-desc" [innerHtml]="tag.desc | safeHtml"></div>
-                                </mat-panel-description> -->
                             </mat-expansion-panel-header>
                             <div class="tag-desc" [innerHtml]="tag.desc | safeHtml"></div>
                             <div class="flex flex-row items-center">

--- a/libs/client/dashboard/src/lib/pages/tags-management/tags-management.component.ts
+++ b/libs/client/dashboard/src/lib/pages/tags-management/tags-management.component.ts
@@ -12,6 +12,8 @@ import { PopupComponent } from '@dragonfish/client/ui';
     styleUrls: ['./tags-management.component.scss'],
 })
 export class TagsManagementComponent implements OnInit {
+    openPanelId: string;
+
     constructor(
         public tagsQuery: TagsQuery,
         private tagsService: TagsService,
@@ -24,6 +26,10 @@ export class TagsManagementComponent implements OnInit {
 
     createTag() {
         this.dialog.open(TagFormComponent);
+    }
+
+    onOpen(id: string) {
+        this.openPanelId = id;
     }
 
     addChild(parentId: string) {

--- a/libs/client/my-stuff/src/lib/components/content-preview/content-preview.component.html
+++ b/libs/client/my-stuff/src/lib/components/content-preview/content-preview.component.html
@@ -83,8 +83,17 @@
                     </button>
                 </div>
                 <ng-container *ngIf="currContent.tags !== null && currContent.tags.length > 0">
-                    <div class="flex flex-row items-center pb-1">
-                        <span class="tag tags">{{ currContent.tags | displayTags }}</span>
+                    <div class="content-tags flex flex-row items-center uppercase text-sm">
+                        <span class="tag tags">
+                            <ng-container *ngFor="let tag of currContent.tags; let i = index">   
+                                <a [routerLink]="['/tag']">
+                                    {{ tag | displayTags }}
+                                </a>
+                                <ng-container *ngIf="i < currContent.tags.length - 1">
+                                    , 
+                                </ng-container>
+                            </ng-container>
+                        </span>
                     </div>
                 </ng-container>
             </div>

--- a/libs/client/my-stuff/src/lib/components/content-preview/content-preview.component.html
+++ b/libs/client/my-stuff/src/lib/components/content-preview/content-preview.component.html
@@ -84,7 +84,7 @@
                 </div>
                 <ng-container *ngIf="currContent.tags !== null && currContent.tags.length > 0">
                     <div class="flex flex-row items-center pb-1">
-                        <span class="tag tags">{{ currContent.tags | displayTags }}</span>
+                        <span class="tag tags" [innerHtml]="currContent.tags | displayTags | safeHtml"></span>
                     </div>
                 </ng-container>
             </div>

--- a/libs/client/my-stuff/src/lib/components/content-preview/content-preview.component.html
+++ b/libs/client/my-stuff/src/lib/components/content-preview/content-preview.component.html
@@ -86,7 +86,7 @@
                     <div class="content-tags flex flex-row items-center uppercase text-sm">
                         <span class="tag tags">
                             <ng-container *ngFor="let tag of currContent.tags; let i = index">   
-                                <a [routerLink]="['/tag']">
+                                <a [routerLink]="['/tag', tag._id, tag.name | slugify]">
                                     {{ tag | displayTags }}
                                 </a>
                                 <ng-container *ngIf="i < currContent.tags.length - 1">

--- a/libs/client/my-stuff/src/lib/components/content-preview/content-preview.component.scss
+++ b/libs/client/my-stuff/src/lib/components/content-preview/content-preview.component.scss
@@ -56,6 +56,15 @@ div.content-box {
             }
         }
     }
+    div.content-tags {
+        a {
+            cursor: pointer;
+            color: whitesmoke;
+            &:hover {
+                background: var(--accent-dark);
+            }
+        }
+    }
     div.edit-cover-art {
         position: relative;
         cursor: pointer;

--- a/libs/client/my-stuff/src/lib/views/prose-form/prose-form.component.html
+++ b/libs/client/my-stuff/src/lib/views/prose-form/prose-form.component.html
@@ -62,11 +62,11 @@
                             <ng-select class="custom" [formControlName]="'tags'" [searchable]="true" [multiple]="true" dropdownPosition="bottom" [placeholder]="'Select Tag(s)'">
                                 <div *ngFor="let tag of tags">
                                     <ng-option [value]="tag._id">
-                                        {{ tag.name }}
+                                        <span class="tag-name" [innerHtml]="tag.name | safeHtml"></span>
                                     </ng-option>
                                     <div *ngFor="let child of tag.children">
                                         <ng-option [value]="child._id">
-                                            {{ tag.name }} — {{ child.name }}
+                                            <span class="parent-name" [innerHtml]="tag.name | safeHtml"></span>  —  <span class="tag-name" [innerHtml]="child.name | safeHtml"></span>
                                         </ng-option>
                                     </div>
                                 </div>

--- a/libs/client/repository/src/lib/tags/tags.service.ts
+++ b/libs/client/repository/src/lib/tags/tags.service.ts
@@ -36,7 +36,9 @@ export class TagsService {
 
     public fetchDescendants(id: string): Observable<TagsTree> {
         return this.network.fetchDescendants(id).pipe(
-            tap(() => {}),
+            tap((tagTree) => {
+                this.tagsStore.set([tagTree]);
+            }),
             catchError(err => {
                 this.alerts.error(err.error.message);
                 return throwError(() => err);

--- a/libs/client/services/src/lib/dragonfish-network.service.ts
+++ b/libs/client/services/src/lib/dragonfish-network.service.ts
@@ -308,10 +308,10 @@ export class DragonfishNetworkService {
         );
     }
 
-    public searchFandomTagContent(tagId: string, pageNum: number): Observable<PaginateResult<ContentModel>> {
+    public getContentByFandomTag(tagId: string, pageNum: number): Observable<PaginateResult<ContentModel>> {
         return handleResponse(
             this.http.get<PaginateResult<ContentModel>>(
-                `${this.baseUrl}/search/get-fandom-tag-content?tagId=${tagId}&pageNum=${pageNum}`,
+                `${this.baseUrl}/search/get-content-by-fandom-tag?tagId=${tagId}&pageNum=${pageNum}`,
                 { observe: 'response', withCredentials: true },
             ),
         );

--- a/libs/client/services/src/lib/dragonfish-network.service.ts
+++ b/libs/client/services/src/lib/dragonfish-network.service.ts
@@ -308,6 +308,15 @@ export class DragonfishNetworkService {
         );
     }
 
+    public searchFandomTagContent(tagId: string, pageNum: number): Observable<PaginateResult<ContentModel>> {
+        return handleResponse(
+            this.http.get<PaginateResult<ContentModel>>(
+                `${this.baseUrl}/search/get-fandom-tag-content?tagId=${tagId}&pageNum=${pageNum}`,
+                { observe: 'response', withCredentials: true },
+            ),
+        );
+    }
+
     //#endregion
 
     //#region ---CASE FILES---

--- a/libs/client/ui/src/lib/components/work-card/work-card.component.html
+++ b/libs/client/ui/src/lib/components/work-card/work-card.component.html
@@ -50,13 +50,11 @@
                 <ng-template #multipleTags>
                     <ng-container *ngIf="showAllTags; else showOneTag">
                         <span class="tag tags">
-                            <ng-container *ngFor="let tag of content.tags; let i = index">   
+                            <ng-container *ngFor="let tag of content.tags; let i = index">
                                 <a
                                    [routerLink]="['/tag', tag._id, tag.name | slugify]"
                                    [innerHtml]="tag | displayTags | safeHtml"
-                                >
-                                    {{ tag | displayTags }}
-                                </a>
+                                ></a>
                                 <ng-container *ngIf="i < content.tags.length - 1">
                                     , 
                                 </ng-container>

--- a/libs/client/ui/src/lib/components/work-card/work-card.component.html
+++ b/libs/client/ui/src/lib/components/work-card/work-card.component.html
@@ -40,15 +40,15 @@
         <ng-container *ngIf="content.tags !== null && content.tags.length > 0">
             <div class="card-tags flex flex-row items-center">
                 <ng-container *ngIf="content.tags.length === 1; else multipleTags">
-                    <span class="tag tags">{{ content.tags[0] | displayTags }}</span>
+                    <span class="tag tags" [innerHtml]="content.tags[0] | displayTags | safeHtml"></span>
                 </ng-container>
                 <ng-template #multipleTags>
                     <ng-container *ngIf="showAllTags; else showOneTag">
-                        <span class="tag tags">{{ content.tags | displayTags }}</span>
+                        <span class="tag tags" [innerHtml]="content.tags | displayTags | safeHtml"></span>
                         <rmx-icon name="arrow-up-s-line" (click)="toggleShowAllTags()"></rmx-icon>
                     </ng-container>
                     <ng-template #showOneTag>
-                        <span class="tag tags">{{ content.tags[0] | displayTags }}</span>
+                        <span class="tag tags" [innerHtml]="content.tags[0] | displayTags | safeHtml"></span>
                         <rmx-icon name="arrow-down-s-line" (click)="toggleShowAllTags()"></rmx-icon>
                     </ng-template>
                 </ng-template>

--- a/libs/client/ui/src/lib/components/work-card/work-card.component.html
+++ b/libs/client/ui/src/lib/components/work-card/work-card.component.html
@@ -40,15 +40,32 @@
         <ng-container *ngIf="content.tags !== null && content.tags.length > 0">
             <div class="card-tags flex flex-row items-center">
                 <ng-container *ngIf="content.tags.length === 1; else multipleTags">
-                    <span class="tag tags">{{ content.tags[0] | displayTags }}</span>
+                    <span class="tag tags">
+                        <a [routerLink]="['/tag']">
+                            {{ content.tags[0] | displayTags }}
+                        </a>
+                    </span>
                 </ng-container>
                 <ng-template #multipleTags>
                     <ng-container *ngIf="showAllTags; else showOneTag">
-                        <span class="tag tags">{{ content.tags | displayTags }}</span>
+                        <span class="tag tags">
+                            <ng-container *ngFor="let tag of content.tags; let i = index">   
+                                <a [routerLink]="['/tag']">
+                                    {{ tag | displayTags }}
+                                </a>
+                                <ng-container *ngIf="i < content.tags.length - 1">
+                                    , 
+                                </ng-container>
+                            </ng-container>
+                        </span>
                         <rmx-icon name="arrow-up-s-line" (click)="toggleShowAllTags()"></rmx-icon>
                     </ng-container>
                     <ng-template #showOneTag>
-                        <span class="tag tags">{{ content.tags[0] | displayTags }}</span>
+                        <span class="tag tags">
+                            <a [routerLink]="['/tag']">
+                                {{ content.tags[0] | displayTags }}
+                            </a>
+                        </span>
                         <rmx-icon name="arrow-down-s-line" (click)="toggleShowAllTags()"></rmx-icon>
                     </ng-template>
                 </ng-template>

--- a/libs/client/ui/src/lib/components/work-card/work-card.component.html
+++ b/libs/client/ui/src/lib/components/work-card/work-card.component.html
@@ -41,7 +41,7 @@
             <div class="card-tags flex flex-row items-center">
                 <ng-container *ngIf="content.tags.length === 1; else multipleTags">
                     <span class="tag tags">
-                        <a [routerLink]="['/tag']">
+                        <a [routerLink]="['/tag', content.tags[0]._id, content.tags[0].name | slugify]">
                             {{ content.tags[0] | displayTags }}
                         </a>
                     </span>
@@ -50,7 +50,7 @@
                     <ng-container *ngIf="showAllTags; else showOneTag">
                         <span class="tag tags">
                             <ng-container *ngFor="let tag of content.tags; let i = index">   
-                                <a [routerLink]="['/tag']">
+                                <a [routerLink]="['/tag', tag._id, tag.name | slugify]">
                                     {{ tag | displayTags }}
                                 </a>
                                 <ng-container *ngIf="i < content.tags.length - 1">
@@ -62,7 +62,7 @@
                     </ng-container>
                     <ng-template #showOneTag>
                         <span class="tag tags">
-                            <a [routerLink]="['/tag']">
+                            <a [routerLink]="['/tag', content.tags[0]._id, content.tags[0].name | slugify]">
                                 {{ content.tags[0] | displayTags }}
                             </a>
                         </span>

--- a/libs/client/ui/src/lib/components/work-card/work-card.component.scss
+++ b/libs/client/ui/src/lib/components/work-card/work-card.component.scss
@@ -23,6 +23,13 @@ div.card {
     }
     div.card-tags {
         border-bottom: 1px solid whitesmoke;
+        a {
+            cursor: pointer;
+            color: whitesmoke;
+            &:hover {
+                background: var(--accent-dark);
+            }
+        }
     }
     span.divider {
         font-size: 14px;

--- a/libs/shared/src/lib/functions/html-decode.ts
+++ b/libs/shared/src/lib/functions/html-decode.ts
@@ -1,0 +1,4 @@
+export function htmlDecode(input: string): string {
+    var doc = new DOMParser().parseFromString(input, "text/html");
+    return doc.documentElement.textContent;
+}

--- a/libs/shared/src/lib/functions/index.ts
+++ b/libs/shared/src/lib/functions/index.ts
@@ -3,3 +3,4 @@ export { isAllowed } from './is-allowed';
 export { isNullOrUndefined } from './is-null-or-undefined';
 export { handleResponse } from './handle-response';
 export { tryParseJsonHttpError } from './try-parse-http-error';
+export { htmlDecode } from './html-decode';


### PR DESCRIPTION
Addresses ticket #636 and #649

## Description
When you click fandom tag, you go to page that describes the tag and lists stories with that tag.

## Changes
- Creates page for each fandom tag. This includes a link to its parent if available, the description, links to its children if available, and all works with this fandom tag. This does not include all works with its children as fandom tags.
- Changes the tag listings in Dashboard, My Stuff, work cards, and content boxes to have links.
- All changes from #650

## Areas Affected
- [ ] Site Navigation
- [ ] Home
- [ ] Sign In/Out
- [ ] Registration
- [ ] Settings

.
- [ ] Profile
- [x] My Stuff (main page)
- [x] Editor
- [x] Browse
- [x] Work Card

.
- [x] Work Page
- [ ] Blog Page
- [ ] Collections
- [ ] Comments
- [ ] Other Pages

.
- [ ] Account Authentication
- [x] Dashboard
- [ ] Mobile
