### PR TITLE
Fixes display of genres on story's main page

### DIFF
--- a/libs/client/ui/src/lib/components/tag-badge/tag-badge.component.html
+++ b/libs/client/ui/src/lib/components/tag-badge/tag-badge.component.html
@@ -34,7 +34,7 @@
         </ng-container>
     </ng-container>
     <ng-container *ngIf="kind === kinds.Genre">
-        <ng-container [ngSwitch]="genre">
+        <ng-container [ngSwitch]="genres[genre]">
             <ng-container *ngSwitchCase="genres.Comedy">
                 <rmx-icon name="emotion-laugh-line"></rmx-icon>
                 <span>Comedy</span>


### PR DESCRIPTION
Addresses ticket #689

## Description
All genre tags with spaces in the name are displayed as "Action/Adventure".

## Changes
Properly accesses the Genre enum name with Genre[genre], fixing the display.

## Areas Affected
- [ ] Site Navigation
- [ ] Home
- [ ] Sign In/Out
- [ ] Registration
- [ ] Settings

.
- [ ] Profile
- [ ] My Stuff (main page)
- [ ] Editor
- [ ] Browse
- [ ] Work Card

.
- [x] Work Page
- [ ] Blog Page
- [ ] Collections
- [ ] Comments
- [ ] Search
- [ ] Other Pages

.
- [ ] Account Authentication
- [ ] Dashboard
- [ ] Mobile
