### PR TITLE
fix news cards not having the correct "Continue Reading" links

### DIFF
--- a/libs/client/ui/src/lib/components/news-card/news-card.component.html
+++ b/libs/client/ui/src/lib/components/news-card/news-card.component.html
@@ -36,7 +36,7 @@
         <div>
             <a
                 class="continue-reading"
-                [routerLink]="['/news', post._id, post.title | slugify]"
+                [routerLink]="['/profile', post.author._id, post.author.userTag, 'post', post._id, post.title | slugify]"
             >
                 Continue Reading
                 <rmx-icon name="arrow-right-s-line"></rmx-icon>


### PR DESCRIPTION
Addresses ticket #

## Description

fixes news card "Continue Reading" links still pointing to the old URL

## Changes


## Areas Affected
- [ ] Site Navigation
- [x] Home
- [ ] Sign In/Out
- [ ] Registration
- [ ] Settings

.
- [ ] Profile
- [ ] My Stuff (main page)
- [ ] Editor
- [ ] Browse
- [ ] Work Card

.
- [ ] Work Page
- [ ] Blog Page
- [ ] Collections
- [ ] Comments
- [ ] Search
- [ ] Other Pages

.
- [ ] Account Authentication
- [ ] Dashboard
- [ ] Mobile
