### PR TITLE
Redirects profile 'home' links to current main page

### DIFF
--- a/apps/bettafish/src/app/app-routing.module.ts
+++ b/apps/bettafish/src/app/app-routing.module.ts
@@ -36,7 +36,6 @@ const routes: Routes = [
     },
     {
         path: 'portfolio', redirectTo: 'profile',
-        // loadChildren: () => import('@dragonfish/client/profile').then((m) => m.ProfileModule),
     },
     {
         path: 'prose',

--- a/libs/client/profile/src/lib/profile-routing.module.ts
+++ b/libs/client/profile/src/lib/profile-routing.module.ts
@@ -26,6 +26,9 @@ const routes: Routes = [
                 component: HomeComponent,
             },
             {
+                path: 'home', redirectTo: '',
+            },
+            {
                 path: 'works',
                 component: WorksComponent,
             },


### PR DESCRIPTION
Addresses ticket #706

## Description
Old profile links that use "home" no longer work

## Changes
- Redirects profile 'home' links to current main page
- Removes commented out code

## Areas Affected
- [ ] Site Navigation
- [ ] Home
- [ ] Sign In/Out
- [ ] Registration
- [ ] Settings

.
- [x] Profile
- [ ] My Stuff (main page)
- [ ] Editor
- [ ] Browse
- [ ] Work Card

.
- [ ] Work Page
- [ ] Blog Page
- [ ] Collections
- [ ] Comments
- [ ] Search
- [ ] Other Pages

.
- [ ] Account Authentication
- [ ] Dashboard
- [ ] Mobile
