### PR TITLE
Add various VSCode and Prettier and ESlint settings to make Dragonfish warn and autoformat

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -4,6 +4,7 @@
         "angular.ng-template",
         "ms-vscode.vscode-typescript-tslint-plugin",
         "esbenp.prettier-vscode",
+        "dbaeumer.vscode-eslint",
         "firsttris.vscode-jest-runner"
     ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,12 @@
 {
     "vsicons.presets.angular": true,
-    "angular.enable-strict-mode-prompt": false
+    "angular.enable-strict-mode-prompt": false,
+    "typescript.referencesCodeLens.enabled": true, // why is this not a default? baffling.
+    "editor.codeActionsOnSave": {
+        // Auto-format on save
+        "source.fixAll": true,
+    },
+    "javascript.format.enable": true,
+    "eslint.format.enable": true,
+    "eslint.lintTask.enable": true,
 }

--- a/apps/api/.eslintrc.json
+++ b/apps/api/.eslintrc.json
@@ -1,9 +1,35 @@
 {
-    "extends": "../../.eslintrc.json",
+    "extends": ["../../.eslintrc.json", "plugin:@typescript-eslint/recommended", "plugin:prettier/recommended", "prettier"],
     "ignorePatterns": [
         "!**/*"
     ],
+    "parser": "@typescript-eslint/parser",
+    "parserOptions": {
+        "ecmaVersion": 2019,
+        "sourceType": "module",
+        "tsconfigRootDir": "apps/api",
+        "project": "tsconfig.app.json"
+    },
+    "plugins": ["@typescript-eslint", "prettier"],
+    "env": {
+        "node": true
+    },
     "rules": {
-        "@typescript-eslint/no-namespace": "off"
+        "@typescript-eslint/no-namespace": "off",
+        "@typescript-eslint/naming-convention": [
+            "warn",
+            {
+                "selector": "variable",
+                "format": ["camelCase", "UPPER_CASE"]
+            },
+            {
+                "selector": ["variable", "function"],
+                "format": ["camelCase"]
+            }
+        ],
+        "require-await": "off",
+        "@typescript-eslint/require-await": "warn",
+        "@typescript-eslint/explicit-function-return-type": ["warn"],
+        "prettier/prettier": ["error", { "endOfLine": "auto" }]
     }
 }

--- a/apps/api/tsconfig.app.json
+++ b/apps/api/tsconfig.app.json
@@ -4,7 +4,7 @@
         "outDir": "../../dist/out-tsc",
         "types": ["node"],
         "emitDecoratorMetadata": true,
-        "target": "es2015"
+        "target": "es2019"
     },
     "exclude": ["**/*.spec.ts"],
     "include": ["**/*.ts"]

--- a/package.json
+++ b/package.json
@@ -183,6 +183,7 @@
         "eslint": "7.22.0",
         "eslint-config-prettier": "8.1.0",
         "eslint-plugin-cypress": "^2.10.3",
+        "eslint-plugin-prettier": "^3.4.1",
         "exitzero": "^1.0.1",
         "jest": "27.0.3",
         "jest-preset-angular": "9.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8831,6 +8831,13 @@ eslint-plugin-cypress@^2.10.3:
   dependencies:
     globals "^11.12.0"
 
+eslint-plugin-prettier@^3.4.1:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-3.4.1.tgz#e9ddb200efb6f3d05ffe83b1665a716af4a387e5"
+  integrity sha512-htg25EUYUeIhKHXjOinK4BgCcDwtLHjqaxCDsMy5nbnUMkKFvIhMVCp+5GFUXQ4Nr8lBsPqtGAqBenbpFqAA2g==
+  dependencies:
+    prettier-linter-helpers "^1.0.0"
+
 eslint-scope@5.1.1, eslint-scope@^5.0.0, eslint-scope@^5.1.0, eslint-scope@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"
@@ -9213,6 +9220,11 @@ fast-deep-equal@^3.1.1:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
+
+fast-diff@^1.1.2:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.2.0.tgz#73ee11982d86caaf7959828d519cfe927fac5f03"
+  integrity sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==
 
 fast-glob@3.2.5, fast-glob@^3.1.1, fast-glob@^3.2.2, fast-glob@^3.2.4, fast-glob@^3.2.5:
   version "3.2.5"
@@ -14983,6 +14995,13 @@ prerender-node@^3.2.5:
   integrity sha512-8vV2kXkYp82mgOqNbcQUBEzVEreB0khNxsASiHVRLfK9PR60mHg2m33QHe/TcOrr0XRsBFYK4j8FgmLMah9ZXw==
   dependencies:
     request "^2.88.0"
+
+prettier-linter-helpers@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz#d23d41fe1375646de2d0104d3454a3008802cf7b"
+  integrity sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==
+  dependencies:
+    fast-diff "^1.1.2"
 
 prettier@2.3.2:
   version "2.3.2"


### PR DESCRIPTION
This doesn't touch any actual code files, but it enables a number of handy editor things in VSCode. Note that this only applies to the Dragonfish project, as I'm less comfortable imposing formatting rules on the frontend, as I'm less familiar with its idiosyncrasies. You could probably use this PR as a template though.

- It turns on auto-format and auto-fix on save by default. This will automatically format the file and apply any automatic fixes from Prettier or ESLint whenever you save.
- It turns on CodeLens by default, which is just handy. It displays a little inline annotation in the file that shows you how often public members (functions & variables) are references externally.
- It will warn on any function that doesn't have an explicit return type
- It will warn on any parameter that doesn't have an explicit type
- It will warn if you have an `async` function that doesn't use `await`.

IN ADDITION:
I also bumped Dragonfish's compile target from ECMAScript 2015 to ECMAScript 2019, as that's the highest that our runtime version of Node can safely support. This will unlock a small handful of new language-level improvements.