### PR TITLE
Adds search by genre and searching without query, fixes searching content filter

### DIFF
--- a/apps/api/src/app/controllers/search/search.controller.ts
+++ b/apps/api/src/app/controllers/search/search.controller.ts
@@ -36,7 +36,7 @@ export class SearchController {
         @Query('category') category: WorkKind | null,
         @Query('genre') genre: Genres | null,
         @Query('pageNum') pageNum: number,
-        @Cookies('contentFilter') contentFilter: ContentFilter
+        @Query('filter') filter: ContentFilter,
     ): Promise<PaginateResult<ContentModel>> {
         return await this.searchService.findRelatedContent(
             query,
@@ -45,7 +45,7 @@ export class SearchController {
             category,
             genre,
             pageNum,
-            contentFilter
+            filter
         );
     }
 

--- a/apps/api/src/app/controllers/search/search.controller.ts
+++ b/apps/api/src/app/controllers/search/search.controller.ts
@@ -3,7 +3,7 @@ import { ApiTags } from '@nestjs/swagger';
 import { Cookies } from '@nestjsplus/cookies';
 import { PaginateResult } from 'mongoose';
 
-import { ContentModel, WorkKind } from '@dragonfish/shared/models/content';
+import { ContentModel, Genres, WorkKind } from '@dragonfish/shared/models/content';
 import { InitialResults } from '@dragonfish/shared/models/util';
 import { ContentFilter } from '@dragonfish/shared/models/works';
 import { DragonfishTags } from '@dragonfish/shared/models/util';
@@ -34,6 +34,7 @@ export class SearchController {
         @Query('kind') kind: SearchKind,
         @Query('author') author: string | null,
         @Query('category') category: WorkKind | null,
+        @Query('genre') genre: Genres | null,
         @Query('pageNum') pageNum: number,
         @Cookies('contentFilter') contentFilter: ContentFilter
     ): Promise<PaginateResult<ContentModel>> {
@@ -42,6 +43,7 @@ export class SearchController {
             kind,
             author,
             category,
+            genre,
             pageNum,
             contentFilter
         );

--- a/apps/api/src/app/services/search/search.service.ts
+++ b/apps/api/src/app/services/search/search.service.ts
@@ -7,7 +7,7 @@ import { ContentFilter } from '@dragonfish/shared/models/works';
 import { InitialResults } from '@dragonfish/shared/models/util';
 import { SearchKind } from '@dragonfish/shared/models/search';
 import { ContentGroupStore } from '@dragonfish/api/database/content/stores';
-import { ContentKind, ContentModel, WorkKind } from '@dragonfish/shared/models/content';
+import { ContentKind, ContentModel, Genres, WorkKind } from '@dragonfish/shared/models/content';
 import { PseudonymsStore } from '@dragonfish/api/database/accounts/stores';
 import { Pseudonym } from '@dragonfish/shared/models/accounts';
 
@@ -60,6 +60,7 @@ export class SearchService implements ISearch {
         searchKind: SearchKind,
         author: string | null,
         category: WorkKind | null,
+        genre: Genres | null,
         pageNum: number,
         contentFilter: ContentFilter
     ): Promise<PaginateResult<ContentModel>> {
@@ -96,12 +97,16 @@ export class SearchService implements ISearch {
         if (Object.values(WorkKind).indexOf(category) < 0) {
             category = null;
         }
+        if (Object.values(Genres).indexOf(genre) < 0) {
+            genre = null;
+        }
 
         return await this.contentGroupStore.findRelatedContent(
             parsedQuery,
             kinds,
             authorId,
             category,
+            genre,
             pageNum,
             this.MAX_PER_PAGE,
             contentFilter
@@ -127,6 +132,7 @@ export class SearchService implements ISearch {
             [ContentKind.BlogContent],
             null,
             null,
+            null,
             pageNum,
             this.MAX_PER_PAGE,
             contentFilter
@@ -145,6 +151,7 @@ export class SearchService implements ISearch {
         return await this.contentGroupStore.findRelatedContent(
             parsedQuery,
             [ContentKind.PoetryContent, ContentKind.ProseContent],
+            null,
             null,
             null,
             pageNum,

--- a/apps/api/src/app/services/search/search.service.ts
+++ b/apps/api/src/app/services/search/search.service.ts
@@ -64,7 +64,7 @@ export class SearchService implements ISearch {
         pageNum: number,
         contentFilter: ContentFilter
     ): Promise<PaginateResult<ContentModel>> {
-        const parsedQuery = `"${sanitizeHtml(query)}"`;
+        const parsedQuery = sanitizeHtml(query);
         const kinds: ContentKind[] = [];
         switch (searchKind) {
             case SearchKind.Blog:

--- a/apps/api/src/app/shared/search/search.interface.ts
+++ b/apps/api/src/app/shared/search/search.interface.ts
@@ -1,6 +1,6 @@
 import { PaginateResult } from 'mongoose';
 
-import { ContentFilter, ContentModel, WorkKind } from '@dragonfish/shared/models/content';
+import { ContentFilter, ContentModel, Genres, WorkKind } from '@dragonfish/shared/models/content';
 import { InitialResults } from '@dragonfish/shared/models/util';
 import { SearchKind } from '@dragonfish/shared/models/search';
 import { Pseudonym } from '@dragonfish/shared/models/accounts';
@@ -29,6 +29,7 @@ export interface ISearch {
         searchKind: SearchKind,
         author: string | null,
         category: WorkKind | null,
+        genre: Genres | null,
         pageNum: number,
         contentFilter: ContentFilter
     ): Promise<PaginateResult<ContentModel>>;

--- a/apps/bettafish/src/app/pages/browse/search/search.component.html
+++ b/apps/bettafish/src/app/pages/browse/search/search.component.html
@@ -35,11 +35,16 @@
                             <div>Category</div>
                             <div class="offprint-select">
                                 <ng-select class="custom" [formControlName]="'category'" [searchable]="false" [placeholder]="'Select Category'">
-                                    <ng-option [value]="ANY_CATEGORY">
-                                        {{ ANY_CATEGORY }}
-                                    </ng-option>
                                     <ng-option *ngFor="let category of categoryOptions | keyvalue" [value]="category.key ">
                                         {{ category.value }}
+                                    </ng-option>
+                                </ng-select>
+                            </div>
+                            <div>Genre</div>
+                            <div class="offprint-select">
+                                <ng-select class="custom" [formControlName]="'genre'" [searchable]="false" [placeholder]="'Select Genre'">
+                                    <ng-option *ngFor="let genre of genreOptions | keyvalue" [value]="genre.key ">
+                                        {{ genre.value }}
                                     </ng-option>
                                 </ng-select>
                             </div>

--- a/apps/bettafish/src/app/pages/browse/search/search.component.ts
+++ b/apps/bettafish/src/app/pages/browse/search/search.component.ts
@@ -7,7 +7,7 @@ import { isMobile } from '@dragonfish/shared/functions';
 import { Constants, setTwoPartTitle } from '@dragonfish/shared/constants';
 import { AlertsService } from '@dragonfish/client/alerts';
 import { SearchKind } from '@dragonfish/shared/models/search';
-import { ContentModel, WorkKind } from '@dragonfish/shared/models/content';
+import { ContentModel, Genres, WorkKind } from '@dragonfish/shared/models/content';
 import { Pseudonym } from '@dragonfish/shared/models/accounts';
 
 @Component({
@@ -18,14 +18,14 @@ import { Pseudonym } from '@dragonfish/shared/models/accounts';
 export class SearchComponent implements OnInit {
     kindOptions = SearchKind;
     categoryOptions = WorkKind;
+    genreOptions = Genres;
     loading = false;
-
-    ANY_CATEGORY = "Any";
 
     currentQuery = '';
     currentSearchKind = SearchKind.ProseAndPoetry;
     currentAuthor = '';
     currentCategory: WorkKind = null;
+    currentGenre: Genres = null;
     pageNum = 1;
 
     searchResultWorks: PaginateResult<ContentModel>;
@@ -37,6 +37,7 @@ export class SearchComponent implements OnInit {
         kind: new FormControl(null),
         author: new FormControl(''),
         category: new FormControl(null),
+        genre: new FormControl(null),
     });
     mobileMode = false;
     showAdvancedOptions = false;
@@ -56,6 +57,7 @@ export class SearchComponent implements OnInit {
         this.currentSearchKind = this.parseKind(queryParams.get('kind'));
         this.currentAuthor = queryParams.get('author');
         this.currentCategory = this.parseCategory(queryParams.get('category'));
+        this.currentGenre = this.parseGenre(queryParams.get('genre'));
         if (queryParams.has('page')) {
             this.pageNum = +queryParams.get('page');
         }
@@ -67,7 +69,8 @@ export class SearchComponent implements OnInit {
             query: this.currentQuery,
             kind: this.currentSearchKind,
             author: this.currentAuthor,
-            category: (this.currentCategory || this.ANY_CATEGORY),
+            category: this.currentCategory,
+            genre: this.currentGenre,
         });
 
         if (this.currentQuery) {
@@ -76,9 +79,10 @@ export class SearchComponent implements OnInit {
                 this.currentSearchKind,
                 this.currentAuthor,
                 this.currentCategory,
+                this.currentGenre,
                 this.pageNum);
         }
-        if (this.currentAuthor || this.currentCategory != null) {
+        if (this.currentAuthor || this.currentCategory != null || this.currentGenre != null) {
             this.showAdvancedOptions = true;
         }
         this.onResize();
@@ -96,6 +100,7 @@ export class SearchComponent implements OnInit {
         this.currentSearchKind = this.parseKind(this.searchForm.controls.kind.value);
         this.currentAuthor = this.searchForm.controls.author.value;
         this.currentCategory = this.parseCategory(this.searchForm.controls.category.value);
+        this.currentGenre = this.parseGenre(this.searchForm.controls.genre.value);
         this.pageNum = 1;
 
         if (this.currentQuery) {
@@ -132,6 +137,11 @@ export class SearchComponent implements OnInit {
         return Object.values(WorkKind).indexOf(category) >= 0 ? category : null;
     }
 
+    private parseGenre(genreString: string): Genres {
+        const genre: Genres = genreString as Genres;
+        return Object.values(Genres).indexOf(genre) >= 0 ? genre : null;
+    }
+
     private navigate() {
         let notUserSearch = this.currentSearchKind != SearchKind.User;
         this.router.navigate([], {
@@ -141,6 +151,7 @@ export class SearchComponent implements OnInit {
                 kind: this.currentSearchKind != SearchKind.ProseAndPoetry ? this.currentSearchKind : null,
                 author: (this.currentAuthor && notUserSearch) ? this.currentAuthor : null,
                 category: (this.currentCategory != null && notUserSearch) ? this.currentCategory : null,
+                genre: (this.currentGenre != null && notUserSearch) ? this.currentGenre : null,
                 page: this.pageNum != 1 ? this.pageNum : null,
             },
             queryParamsHandling: 'merge',
@@ -152,6 +163,7 @@ export class SearchComponent implements OnInit {
                 this.currentSearchKind,
                 this.currentAuthor,
                 this.currentCategory,
+                this.currentGenre,
                 this.pageNum
             );
         });
@@ -162,6 +174,7 @@ export class SearchComponent implements OnInit {
         searchKind: SearchKind,
         author: string | null,
         searchCategory: WorkKind | null,
+        genre: Genres | null,
         pageNum: number
         ) {
         this.loading = true;
@@ -173,6 +186,7 @@ export class SearchComponent implements OnInit {
                     searchKind,
                     author,
                     searchCategory,
+                    genre,
                     pageNum
                 ).subscribe((results) => {
                     this.searchResultBlogs = results;
@@ -185,6 +199,7 @@ export class SearchComponent implements OnInit {
                     searchKind,
                     author,
                     searchCategory,
+                    genre,
                     pageNum
                 ).subscribe((results) => {
                     this.searchResultNews = results;
@@ -206,6 +221,7 @@ export class SearchComponent implements OnInit {
                     searchKind,
                     author,
                     searchCategory,
+                    genre,
                     pageNum
                 ).subscribe((results) => {
                     this.searchResultWorks = results;

--- a/apps/bettafish/src/app/pages/browse/search/search.component.ts
+++ b/apps/bettafish/src/app/pages/browse/search/search.component.ts
@@ -9,6 +9,7 @@ import { AlertsService } from '@dragonfish/client/alerts';
 import { SearchKind } from '@dragonfish/shared/models/search';
 import { ContentModel, Genres, WorkKind } from '@dragonfish/shared/models/content';
 import { Pseudonym } from '@dragonfish/shared/models/accounts';
+import { AppQuery } from '@dragonfish/client/repository/app';
 
 @Component({
     selector: 'dragonfish-search',
@@ -47,6 +48,7 @@ export class SearchComponent implements OnInit {
         public route: ActivatedRoute,
         private router: Router,
         private alerts: AlertsService,
+        private appQuery: AppQuery,
     ) {}
 
     ngOnInit(): void {
@@ -66,7 +68,7 @@ export class SearchComponent implements OnInit {
         }
 
         this.searchForm.setValue({
-            query: this.currentQuery,
+            query: (this.currentQuery || ''),
             kind: this.currentSearchKind,
             author: this.currentAuthor,
             category: this.currentCategory,
@@ -103,9 +105,7 @@ export class SearchComponent implements OnInit {
         this.currentGenre = this.parseGenre(this.searchForm.controls.genre.value);
         this.pageNum = 1;
 
-        if (this.currentQuery) {
-            this.navigate()
-        }
+        this.navigate();
     }
 
     /**
@@ -187,7 +187,8 @@ export class SearchComponent implements OnInit {
                     author,
                     searchCategory,
                     genre,
-                    pageNum
+                    pageNum,
+                    this.appQuery.filter,
                 ).subscribe((results) => {
                     this.searchResultBlogs = results;
                     this.loading = false;
@@ -200,7 +201,8 @@ export class SearchComponent implements OnInit {
                     author,
                     searchCategory,
                     genre,
-                    pageNum
+                    pageNum,
+                    this.appQuery.filter,
                 ).subscribe((results) => {
                     this.searchResultNews = results;
                     this.loading = false;
@@ -222,7 +224,8 @@ export class SearchComponent implements OnInit {
                     author,
                     searchCategory,
                     genre,
-                    pageNum
+                    pageNum,
+                    this.appQuery.filter,
                 ).subscribe((results) => {
                     this.searchResultWorks = results;
                     this.loading = false;

--- a/libs/api/database/src/lib/accounts/stores/pseudonyms.store.ts
+++ b/libs/api/database/src/lib/accounts/stores/pseudonyms.store.ts
@@ -34,6 +34,16 @@ export class PseudonymsStore {
      * @param maxPerPage The maximum number of results per page
      */
     async findRelatedUsers(query: string, pageNum: number, maxPerPage: number): Promise<PaginateResult<PseudonymDocument>> {
+        if (!query) {
+            return await this.pseudModel.paginate(
+                {},
+                {
+                    sort: { screenName: 1 },
+                    page: pageNum,
+                    limit: maxPerPage,
+                },
+            );
+        }
         if (query.charAt(0) === '@') {
             return await this.pseudModel.paginate(
                 { userTag: query.substr(1) },
@@ -49,6 +59,7 @@ export class PseudonymsStore {
                 { userTag: query }
             ] },
             {
+                sort: { screenName: 1 },
                 page: pageNum,
                 limit: maxPerPage,
             },

--- a/libs/api/database/src/lib/content/stores/content-group.store.ts
+++ b/libs/api/database/src/lib/content/stores/content-group.store.ts
@@ -202,15 +202,18 @@ export class ContentGroupStore {
         filter: ContentFilter,
     ): Promise<PaginateResult<ContentDocument>> {
         const paginateOptions: PaginateOptions = {
+            sort: { 'audit.publishedOn': this.NEWEST_FIRST },
             page: pageNum,
             limit: maxPerPage,
         };
         const paginateQuery = {
-            $text: { $search: query },
             'audit.published': PubStatus.Published,
             'audit.isDeleted': false,
             kind: { $in: kinds },
         };
+        if (query) {
+            paginateQuery['$text'] = { $search: query };
+        }
         if (authorId) {
             paginateQuery['author'] = authorId;
         }
@@ -221,6 +224,7 @@ export class ContentGroupStore {
             paginateQuery['meta.genres'] = genre;
         }
         await ContentGroupStore.determineContentFilter(paginateQuery, filter);
+        console.log(paginateQuery);
         return await this.content.paginate(paginateQuery, paginateOptions);
     }
 
@@ -329,6 +333,7 @@ export class ContentGroupStore {
      * @private
      */
     private static async determineContentFilter(query, filter: ContentFilter) {
+        console.log(filter);
         switch (filter) {
             case ContentFilter.Everything:
                 break;

--- a/libs/api/database/src/lib/content/stores/content-group.store.ts
+++ b/libs/api/database/src/lib/content/stores/content-group.store.ts
@@ -224,7 +224,6 @@ export class ContentGroupStore {
             paginateQuery['meta.genres'] = genre;
         }
         await ContentGroupStore.determineContentFilter(paginateQuery, filter);
-        console.log(paginateQuery);
         return await this.content.paginate(paginateQuery, paginateOptions);
     }
 
@@ -333,7 +332,6 @@ export class ContentGroupStore {
      * @private
      */
     private static async determineContentFilter(query, filter: ContentFilter) {
-        console.log(filter);
         switch (filter) {
             case ContentFilter.Everything:
                 break;

--- a/libs/api/database/src/lib/content/stores/content-group.store.ts
+++ b/libs/api/database/src/lib/content/stores/content-group.store.ts
@@ -5,7 +5,7 @@ import { ContentDocument, RatingsDocument, ReadingHistoryDocument, SectionsDocum
 import { isNullOrUndefined } from '@dragonfish/shared/functions';
 import { RatingOption } from '@dragonfish/shared/models/reading-history';
 import { JwtPayload } from '@dragonfish/shared/models/auth';
-import { ContentFilter, ContentKind, ContentRating, PubStatus, WorkKind } from '@dragonfish/shared/models/content';
+import { ContentFilter, ContentKind, ContentRating, Genres, PubStatus, WorkKind } from '@dragonfish/shared/models/content';
 import { Pseudonym } from '@dragonfish/shared/models/accounts';
 
 /**
@@ -196,6 +196,7 @@ export class ContentGroupStore {
         kinds: ContentKind[],
         authorId: string | null,
         category: WorkKind | null,
+        genre: Genres | null,
         pageNum: number,
         maxPerPage: number,
         filter: ContentFilter,
@@ -215,6 +216,9 @@ export class ContentGroupStore {
         }
         if (category) {
             paginateQuery['meta.category'] = category;
+        }
+        if (genre) {
+            paginateQuery['meta.genres'] = genre;
         }
         await ContentGroupStore.determineContentFilter(paginateQuery, filter);
         return await this.content.paginate(paginateQuery, paginateOptions);

--- a/libs/client/services/src/lib/dragonfish-network.service.ts
+++ b/libs/client/services/src/lib/dragonfish-network.service.ts
@@ -1,4 +1,4 @@
-import { InviteCodes, User } from '@dragonfish/shared/models/users';
+import { InviteCodes } from '@dragonfish/shared/models/users';
 import { Collection, CollectionForm } from '@dragonfish/shared/models/collections';
 import { Comment, CommentForm, CommentKind } from '@dragonfish/shared/models/comments';
 import {
@@ -295,6 +295,7 @@ export class DragonfishNetworkService {
      * @param author (Optional) The author of content that searching for
      * @param category (Optional) The category of content that searching for
      * @param pageNum The current results page
+     * @param contentFilter The mature/explicit/etc. content filter to apply
      */
     public findRelatedContent(
         query: string,
@@ -303,11 +304,13 @@ export class DragonfishNetworkService {
         category: WorkKind | null,
         genre: Genres | null,
         pageNum: number,
+        contentFilter: ContentFilter,
     ): Observable<PaginateResult<ContentModel>> {
         return handleResponse(
             this.http.get<PaginateResult<ContentModel>>(
-                `${this.baseUrl}/search/find-related-content?query=` +
-                    `${query}&kind=${kind}&author=${author}&category=${category}&genre=${genre}&pageNum=${pageNum}`,
+                `${this.baseUrl}/search/find-related-content?`
+                 + `query=${query}&kind=${kind}&author=${author}&category=${category}&genre=${genre}`
+                 + `&pageNum=${pageNum}&filter=${contentFilter}`,
                 { observe: 'response', withCredentials: true },
             ),
         );

--- a/libs/client/services/src/lib/dragonfish-network.service.ts
+++ b/libs/client/services/src/lib/dragonfish-network.service.ts
@@ -6,6 +6,7 @@ import {
     ContentKind,
     ContentModel,
     FormType,
+    Genres,
     NewsContentModel,
     PubChange,
     PubContent,
@@ -300,12 +301,13 @@ export class DragonfishNetworkService {
         kind: SearchKind,
         author: string | null,
         category: WorkKind | null,
+        genre: Genres | null,
         pageNum: number,
     ): Observable<PaginateResult<ContentModel>> {
         return handleResponse(
             this.http.get<PaginateResult<ContentModel>>(
                 `${this.baseUrl}/search/find-related-content?query=` +
-                    `${query}&kind=${kind}&author=${author}&category=${category}&pageNum=${pageNum}`,
+                    `${query}&kind=${kind}&author=${author}&category=${category}&genre=${genre}&pageNum=${pageNum}`,
                 { observe: 'response', withCredentials: true },
             ),
         );

--- a/libs/shared/src/lib/models/works/genres.enum.ts
+++ b/libs/shared/src/lib/models/works/genres.enum.ts
@@ -1,3 +1,6 @@
+/**
+ * @deprecated
+ */
 export type Genres = GenresPoetry | GenresFiction;
 
 export enum GenresFiction {


### PR DESCRIPTION
Partially addresses ticket #637

## Description
Adds ability to search by genre and searching without a query (so it can list all entries of a category, or with the advanced options' restrictions). Fixes content filter in search.

## Changes
- Adds ability to search works by genre. Searching by multiple genres is not implemented yet.
- Adds ability to search without a query, so it can search by the other advanced options without needing to search the title, or it can just display all works/users.
- Fixes content filter in search. It previously looked at a now-unused cookie for the filter.
- Removes "Any" category listing.
- Sorts user results by name.

## Areas Affected
- [ ] Site Navigation
- [ ] Home
- [ ] Sign In/Out
- [ ] Registration
- [ ] Settings

.
- [ ] Profile
- [ ] My Stuff (main page)
- [ ] Editor
- [ ] Browse
- [ ] Work Card

.
- [ ] Work Page
- [ ] Blog Page
- [ ] Collections
- [ ] Comments
- [x] Search
- [ ] Other Pages

.
- [ ] Account Authentication
- [ ] Dashboard
- [ ] Mobile
