### PR TITLE
Create separate Search page

### DIFF
--- a/apps/bettafish/src/app/pages/browse/browse.component.html
+++ b/apps/bettafish/src/app/pages/browse/browse.component.html
@@ -8,15 +8,6 @@
 <div class="flex" style="height: calc(100vh - 52px);">
     <ng-container *ngIf="!mobileMode">
         <dragonfish-pagebar>
-            <form [formGroup]="searchForm" (ngSubmit)="submitSearch()">
-                <dragonfish-text-field
-                    [formControlName]="'query'"
-                    [name]="'query'"
-                    [type]="'text'"
-                    [placeholder]="'Search...'"
-                    [searchBox]="true"
-                ></dragonfish-text-field>
-            </form>
             <div class="my-2 border-b w-full border-white"><!--spacer--></div>
             <a class="link" [routerLink]="['/browse']" [routerLinkActive]="'active'" [routerLinkActiveOptions]="{ exact: true }">
                 <span class="link-icon"><rmx-icon name="sun-line"></rmx-icon></span>A taste of today
@@ -28,17 +19,6 @@
     </ng-container>
     <div class="w-full">
         <ng-scrollbar>
-            <ng-container *ngIf="mobileMode">
-                <form [formGroup]="searchForm" (ngSubmit)="submitSearch()">
-                    <dragonfish-text-field
-                        [formControlName]="'query'"
-                        [name]="'query'"
-                        [type]="'text'"
-                        [placeholder]="'Search...'"
-                        [searchBox]="true"
-                    ></dragonfish-text-field>
-                </form>
-            </ng-container>
             <ng-container *ngIf="route.children.length === 0; else routerOutlet">
                 <div class="w-11/12 mx-auto my-6">
                     <div class="section-header flex flex-row items-center p-2 mb-4">

--- a/apps/bettafish/src/app/pages/browse/browse.component.ts
+++ b/apps/bettafish/src/app/pages/browse/browse.component.ts
@@ -44,16 +44,6 @@ export class BrowseComponent implements OnInit {
             this.loadingNew = false;
         });
     }
-
-    submitSearch() {
-        this.router.navigate(['search'], {
-            relativeTo: this.route,
-            queryParams: { query: this.searchForm.controls.query.value },
-            queryParamsHandling: 'merge',
-        }).catch(() => {
-            this.alerts.error(`Something went wrong! Try again in a little bit.`);
-        });
-    }
     
     @HostListener('window:resize', ['$event'])
     onResize() {

--- a/apps/bettafish/src/app/pages/browse/index.ts
+++ b/apps/bettafish/src/app/pages/browse/index.ts
@@ -15,13 +15,13 @@ export const BrowseRoutes: Routes = [
         component: BrowseComponent,
         children: [
             {
-                path: 'search',
-                component: SearchComponent,
-            },
-            {
                 path: 'newest-works',
                 component: NewestWorksComponent,
             },
         ],
+    },
+    {
+        path: 'search',
+        component: SearchComponent,
     },
 ];

--- a/apps/bettafish/src/app/pages/browse/search/search.component.html
+++ b/apps/bettafish/src/app/pages/browse/search/search.component.html
@@ -1,49 +1,90 @@
-<div class="search-header">
-    <div class="w-11/12 mx-auto pb-2 pt-4 flex flex-row justify-center">
-        <rmx-icon name="search-line" class="mr-4 header"></rmx-icon>
-        <h3 class="text-2xl italic text-white">Search Results</h3>
+<div class="flex" style="height: 100vh">
+    <ng-container *ngIf="!mobileMode">
+        <dragonfish-pagebar>
+            <form [formGroup]="searchForm" (ngSubmit)="submitSearch()">
+                <dragonfish-text-field
+                    [formControlName]="'query'"
+                    [name]="'query'"
+                    [type]="'text'"
+                    [placeholder]="'Search...'"
+                    [searchBox]="true"
+                ></dragonfish-text-field>
+            </form>
+            <button
+                class="py-1.5 px-2.5 rounded-full border-none shadow-none"
+                (click)="submitSearch()"
+            >Search</button>
+        </dragonfish-pagebar>
+    </ng-container>
+    <div class="w-full">
+        <ng-scrollbar>
+            <ng-container *ngIf="mobileMode">
+                <form [formGroup]="searchForm" (ngSubmit)="submitSearch()">
+                    <dragonfish-text-field
+                        [formControlName]="'query'"
+                        [name]="'query'"
+                        [type]="'text'"
+                        [placeholder]="'Search...'"
+                        [searchBox]="true"
+                    ></dragonfish-text-field>
+                </form>
+                <button
+                    class="py-1.5 px-2.5 rounded-full border-none shadow-none"
+                    (click)="submitSearch()"
+                >Search</button>
+            </ng-container>
+            <div class="w-11/12 mx-auto my-6">
+                <div class="search-header">
+                    <div class="w-11/12 mx-auto pb-2 pt-4 flex flex-row justify-center">
+                        <rmx-icon name="search-line" class="mr-4 header"></rmx-icon>
+                        <h3 class="text-2xl italic text-white">Search Results</h3>
+                    </div>
+                </div>
+                
+                <ng-container *ngIf="loading; else notLoading">
+                    <div class="flex flex-row items-center justify-center h-full">
+                        <mat-spinner></mat-spinner>
+                    </div>
+                </ng-container>
+                
+                <ng-template #notLoading>
+                    <div class="w-11/12 mx-auto my-6" *ngIf="searchResults">
+                        <div class="flex flex-row py-4 items-center" *ngIf="searchResults.works.length !== 0">
+                            <rmx-icon name="book-open-line" class="relative -top-0.5 mr-2"></rmx-icon>
+                            <h3 class="text-4xl font-medium">Works</h3>
+                        </div>
+                        <div class="grid 2xl:grid-cols-4 lg:grid-cols-3 md:grid-cols-2 sm:grid-cols-1 gap-2">
+                            <!--Works-->
+                            <ng-container *ngFor="let work of searchResults.works">
+                                <dragonfish-work-card [content]="work" [showAuthor]="true"></dragonfish-work-card>
+                            </ng-container>
+                        </div>
+                
+                        <div class="flex flex-row py-4 items-center" *ngIf="searchResults.blogs.length !== 0">
+                            <rmx-icon name="cup-line" class="relative -top-0.5 mr-2"></rmx-icon>
+                            <h3 class="text-4xl font-medium">Blogs</h3>
+                        </div>
+                        <div class="grid 2xl:grid-cols-4 lg:grid-cols-3 md:grid-cols-2 sm:grid-cols-1 gap-2">
+                            <!--Blogs-->
+                            <ng-container *ngFor="let blog of searchResults.blogs">
+                                <dragonfish-blog-card [blog]="blog" [showAuthor]="true"></dragonfish-blog-card>
+                            </ng-container>
+                        </div>
+                
+                        <div class="flex flex-row py-4 items-center" *ngIf="searchResults.users.length !== 0">
+                            <rmx-icon name="group-line" class="relative -top-0.5 mr-2"></rmx-icon>
+                            <h3 class="text-4xl font-medium">Users</h3>
+                        </div>
+                        <div class="grid 2xl:grid-cols-4 lg:grid-cols-3 md:grid-cols-2 sm:grid-cols-1 gap-2">
+                            <!--Users-->
+                            <ng-container *ngFor="let user of searchResults.users">
+                                <dragonfish-user-card [user]="user"></dragonfish-user-card>
+                            </ng-container>
+                        </div>
+                    </div>
+                </ng-template>
+            </div>
+        </ng-scrollbar>
     </div>
 </div>
 
-<ng-container *ngIf="loading; else notLoading">
-    <div class="flex flex-row items-center justify-center h-full">
-        <mat-spinner></mat-spinner>
-    </div>
-</ng-container>
-
-<ng-template #notLoading>
-    <div class="w-11/12 mx-auto my-6">
-        <div class="flex flex-row py-4 items-center" *ngIf="searchResults.works.length !== 0">
-            <rmx-icon name="book-open-line" class="relative -top-0.5 mr-2"></rmx-icon>
-            <h3 class="text-4xl font-medium">Works</h3>
-        </div>
-        <div class="grid 2xl:grid-cols-4 lg:grid-cols-3 md:grid-cols-2 sm:grid-cols-1 gap-2">
-            <!--Works-->
-            <ng-container *ngFor="let work of searchResults.works">
-                <dragonfish-work-card [content]="work" [showAuthor]="true"></dragonfish-work-card>
-            </ng-container>
-        </div>
-
-        <div class="flex flex-row py-4 items-center" *ngIf="searchResults.blogs.length !== 0">
-            <rmx-icon name="cup-line" class="relative -top-0.5 mr-2"></rmx-icon>
-            <h3 class="text-4xl font-medium">Blogs</h3>
-        </div>
-        <div class="grid 2xl:grid-cols-4 lg:grid-cols-3 md:grid-cols-2 sm:grid-cols-1 gap-2">
-            <!--Blogs-->
-            <ng-container *ngFor="let blog of searchResults.blogs">
-                <dragonfish-blog-card [blog]="blog" [showAuthor]="true"></dragonfish-blog-card>
-            </ng-container>
-        </div>
-
-        <div class="flex flex-row py-4 items-center" *ngIf="searchResults.users.length !== 0">
-            <rmx-icon name="group-line" class="relative -top-0.5 mr-2"></rmx-icon>
-            <h3 class="text-4xl font-medium">Users</h3>
-        </div>
-        <div class="grid 2xl:grid-cols-4 lg:grid-cols-3 md:grid-cols-2 sm:grid-cols-1 gap-2">
-            <!--Users-->
-            <ng-container *ngFor="let user of searchResults.users">
-                <dragonfish-user-card [user]="user"></dragonfish-user-card>
-            </ng-container>
-        </div>
-    </div>
-</ng-template>

--- a/apps/bettafish/src/app/pages/browse/search/search.component.ts
+++ b/apps/bettafish/src/app/pages/browse/search/search.component.ts
@@ -1,7 +1,11 @@
-import { Component } from '@angular/core';
-import { ActivatedRoute } from '@angular/router';
+import { Component, HostListener } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
 import { InitialResults } from '@dragonfish/shared/models/util';
 import { DragonfishNetworkService } from '@dragonfish/client/services';
+import { FormGroup, FormControl } from '@angular/forms';
+import { isMobile } from '@dragonfish/shared/functions';
+import { Constants, setTwoPartTitle } from '@dragonfish/shared/constants';
+import { AlertsService } from '@dragonfish/client/alerts';
 
 @Component({
     selector: 'dragonfish-search',
@@ -11,15 +15,26 @@ import { DragonfishNetworkService } from '@dragonfish/client/services';
 export class SearchComponent {
     loading = false;
     searchResults: InitialResults;
+    searchForm = new FormGroup({
+        query: new FormControl('')
+    });
+    mobileMode = false;
 
-    constructor(private network: DragonfishNetworkService, public route: ActivatedRoute) {}
+    constructor(
+        private network: DragonfishNetworkService,
+        public route: ActivatedRoute,
+        private router: Router,
+        private alerts: AlertsService,
+    ) {}
 
     ngOnInit(): void {
+        setTwoPartTitle(Constants.SEARCH);
         const queryParams = this.route.snapshot.queryParamMap;
         if (queryParams.has('query')) {
             const query = queryParams.get('query');
             this.fetchData(query);
         }
+        this.onResize();
     }
 
     private fetchData(query: string) {
@@ -28,5 +43,22 @@ export class SearchComponent {
             this.searchResults = results;
             this.loading = false;
         });
+    }
+    
+    submitSearch() {
+        this.router.navigate([], {
+            relativeTo: this.route,
+            queryParams: { query: this.searchForm.controls.query.value },
+            queryParamsHandling: 'merge',
+        }).catch(() => {
+            this.alerts.error(`Something went wrong! Try again in a little bit.`);
+        });
+
+        this.fetchData(this.searchForm.controls.query.value);
+    }
+    
+    @HostListener('window:resize', ['$event'])
+    onResize() {
+        this.mobileMode = isMobile();
     }
 }

--- a/libs/api/database/src/lib/content/stores/content-group.store.ts
+++ b/libs/api/database/src/lib/content/stores/content-group.store.ts
@@ -9,12 +9,13 @@ import { ContentFilter, ContentKind, ContentRating, PubStatus } from '@dragonfis
 import { Pseudonym } from '@dragonfish/shared/models/accounts';
 
 /**
- * ## Browse Store
+ * ## Content Group Store
  *
  * Functions that find and filter published content.
  */
 @Injectable()
 export class ContentGroupStore {
+    readonly NEWEST_FIRST = -1
     constructor(
         @InjectModel('Content') private readonly content: PaginateModel<ContentDocument>,
         @InjectModel('Sections') private readonly sections: Model<SectionsDocument>,
@@ -37,7 +38,7 @@ export class ContentGroupStore {
             'audit.published': PubStatus.Published,
         };
         const filteredQuery = await ContentGroupStore.determineContentFilter(query, filter);
-        return this.content.find(filteredQuery).sort({ 'audit.publishedOn': -1 }).limit(6);
+        return this.content.find(filteredQuery).sort({ 'audit.publishedOn': this.NEWEST_FIRST }).limit(6);
     }
 
     public async fetchFirstUpdated() {
@@ -57,7 +58,7 @@ export class ContentGroupStore {
             'audit.isDeleted': false,
             'audit.published': PubStatus.Published,
         };
-        return this.content.find(query).sort({ 'audit.publishedOn': -1 }).limit(6);
+        return this.content.find(query).sort({ 'audit.publishedOn': this.NEWEST_FIRST }).limit(6);
     }
 
     /**
@@ -75,7 +76,7 @@ export class ContentGroupStore {
     ): Promise<PaginateResult<ContentDocument>> {
         const query = { kind: { $in: kinds }, 'audit.isDeleted': false, 'audit.published': PubStatus.Published };
         const filteredQuery = await ContentGroupStore.determineContentFilter(query, filter);
-        const paginateOptions = { sort: { 'audit.publishedOn': -1 }, page: pageNum, limit: 15 };
+        const paginateOptions = { sort: { 'audit.publishedOn': this.NEWEST_FIRST }, page: pageNum, limit: 15 };
 
         if (userId) {
             filteredQuery['author'] = userId;
@@ -131,7 +132,7 @@ export class ContentGroupStore {
             'audit.published': PubStatus.Published,
         };
         const filteredWorksQuery = await ContentGroupStore.determineContentFilter(worksQuery, filter);
-        const works = await this.content.find(filteredWorksQuery).sort({ 'audit.publishedOn': -1 }).limit(3);
+        const works = await this.content.find(filteredWorksQuery).sort({ 'audit.publishedOn': this.NEWEST_FIRST }).limit(3);
 
         const blogsQuery = {
             author: userId,
@@ -140,7 +141,7 @@ export class ContentGroupStore {
             'audit.published': PubStatus.Published,
         };
         const filteredBlogsQuery = await ContentGroupStore.determineContentFilter(blogsQuery, filter);
-        const blogs = await this.content.find(filteredBlogsQuery).sort({ 'audit.publishedOn': -1 }).limit(3);
+        const blogs = await this.content.find(filteredBlogsQuery).sort({ 'audit.publishedOn': this.NEWEST_FIRST }).limit(3);
 
         return { works: works, blogs: blogs };
     }
@@ -161,7 +162,7 @@ export class ContentGroupStore {
     ): Promise<PaginateResult<ContentDocument>> {
         const query = { kind: { $in: kinds }, 'audit.isDeleted': false, 'audit.published': PubStatus.Published };
         const filteredQuery = await ContentGroupStore.determineContentFilter(query, filter);
-        const paginateOptions = { sort: { 'audit.publishedOn': -1 }, page: pageNum, limit: 15 };
+        const paginateOptions = { sort: { 'audit.publishedOn': this.NEWEST_FIRST }, page: pageNum, limit: 15 };
 
         if (userId) {
             filteredQuery['author'] = userId;
@@ -220,7 +221,7 @@ export class ContentGroupStore {
         filter: ContentFilter,
     ): Promise<PaginateResult<ContentDocument>> {
         const paginateOptions: PaginateOptions = {
-            sort: { 'audit.publishedOn': -1 },
+            sort: { 'audit.publishedOn': this.NEWEST_FIRST },
             page: pageNum,
             limit: maxPerPage,
         };

--- a/libs/client/ui/src/lib/components/nav/mobile-nav/mobile-nav.component.html
+++ b/libs/client/ui/src/lib/components/nav/mobile-nav/mobile-nav.component.html
@@ -30,4 +30,14 @@
     >
         <span class="link-icon"><rmx-icon name="group-line"></rmx-icon></span>
     </a>
+    <a
+        class="link"
+        [routerLink]="['/search']"
+        [routerLinkActive]="'active'"
+        [matTooltip]="'Search'"
+        [matTooltipPosition]="'right'"
+        [matTooltipClass]="'offprint-tooltip'"
+    >
+        <span class="link-icon"><rmx-icon name="search-line"></rmx-icon></span>
+    </a>
 </div>

--- a/libs/client/ui/src/lib/components/nav/sidebar/sidebar.component.html
+++ b/libs/client/ui/src/lib/components/nav/sidebar/sidebar.component.html
@@ -104,6 +104,16 @@
         >
             <span class="link-icon"><rmx-icon name="group-line"></rmx-icon></span>
         </a>
+        <a
+            class="link"
+            [routerLink]="['/search']"
+            [routerLinkActive]="'active'"
+            [matTooltip]="'Search'"
+            [matTooltipPosition]="'right'"
+            [matTooltipClass]="'offprint-tooltip'"
+        >
+            <span class="link-icon"><rmx-icon name="search-line"></rmx-icon></span>
+        </a>
     </div>
 
     <a


### PR DESCRIPTION
Part of ticket #637

## Description
Removes Search from the Browse page and splits it off into its own page.

## Changes
- Splits off Search page
- Before, entering new search query then entering did not search for the new query; fixes that
- Adds button to search, instead of just entering
- Adds search icon to side menu and mobile menu
- Fixes content-group doc and adds constant

## Areas Affected
- [x] Site Navigation
- [ ] Home
- [ ] Sign In/Out
- [ ] Registration
- [ ] Settings

.
- [ ] Profile
- [ ] My Stuff (main page)
- [ ] Editor
- [x] Browse
- [ ] Work Card

.
- [ ] Work Page
- [ ] Blog Page
- [ ] Collections
- [ ] Comments
- [x] Other Pages

.
- [ ] Account Authentication
- [ ] Dashboard
- [ ] Mobile
