### PR TITLE
Fixes advanced searches by disabling strict queries for searches

### DIFF
--- a/libs/api/database/src/lib/content/stores/content-group.store.ts
+++ b/libs/api/database/src/lib/content/stores/content-group.store.ts
@@ -205,6 +205,9 @@ export class ContentGroupStore {
             sort: { 'audit.publishedOn': this.NEWEST_FIRST },
             page: pageNum,
             limit: maxPerPage,
+            options: {
+                strictQuery: false,
+            },
         };
         const paginateQuery = {
             'audit.published': PubStatus.Published,


### PR DESCRIPTION
Addresses ticket #713

## Description
Starting in Mongoose 6, queries prevent access of fields that aren't present in the schema, which caused issues when using the Content schema to access prose-exclusive fields.

## Changes
Disables strict queries for searches.

## Areas Affected
- [ ] Site Navigation
- [ ] Home
- [ ] Sign In/Out
- [ ] Registration
- [ ] Settings

.
- [ ] Profile
- [ ] My Stuff (main page)
- [ ] Editor
- [ ] Browse
- [ ] Work Card

.
- [ ] Work Page
- [ ] Blog Page
- [ ] Collections
- [ ] Comments
- [x] Search
- [ ] Other Pages

.
- [ ] Account Authentication
- [ ] Dashboard
- [ ] Mobile
