### PR TITLE
Updates blog and work counts on any modification

### DIFF
--- a/apps/api/src/app/services/content/sections.service.ts
+++ b/apps/api/src/app/services/content/sections.service.ts
@@ -1,12 +1,17 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { ContentStore } from '@dragonfish/api/database/content/stores';
 import { Section, SectionForm, PublishSection } from '@dragonfish/shared/models/sections';
+import { PseudonymsStore } from '@dragonfish/api/database/accounts/stores';
+import { ContentKind } from '@dragonfish/shared/models/content';
 
 @Injectable()
 export class SectionsService {
     private readonly logger: Logger = new Logger(SectionsService.name);
 
-    constructor(private readonly content: ContentStore) {}
+    constructor(
+        private readonly content: ContentStore,
+        private readonly pseudonyms: PseudonymsStore,
+    ) {}
 
     async fetchOneById(sectionId: string, published?: boolean): Promise<Section> {
         return await this.content.fetchSectionById(sectionId, published);
@@ -17,18 +22,37 @@ export class SectionsService {
     }
 
     async create(user: string, contentId: string, sectionInfo: SectionForm): Promise<Section> {
+        await this.updateCounts(user);
         return await this.content.createSection(user, contentId, sectionInfo);
     }
 
     async save(user: string, contentId: string, sectionId: string, sectionInfo: SectionForm): Promise<Section> {
+        await this.updateCounts(user);
         return await this.content.editSection(user, contentId, sectionId, sectionInfo);
     }
 
     async publish(user: string, contentId: string, sectionId: string, pubStatus: PublishSection): Promise<Section> {
+        await this.updateCounts(user);
         return await this.content.publishSection(user, contentId, sectionId, pubStatus);
     }
 
     async delete(user: string, contentId: string, sectionId: string): Promise<void> {
+        await this.updateCounts(user);
         return await this.content.deleteSection(user, contentId, sectionId);
+    }
+
+    /**
+     * Updates user's counts of both blogs and works
+     * @param user 
+     */
+    private async updateCounts(user: string) {
+        await this.pseudonyms.updateBlogCount(
+            user,
+            await this.content.countContent(user, [ContentKind.BlogContent]),
+        );
+        await this.pseudonyms.updateWorkCount(
+            user,
+            await this.content.countContent(user, [ContentKind.ProseContent, ContentKind.PoetryContent]),
+        );
     }
 }


### PR DESCRIPTION
Addresses ticket #

## Description
Currently, we update a user's blog and work counts only when they publish that work.

## Changes
This updates the counts for both blogs and works whenever the user modifies either. This isn't an expensive operation, so it shouldn't be an issue. We can cut back on this later, once we're sure users all have accurate counts.

## Areas Affected
- [ ] Site Navigation
- [ ] Home
- [ ] Sign In/Out
- [ ] Registration
- [ ] Settings

.
- [x] Profile
- [ ] My Stuff (main page)
- [ ] Editor
- [ ] Browse
- [ ] Work Card

.
- [ ] Work Page
- [ ] Blog Page
- [ ] Collections
- [ ] Comments
- [ ] Search
- [ ] Other Pages

.
- [ ] Account Authentication
- [ ] Dashboard
- [ ] Mobile
