### PR TITLE
Improve mobile Browse and grids

### DIFF
--- a/apps/bettafish/src/app/app.component.ts
+++ b/apps/bettafish/src/app/app.component.ts
@@ -6,6 +6,7 @@ import { SessionQuery } from '@dragonfish/client/repository/session';
 import { AuthService } from '@dragonfish/client/repository/session/services';
 import { AppQuery } from '@dragonfish/client/repository/app';
 import { DragonfishElectronService } from '@dragonfish/client/services';
+import { isMobile } from '@dragonfish/shared/functions';
 
 @UntilDestroy()
 @Component({
@@ -14,8 +15,6 @@ import { DragonfishElectronService } from '@dragonfish/client/services';
     styleUrls: ['./app.component.scss'],
 })
 export class AppComponent implements OnInit {
-    screenWidth: number;
-    screenHeight: number;
     mobileMode = false;
     showNav = true;
 
@@ -65,9 +64,6 @@ export class AppComponent implements OnInit {
 
     @HostListener('window:resize', ['$event'])
     onResize() {
-        this.screenHeight = window.innerHeight;
-        this.screenWidth = window.innerWidth;
-
-        this.mobileMode = this.screenWidth < 1100;
+        this.mobileMode = isMobile();
     }
 }

--- a/apps/bettafish/src/app/pages/browse/browse.component.html
+++ b/apps/bettafish/src/app/pages/browse/browse.component.html
@@ -6,27 +6,40 @@
 </dragonfish-topbar>
 
 <div class="flex" style="height: calc(100vh - 52px);">
-    <dragonfish-pagebar>
-        <form [formGroup]="searchForm" (ngSubmit)="submitSearch()">
-            <dragonfish-text-field
-                [formControlName]="'query'"
-                [name]="'query'"
-                [type]="'text'"
-                [placeholder]="'Search...'"
-                [searchBox]="true"
-            ></dragonfish-text-field>
-        </form>
-        <div class="my-2 border-b w-full border-white"><!--spacer--></div>
-        <a class="link" [routerLink]="['/browse']" [routerLinkActive]="'active'" [routerLinkActiveOptions]="{ exact: true }">
-            <span class="link-icon"><rmx-icon name="sun-line"></rmx-icon></span>A taste of today
-        </a>
-        <a class="link" [routerLink]="['newest-works']" [routerLinkActive]="'active'">
-            <span class="link-icon"><rmx-icon name="newspaper-line"></rmx-icon></span>What's new
-        </a>
-    </dragonfish-pagebar>
-    <ng-container *ngIf="route.children.length === 0; else routerOutlet">
-        <div class="w-full">
-            <ng-scrollbar>
+    <ng-container *ngIf="!mobileMode">
+        <dragonfish-pagebar>
+            <form [formGroup]="searchForm" (ngSubmit)="submitSearch()">
+                <dragonfish-text-field
+                    [formControlName]="'query'"
+                    [name]="'query'"
+                    [type]="'text'"
+                    [placeholder]="'Search...'"
+                    [searchBox]="true"
+                ></dragonfish-text-field>
+            </form>
+            <div class="my-2 border-b w-full border-white"><!--spacer--></div>
+            <a class="link" [routerLink]="['/browse']" [routerLinkActive]="'active'" [routerLinkActiveOptions]="{ exact: true }">
+                <span class="link-icon"><rmx-icon name="sun-line"></rmx-icon></span>A taste of today
+            </a>
+            <a class="link" [routerLink]="['newest-works']" [routerLinkActive]="'active'">
+                <span class="link-icon"><rmx-icon name="newspaper-line"></rmx-icon></span>What's new
+            </a>
+        </dragonfish-pagebar>
+    </ng-container>
+    <div class="w-full">
+        <ng-scrollbar>
+            <ng-container *ngIf="mobileMode">
+                <form [formGroup]="searchForm" (ngSubmit)="submitSearch()">
+                    <dragonfish-text-field
+                        [formControlName]="'query'"
+                        [name]="'query'"
+                        [type]="'text'"
+                        [placeholder]="'Search...'"
+                        [searchBox]="true"
+                    ></dragonfish-text-field>
+                </form>
+            </ng-container>
+            <ng-container *ngIf="route.children.length === 0; else routerOutlet">
                 <div class="w-11/12 mx-auto my-6">
                     <div class="section-header flex flex-row items-center p-2 mb-4">
                         <h3 class="text-3xl font-medium flex-1">What's new</h3>
@@ -38,24 +51,19 @@
                         </div>
                     </ng-container>
                     <ng-template #notLoadingNew>
-                        <div class="grid lg:grid-cols-3 md:grid-cols-2 sm:grid-cols-1 gap-2">
+                        <div class="grid 2xl:grid-cols-4 lg:grid-cols-3 md:grid-cols-2 sm:grid-cols-1 gap-2">
                             <ng-container *ngFor="let work of newWorks">
                                 <dragonfish-work-card [content]="work" [showAuthor]="true"></dragonfish-work-card>
                             </ng-container>
                         </div>
                     </ng-template>
                 </div>
-            </ng-scrollbar>
-
-        </div>
-    </ng-container>
-    <ng-template #routerOutlet>
-        <div class="w-full">
-            <ng-scrollbar>
+            </ng-container>
+            <ng-template #routerOutlet>
                 <div class="w-11/12 mx-auto my-6">
                     <router-outlet></router-outlet>
                 </div>
-            </ng-scrollbar>
-        </div>
-    </ng-template>
+            </ng-template>
+        </ng-scrollbar>
+    </div>
 </div>

--- a/apps/bettafish/src/app/pages/browse/browse.component.ts
+++ b/apps/bettafish/src/app/pages/browse/browse.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, HostListener, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { FormControl, FormGroup } from '@angular/forms';
 import { AlertsService } from '@dragonfish/client/alerts';
@@ -6,6 +6,7 @@ import { ContentModel } from '@dragonfish/shared/models/content';
 import { DragonfishNetworkService } from '@dragonfish/client/services';
 import { Constants, setTwoPartTitle } from '@dragonfish/shared/constants';
 import { AppQuery } from '@dragonfish/client/repository/app';
+import { isMobile } from '@dragonfish/shared/functions';
 
 @Component({
     selector: 'dragonfish-browse',
@@ -18,6 +19,7 @@ export class BrowseComponent implements OnInit {
     searchForm = new FormGroup({
         query: new FormControl('')
     });
+    mobileMode = false;
 
     constructor(
         public route: ActivatedRoute,
@@ -30,6 +32,7 @@ export class BrowseComponent implements OnInit {
     ngOnInit() {
         setTwoPartTitle(Constants.BROWSE);
         this.loadFirstNew();
+        this.onResize();
     }
 
     loadFirstNew() {
@@ -50,5 +53,10 @@ export class BrowseComponent implements OnInit {
         }).catch(() => {
             this.alerts.error(`Something went wrong! Try again in a little bit.`);
         });
+    }
+    
+    @HostListener('window:resize', ['$event'])
+    onResize() {
+        this.mobileMode = isMobile();
     }
 }

--- a/apps/bettafish/src/app/pages/browse/newest-works/newest-works.component.html
+++ b/apps/bettafish/src/app/pages/browse/newest-works/newest-works.component.html
@@ -5,7 +5,7 @@
 </ng-container>
 
 <ng-template #notLoading>
-    <div class="grid lg:grid-cols-3 md:grid-cols-2 sm:grid-cols-1 gap-4 mb-4">
+    <div class="grid 2xl:grid-cols-4 lg:grid-cols-3 md:grid-cols-2 sm:grid-cols-1 gap-2">
         <ng-container *ngFor="let work of works.docs | paginate: {itemsPerPage: works.limit, currentPage: pageNum, totalItems: works.totalDocs}">
             <dragonfish-work-card [content]="work" [showAuthor]="true"></dragonfish-work-card>
         </ng-container>

--- a/apps/bettafish/src/app/pages/browse/search/search.component.html
+++ b/apps/bettafish/src/app/pages/browse/search/search.component.html
@@ -2,13 +2,6 @@
     <div class="w-11/12 mx-auto pb-2 pt-4 flex flex-row justify-center">
         <rmx-icon name="search-line" class="mr-4 header"></rmx-icon>
         <h3 class="text-2xl italic text-white">Search Results</h3>
-
-        <!--
-        <a class="text-lg text-white px-3.5 py-2.5 hover:no-underline hover:text-white">Initial Results</a>
-        <a class="text-lg text-white px-3.5 py-2.5 hover:no-underline hover:text-white">All Works</a>
-        <a class="text-lg text-white px-3.5 py-2.5 hover:no-underline hover:text-white">All Blogs</a>
-        <a class="text-lg text-white px-3.5 py-2.5 hover:no-underline hover:text-white">All Users</a>
-        -->
     </div>
 </div>
 
@@ -24,7 +17,7 @@
             <rmx-icon name="book-open-line" class="relative -top-0.5 mr-2"></rmx-icon>
             <h3 class="text-4xl font-medium">Works</h3>
         </div>
-        <div class="grid grid-cols-3 gap-4">
+        <div class="grid 2xl:grid-cols-4 lg:grid-cols-3 md:grid-cols-2 sm:grid-cols-1 gap-2">
             <!--Works-->
             <ng-container *ngFor="let work of searchResults.works">
                 <dragonfish-work-card [content]="work" [showAuthor]="true"></dragonfish-work-card>
@@ -35,7 +28,7 @@
             <rmx-icon name="cup-line" class="relative -top-0.5 mr-2"></rmx-icon>
             <h3 class="text-4xl font-medium">Blogs</h3>
         </div>
-        <div class="grid grid-cols-3 gap-4">
+        <div class="grid 2xl:grid-cols-4 lg:grid-cols-3 md:grid-cols-2 sm:grid-cols-1 gap-2">
             <!--Blogs-->
             <ng-container *ngFor="let blog of searchResults.blogs">
                 <dragonfish-blog-card [blog]="blog" [showAuthor]="true"></dragonfish-blog-card>
@@ -46,7 +39,7 @@
             <rmx-icon name="group-line" class="relative -top-0.5 mr-2"></rmx-icon>
             <h3 class="text-4xl font-medium">Users</h3>
         </div>
-        <div class="grid grid-cols-3 gap-4">
+        <div class="grid 2xl:grid-cols-4 lg:grid-cols-3 md:grid-cols-2 sm:grid-cols-1 gap-2">
             <!--Users-->
             <ng-container *ngFor="let user of searchResults.users">
                 <dragonfish-user-card [user]="user"></dragonfish-user-card>

--- a/apps/bettafish/src/app/pages/docs/site-staff/site-staff.component.html
+++ b/apps/bettafish/src/app/pages/docs/site-staff/site-staff.component.html
@@ -7,7 +7,7 @@
 
     <ng-scrollbar>
         <div class="w-11/12 mx-auto my-8">
-            <div class="grid 2xl:grid-cols-5 xl:grid-cols-4 lg:grid-cols-3 md:grid-cols-2 gap-4 place-items-center">
+            <div class="grid 2xl:grid-cols-4 lg:grid-cols-3 md:grid-cols-2 sm:grid-cols-1 gap-2">
                 <ng-container *ngFor="let user of staffData">
                     <dragonfish-user-card [user]="user"></dragonfish-user-card>
                 </ng-container>

--- a/apps/bettafish/src/app/pages/docs/supporters/supporters.component.html
+++ b/apps/bettafish/src/app/pages/docs/supporters/supporters.component.html
@@ -7,7 +7,7 @@
 
     <ng-scrollbar>
         <div class="w-11/12 mx-auto my-8">
-            <div class="grid 2xl:grid-cols-5 xl:grid-cols-4 lg:grid-cols-3 md:grid-cols-2 gap-4 place-items-center">
+            <div class="grid 2xl:grid-cols-4 lg:grid-cols-3 md:grid-cols-2 sm:grid-cols-1 gap-2">
                 <ng-container *ngFor="let user of supporters">
                     <dragonfish-user-card [user]="user"></dragonfish-user-card>
                 </ng-container>

--- a/apps/bettafish/src/app/pages/home/home.component.html
+++ b/apps/bettafish/src/app/pages/home/home.component.html
@@ -28,7 +28,7 @@
                     </div>
                 </ng-container>
                 <ng-template #notLoadingLatest>
-                    <div class="grid lg:grid-cols-3 md:grid-cols-2 sm:grid-cols-1 gap-2 w-11/12 mx-auto">
+                    <div class="grid 2xl:grid-cols-4 lg:grid-cols-3 md:grid-cols-2 sm:grid-cols-1 gap-2 w-11/12 mx-auto">
                         <ng-container *ngFor="let posts of latestPosts">
                             <dragonfish-news-card [post]="posts"></dragonfish-news-card>
                         </ng-container>

--- a/apps/bettafish/src/app/pages/home/news-feed/news-feed.component.html
+++ b/apps/bettafish/src/app/pages/home/news-feed/news-feed.component.html
@@ -22,7 +22,7 @@
             </ng-container>
 
             <ng-template #hasDocs>
-                <div class="grid lg:grid-cols-3 md:grid-cols-2 sm:grid-cols-1 gap-2 w-11/12 mx-auto my-8">
+                <div class="grid 2xl:grid-cols-4 lg:grid-cols-3 md:grid-cols-2 sm:grid-cols-1 gap-2 w-11/12 mx-auto my-8">
                     <ng-container
                         *ngFor="
                 let post of posts.docs

--- a/apps/bettafish/src/app/pages/portfolio/portfolio-blog/portfolio-blog.component.html
+++ b/apps/bettafish/src/app/pages/portfolio/portfolio-blog/portfolio-blog.component.html
@@ -5,7 +5,7 @@
         </div>
     </ng-container>
     <ng-template #notLoading>
-        <div class="grid grid-cols-2 gap-6 my-8 w-11/12 mx-auto" *ngIf="blogsData.totalDocs !== 0; else noGalleryBlogs">
+        <div class="grid 2xl:grid-cols-4 lg:grid-cols-3 md:grid-cols-2 sm:grid-cols-1 gap-2 my-8 w-11/12 mx-auto" *ngIf="blogsData.totalDocs !== 0; else noGalleryBlogs">
             <ng-container *ngFor="let blog of blogsData.docs | paginate: {itemsPerPage: blogsData.limit, currentPage: pageNum, totalItems: blogsData.totalDocs}">
                 <dragonfish-blog-card [blog]="blog" [showAuthor]="false"></dragonfish-blog-card>
             </ng-container>

--- a/apps/bettafish/src/app/pages/portfolio/portfolio-collections/portfolio-collection-page/portfolio-collection-page.component.html
+++ b/apps/bettafish/src/app/pages/portfolio/portfolio-collections/portfolio-collection-page/portfolio-collection-page.component.html
@@ -48,7 +48,7 @@
             </div>
         </ng-container>
         <ng-template #hasContent>
-            <div class="grid grid-cols-3 gap-4">
+            <div class="grid 2xl:grid-cols-4 lg:grid-cols-3 md:grid-cols-2 sm:grid-cols-1 gap-2">
                 <ng-container *ngFor="let content of collData.contains">
                     <dragonfish-work-card [content]="content" [showAuthor]="true"></dragonfish-work-card>
                 </ng-container>

--- a/apps/bettafish/src/app/pages/portfolio/portfolio-collections/portfolio-collections.component.html
+++ b/apps/bettafish/src/app/pages/portfolio/portfolio-collections/portfolio-collections.component.html
@@ -12,7 +12,7 @@
                 </div>
             </ng-container>
         </ng-container>
-        <div class="grid grid-cols-3 gap-4 mb-6 w-11/12 mx-auto" *ngIf="currPageCollections.docs.length !== 0; else noDocs">
+        <div class="grid 2xl:grid-cols-4 lg:grid-cols-3 md:grid-cols-2 sm:grid-cols-1 gap-2 mb-6 w-11/12 mx-auto" *ngIf="currPageCollections.docs.length !== 0; else noDocs">
             <ng-container
                 *ngFor="let coll of currPageCollections.docs | paginate: {
                     itemsPerPage: currPageCollections.limit,

--- a/apps/bettafish/src/app/pages/portfolio/portfolio-works/portfolio-works.component.html
+++ b/apps/bettafish/src/app/pages/portfolio/portfolio-works/portfolio-works.component.html
@@ -5,7 +5,7 @@
         </div>
     </ng-container>
     <ng-template #notLoading>
-        <div class="grid grid-cols-3 gap-4 w-11/12 mx-auto my-8" *ngIf="contentData.totalDocs !== 0; else noGalleryWorks">
+        <div class="grid 2xl:grid-cols-4 lg:grid-cols-3 md:grid-cols-2 sm:grid-cols-1 gap-2 w-11/12 mx-auto my-8" *ngIf="contentData.totalDocs !== 0; else noGalleryWorks">
             <ng-container
                 *ngFor="
                 let work of contentData.docs

--- a/apps/bettafish/src/app/pages/tags/tag-page.component.html
+++ b/apps/bettafish/src/app/pages/tags/tag-page.component.html
@@ -41,7 +41,7 @@
                     <p>
                         <span [innerHtml]="tags[0].desc | safeHtml"></span>
                     </p>
-                    <div class="grid grid-cols-3 gap-4">
+                    <div class="grid 2xl:grid-cols-4 lg:grid-cols-3 md:grid-cols-2 sm:grid-cols-1 gap-2">
                         <ng-container *ngIf="searchResults">
                             <ng-container *ngFor="let result of searchResults.docs | paginate: {itemsPerPage: searchResults.limit, currentPage: pageNum, totalItems: searchResults.totalDocs}">
                                 <dragonfish-work-card [content]="result" [showAuthor]="false"></dragonfish-work-card>

--- a/libs/client/my-stuff/src/lib/views/blog-form/blog-form.component.html
+++ b/libs/client/my-stuff/src/lib/views/blog-form/blog-form.component.html
@@ -87,7 +87,7 @@
             <div class="w-8/12 mx-auto">
                 <ng-container *ngIf="editMode; else previewBlog">
                     <form [formGroup]="blogForm" *ngIf="editMode">
-                        <div class="grid grid-cols-2 gap-4">
+                        <div class="grid md:grid-cols-2 sm:grid-cols-1 gap-4">
                             <div>
                                 <dragonfish-text-field
                                     [formControlName]="'title'"
@@ -139,7 +139,7 @@
         <ng-template #createMode>
             <div class="w-8/12 mx-auto">
                 <form [formGroup]="blogForm">
-                    <div class="grid grid-cols-2 gap-4">
+                    <div class="grid md:grid-cols-2 sm:grid-cols-1 gap-4">
                         <div>
                             <dragonfish-text-field
                                 [formControlName]="'title'"

--- a/libs/client/my-stuff/src/lib/views/content-page/content-page.component.html
+++ b/libs/client/my-stuff/src/lib/views/content-page/content-page.component.html
@@ -13,7 +13,7 @@
         </ng-container>
 
         <ng-template #hasContent>
-            <div class="grid 2xl:grid-cols-4 xl:grid-cols-3 lg:grid-cols-2 my-4 mx-auto w-11/12 gap-2">
+            <div class="grid 2xl:grid-cols-4 lg:grid-cols-3 md:grid-cols-2 sm:grid-cols-1 gap-2 my-4 mx-auto w-11/12 gap-2">
                 <ng-container *ngFor="let content of myStuff">
                     <dragonfish-content-item [content]="content" (viewItem)="viewContent($event)"></dragonfish-content-item>
                 </ng-container>

--- a/libs/client/my-stuff/src/lib/views/poetry-form/poetry-form.component.html
+++ b/libs/client/my-stuff/src/lib/views/poetry-form/poetry-form.component.html
@@ -34,7 +34,7 @@
                     [placeholder]="'There\'s Something I Gotta Say...'"
                 ></dragonfish-text-field>
 
-                <div class="grid grid-cols-3 gap-4">
+                <div class="grid lg:grid-cols-3 md:grid-cols-2 sm:grid-cols-1 gap-4">
                     <div>
                         <div class="offprint-select">
                             <label>Category</label>
@@ -92,7 +92,7 @@
                 </ng-template>
                 <dragonfish-editor-lite [formControlName]="'body'"></dragonfish-editor-lite>
 
-                <div class="grid grid-cols-2 gap-4">
+                <div class="grid lg:grid-cols-3 md:grid-cols-2 sm:grid-cols-1 gap-4">
                     <div>
                         <div class="offprint-select">
                             <label>Rating</label>

--- a/libs/client/my-stuff/src/lib/views/prose-form/prose-form.component.html
+++ b/libs/client/my-stuff/src/lib/views/prose-form/prose-form.component.html
@@ -32,7 +32,7 @@
                     [placeholder]="'There\'s Something I Gotta Say...'"
                 ></dragonfish-text-field>
 
-                <div class="grid grid-cols-2 gap-4">
+                <div class="grid md:grid-cols-2 sm:grid-cols-1 gap-4">
                     <div>
                         <div class="offprint-select">
                             <label>Category</label>
@@ -86,7 +86,7 @@
                 <label>Long Description</label>
                 <dragonfish-editor-lite [formControlName]="'body'"></dragonfish-editor-lite>
 
-                <div class="grid grid-cols-2 gap-4">
+                <div class="grid md:grid-cols-2 sm:grid-cols-1 gap-4">
                     <div>
                         <div class="offprint-select">
                             <label>Rating</label>

--- a/libs/shared/src/lib/functions/index.ts
+++ b/libs/shared/src/lib/functions/index.ts
@@ -4,3 +4,4 @@ export { isNullOrUndefined } from './is-null-or-undefined';
 export { handleResponse } from './handle-response';
 export { tryParseJsonHttpError } from './try-parse-http-error';
 export { htmlDecode } from './html-decode';
+export { isMobile } from './is-mobile';

--- a/libs/shared/src/lib/functions/is-mobile.ts
+++ b/libs/shared/src/lib/functions/is-mobile.ts
@@ -1,0 +1,3 @@
+export function isMobile(): boolean {
+    return window.innerWidth < 1100;
+}

--- a/libs/shared/src/lib/functions/is-mobile.ts
+++ b/libs/shared/src/lib/functions/is-mobile.ts
@@ -1,3 +1,3 @@
 export function isMobile(): boolean {
-    return window.innerWidth < 1100;
+    return window.innerWidth < 640;
 }


### PR DESCRIPTION
Addresses ticket #641

## Description
The Browse screen looks like this on mobile currently
![image](https://user-images.githubusercontent.com/71996084/131234901-053c3fe8-589c-4baf-85f6-8c19c11405be.png)

Where you are unable to scroll the side menu off screen.

In addition, grids of work cards and other elements are written inconsistently throughout the app, sometimes looking bad on mobile.

## Changes
The Browse screen now looks like this
![image](https://user-images.githubusercontent.com/71996084/131234924-2f842f68-b195-4217-af62-7b3f226546d2.png)

I've removed the side menu, leaving behind only the Search bar, moved to the top. "See More" takes you to What's New, like on the desktop version.

In addition
- Makes global the method to check if the device is mobile
- Uses a more consistent grid layout throughout the site, for work cards, user cards, blog cards, news cards, and collection cards
- Also makes some minor adjustments to My Stuff content forms to account for smaller screen sizes in its grids

## Areas Affected
- [ ] Site Navigation
- [x] Home
- [ ] Sign In/Out
- [ ] Registration
- [ ] Settings

.
- [x] Profile
- [ ] My Stuff (main page)
- [ ] Editor
- [x] Browse
- [ ] Work Card

.
- [ ] Work Page
- [ ] Blog Page
- [x] Collections
- [ ] Comments
- [x] Other Pages

.
- [ ] Account Authentication
- [ ] Dashboard
- [x] Mobile
