### PR TITLE
Fixes tag link display on Dashboard and improves tag page header

### DIFF
--- a/apps/bettafish/src/app/pages/tags/tag-page.component.html
+++ b/apps/bettafish/src/app/pages/tags/tag-page.component.html
@@ -16,7 +16,7 @@
             </ng-container>
             <ng-template #notEmpty>
                 <div class="w-11/12 mx-auto my-6">
-                    <h3>
+                    <div class="tag-header">
                         <ng-container *ngIf="tags[0].parent">
                             <a
                                 [routerLink]="['/tag', tags[0].parent._id, tags[0].parent.name | slugify]"
@@ -25,7 +25,7 @@
                             &nbsp;— 
                         </ng-container>
                         <span [innerHtml]="tags[0].name | safeHtml"></span>
-                    </h3>
+                    </div>
                     <ng-container *ngIf="tags[0].children && tags[0].children.length > 0">
                         Child Tags: 
                         <ng-container *ngFor="let child of tags[0].children; let i = index">

--- a/apps/bettafish/src/app/pages/tags/tag-page.component.html
+++ b/apps/bettafish/src/app/pages/tags/tag-page.component.html
@@ -16,7 +16,7 @@
             </ng-container>
             <ng-template #notEmpty>
                 <div class="w-11/12 mx-auto my-6">
-                    <div class="tag-header">
+                    <div class="text-2xl">
                         <ng-container *ngIf="tags[0].parent">
                             <a
                                 [routerLink]="['/tag', tags[0].parent._id, tags[0].parent.name | slugify]"

--- a/apps/bettafish/src/app/pages/tags/tag-page.component.scss
+++ b/apps/bettafish/src/app/pages/tags/tag-page.component.scss
@@ -1,3 +1,0 @@
-div.tag-header {
-    font-size: 24px;
-}

--- a/apps/bettafish/src/app/pages/tags/tag-page.component.scss
+++ b/apps/bettafish/src/app/pages/tags/tag-page.component.scss
@@ -1,0 +1,3 @@
+div.tag-header {
+    font-size: 24px;
+}

--- a/apps/bettafish/src/app/pages/tags/tag-page.component.ts
+++ b/apps/bettafish/src/app/pages/tags/tag-page.component.ts
@@ -13,6 +13,7 @@ import { combineLatest } from "rxjs";
 @Component({
     selector: 'dragonfish-tag-page',
     templateUrl: './tag-page.component.html',
+    styleUrls: ['./tag-page.component.scss'],
 })
 export class TagPageComponent implements OnInit {
     tagId = "";

--- a/libs/client/dashboard/src/lib/dashboard.component.html
+++ b/libs/client/dashboard/src/lib/dashboard.component.html
@@ -54,7 +54,7 @@
                 Case Files
             </a>
             <a
-                class="link"
+                class="link dropdown-item"
                 [routerLink]="['tags']"
                 [routerLinkActive]="'active'"
             >


### PR DESCRIPTION
## Description
The tag management link on the Dashboard doesn't match other links on the page in appearance, and the tag page header is a bit hard to read.

## Changes
Changes the type of link used on the Dashboard to match the others, and creates a CSS file for tag-page to adjust the appearance of the header.

## Areas Affected
- [ ] Site Navigation
- [ ] Home
- [ ] Sign In/Out
- [ ] Registration
- [ ] Settings

.
- [ ] Profile
- [ ] My Stuff (main page)
- [ ] Editor
- [ ] Browse
- [ ] Work Card

.
- [ ] Work Page
- [ ] Blog Page
- [ ] Collections
- [ ] Comments
- [x] Other Pages

.
- [ ] Account Authentication
- [x] Dashboard
- [ ] Mobile
