### PR TITLE
Fix tag problems (PR for tag_pages branch)

### DIFF
--- a/apps/bettafish/src/app/components/content/content-box/content-box.component.html
+++ b/apps/bettafish/src/app/components/content/content-box/content-box.component.html
@@ -61,7 +61,7 @@
                         </div>
                         <ng-container *ngIf="content.currContent.tags !== null && content.currContent.tags.length > 0">
                             <div class="flex flex-row items-center uppercase text-sm">
-                                <span class="tag tags">{{ content.currContent.tags | displayTags }}</span>
+                                <span class="tag tags" [innerHtml]="content.currContent.tags | displayTags | safeHtml"></span>
                             </div>
                         </ng-container>
                     </div>

--- a/apps/bettafish/src/material.scss
+++ b/apps/bettafish/src/material.scss
@@ -86,35 +86,6 @@ button.mat-menu-item {
     border: 1px solid var(--borders) !important;
 }
 
-.mat-expansion-panel-header-description, .mat-expansion-indicator {
-    position: relative !important;
-    top: -0.25rem;
-    &::after {
-        color: var(--text-color) !important;
-        font-size: 0.875rem !important;
-    }
-}
-
-.mat-expansion-panel-header {
-    font-family: 'Inter', sans-serif !important;
-    font-size: 1rem !important;
-    border-radius: 0.375rem !important;
-}
-
-.mat-expansion-panel-header-title {
-    color: var(--accent) !important;
-    font-family: 'Josefin Sans', sans-serif !important;
-    font-size: 1.15rem !important;
-    font-weight: 500 !important;
-}
-
-/* Mat Expansion Panel */
-.mat-expansion-panel {
-    background: var(--background) !important;
-    color: var(--text-color) !important;
-    border: 1px solid var(--borders) !important;
-}
-
 .mat-expansion-panel-header-description, .mat-expansion-indicator::after {
     color: var(--text-color) !important;
     font-size: 0.875rem !important;

--- a/libs/client/dashboard/src/lib/components/tags-management/child-tag-item/child-tag-item.component.html
+++ b/libs/client/dashboard/src/lib/components/tags-management/child-tag-item/child-tag-item.component.html
@@ -3,10 +3,10 @@
         class="text-lg font-medium"
         style="font-family: 'Josefin Sans', sans-serif; color: var(--accent);"
     >
-        {{ tag.name }}
+        <div class="tag-name" [innerHtml]="tag.name | safeHtml"></div>
     </div>
     <div class="flex-1 text-center mx-2 relative -top-0.5">
-        {{ tag.desc }}
+        <div class="tag-desc" [innerHtml]="tag.desc | safeHtml"></div>
     </div>
     <button class="py-1.5 px-2.5 rounded-full border-none shadow-none" (click)="editTag()">
         <i-feather name="edit-3" class="mr-0"></i-feather>

--- a/libs/client/dashboard/src/lib/components/tags-management/tag-form/tag-form.component.html
+++ b/libs/client/dashboard/src/lib/components/tags-management/tag-form/tag-form.component.html
@@ -30,7 +30,7 @@
                     No Parent
                 </ng-option>
                 <ng-option *ngFor="let tag of tags" [value]="tag._id">
-                    {{ tag.name }}
+                    <div class="tag-name" [innerHtml]="tag.name | safeHtml"></div>
                 </ng-option>
             </ng-select>
         </div>

--- a/libs/client/dashboard/src/lib/components/tags-management/tag-form/tag-form.component.ts
+++ b/libs/client/dashboard/src/lib/components/tags-management/tag-form/tag-form.component.ts
@@ -32,8 +32,8 @@ export class TagFormComponent implements OnInit {
     ngOnInit(): void {
         if (this.data.tag) {
             this.tagForm.setValue({
-                name: this.data.tag.name,
-                desc: this.data.tag.desc,
+                name: this.htmlDecode(this.data.tag.name),
+                desc: this.htmlDecode(this.data.tag.desc),
                 parent: (this.data.tag.parent || this.NO_PARENT),
             });
             this.editMode = true;
@@ -81,5 +81,10 @@ export class TagFormComponent implements OnInit {
                 this.dialogRef.close();
             });
         }
+    }
+
+    htmlDecode(input: string) {
+        var doc = new DOMParser().parseFromString(input, "text/html");
+        return doc.documentElement.textContent;
     }
 }

--- a/libs/client/dashboard/src/lib/pages/tags-management/tags-management.component.html
+++ b/libs/client/dashboard/src/lib/pages/tags-management/tags-management.component.html
@@ -28,12 +28,13 @@
                         <mat-expansion-panel>
                             <mat-expansion-panel-header>
                                 <mat-panel-title>
-                                    {{ tag.name }}
+                                    <div class="tag-name" [innerHtml]="tag.name | safeHtml"></div>
                                 </mat-panel-title>
-                                <mat-panel-description>
-                                    {{ tag.desc }}
-                                </mat-panel-description>
+                                <!-- <mat-panel-description>
+                                    <div class="tag-desc" [innerHtml]="tag.desc | safeHtml"></div>
+                                </mat-panel-description> -->
                             </mat-expansion-panel-header>
+                            <div class="tag-desc" [innerHtml]="tag.desc | safeHtml"></div>
                             <div class="flex flex-row items-center">
                                 <button (click)="addChild(tag._id)"><i-feather name="plus"></i-feather>Child</button>
                                 <div class="mx-1"><!--spacer--></div>

--- a/libs/client/dashboard/src/lib/pages/tags-management/tags-management.component.html
+++ b/libs/client/dashboard/src/lib/pages/tags-management/tags-management.component.html
@@ -25,14 +25,11 @@
             <div class="w-8/12 mx-auto my-8">
                 <mat-accordion>
                     <ng-container *ngFor="let tag of tags">
-                        <mat-expansion-panel>
+                        <mat-expansion-panel [expanded]="(tag._id === openPanelId)? true : false" (opened)="onOpen(tag._id)">
                             <mat-expansion-panel-header>
                                 <mat-panel-title>
                                     <div class="tag-name" [innerHtml]="tag.name | safeHtml"></div>
                                 </mat-panel-title>
-                                <!-- <mat-panel-description>
-                                    <div class="tag-desc" [innerHtml]="tag.desc | safeHtml"></div>
-                                </mat-panel-description> -->
                             </mat-expansion-panel-header>
                             <div class="tag-desc" [innerHtml]="tag.desc | safeHtml"></div>
                             <div class="flex flex-row items-center">

--- a/libs/client/dashboard/src/lib/pages/tags-management/tags-management.component.ts
+++ b/libs/client/dashboard/src/lib/pages/tags-management/tags-management.component.ts
@@ -12,6 +12,8 @@ import { PopupComponent } from '@dragonfish/client/ui';
     styleUrls: ['./tags-management.component.scss'],
 })
 export class TagsManagementComponent implements OnInit {
+    openPanelId: string;
+
     constructor(
         public tagsQuery: TagsQuery,
         private tagsService: TagsService,
@@ -24,6 +26,10 @@ export class TagsManagementComponent implements OnInit {
 
     createTag() {
         this.dialog.open(TagFormComponent);
+    }
+
+    onOpen(id: string) {
+        this.openPanelId = id;
     }
 
     addChild(parentId: string) {

--- a/libs/client/my-stuff/src/lib/components/content-preview/content-preview.component.html
+++ b/libs/client/my-stuff/src/lib/components/content-preview/content-preview.component.html
@@ -84,7 +84,7 @@
                 </div>
                 <ng-container *ngIf="currContent.tags !== null && currContent.tags.length > 0">
                     <div class="flex flex-row items-center pb-1">
-                        <span class="tag tags">{{ currContent.tags | displayTags }}</span>
+                        <span class="tag tags" [innerHtml]="currContent.tags | displayTags | safeHtml"></span>
                     </div>
                 </ng-container>
             </div>

--- a/libs/client/ui/src/lib/components/work-card/work-card.component.html
+++ b/libs/client/ui/src/lib/components/work-card/work-card.component.html
@@ -40,15 +40,15 @@
         <ng-container *ngIf="content.tags !== null && content.tags.length > 0">
             <div class="card-tags flex flex-row items-center">
                 <ng-container *ngIf="content.tags.length === 1; else multipleTags">
-                    <span class="tag tags">{{ content.tags[0] | displayTags }}</span>
+                    <span class="tag tags" [innerHtml]="content.tags[0] | displayTags | safeHtml"></span>
                 </ng-container>
                 <ng-template #multipleTags>
                     <ng-container *ngIf="showAllTags; else showOneTag">
-                        <span class="tag tags">{{ content.tags | displayTags }}</span>
+                        <span class="tag tags" [innerHtml]="content.tags | displayTags | safeHtml"></span>
                         <rmx-icon name="arrow-up-s-line" (click)="toggleShowAllTags()"></rmx-icon>
                     </ng-container>
                     <ng-template #showOneTag>
-                        <span class="tag tags">{{ content.tags[0] | displayTags }}</span>
+                        <span class="tag tags" [innerHtml]="content.tags[0] | displayTags | safeHtml"></span>
                         <rmx-icon name="arrow-down-s-line" (click)="toggleShowAllTags()"></rmx-icon>
                     </ng-template>
                 </ng-template>


### PR DESCRIPTION
Addresses ticket #649

## Description
Addresses four problems:
1. Tag boxes close with every modification, notably when adding a child tag
2. Tag boxes can't handle long descriptions
3. Tags display & as \&amp;
4. Child tags of different parents can't share names (so two parent tags can't both have child tags named "IDW Comics")

## Changes
1. Keeps track of what tag box was open and keeps it open when tags are refreshed
2. Moves tag descriptions to inside the tag box, rather than using the build in description field
3. Processes HTML when displaying tag names and descriptions
4. Implements smarter name checking, so that parent tags only check for name duplication with other parent tags, and child tags only check with other tags that share their parent. This applies to editing tags too.
5. Also removes duplicated code in material.scss

## Areas Affected
- [ ] Site Navigation
- [ ] Home
- [ ] Sign In/Out
- [ ] Registration
- [ ] Settings

.
- [ ] Profile
- [x] My Stuff (main page)
- [ ] Editor
- [ ] Browse
- [x] Work Card

.
- [x] Work Page
- [ ] Blog Page
- [ ] Collections
- [ ] Comments
- [ ] Other Pages

.
- [ ] Account Authentication
- [x] Dashboard
- [ ] Mobile
