### PR TITLE
Fix poetry submission and tags

### DIFF
--- a/apps/api/src/app/controllers/search/search.controller.ts
+++ b/apps/api/src/app/controllers/search/search.controller.ts
@@ -1,6 +1,5 @@
 import { Controller, Get, Inject, Query } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
-import { Cookies } from '@nestjsplus/cookies';
 import { PaginateResult } from 'mongoose';
 
 import { ContentModel } from '@dragonfish/shared/models/content';

--- a/apps/api/src/app/services/content/tags.service.ts
+++ b/apps/api/src/app/services/content/tags.service.ts
@@ -1,14 +1,12 @@
-import { Inject, Injectable, NotFoundException } from "@nestjs/common";
-import { TagsStore } from "@dragonfish/api/database/content/stores";
-import { TagKind, TagsModel, TagsForm } from "@dragonfish/shared/models/content/tags";
-import { TagsTree } from "@dragonfish/shared/models/content/tags/tags.model";
-import { IContent, ITagsService } from "../../shared/content";
+import { Inject, Injectable, NotFoundException } from '@nestjs/common';
+import { TagsStore } from '@dragonfish/api/database/content/stores';
+import { TagKind, TagsModel, TagsForm } from '@dragonfish/shared/models/content/tags';
+import { TagsTree } from '@dragonfish/shared/models/content/tags/tags.model';
+import { IContent, ITagsService } from '../../shared/content';
 
 @Injectable()
 export class TagsService implements ITagsService {
-    constructor(
-        private readonly tagsStore: TagsStore,
-        @Inject('IContent') private readonly contentService: IContent) { }
+    constructor(private readonly tagsStore: TagsStore, @Inject('IContent') private readonly contentService: IContent) {}
 
     async fetchTagsTrees(kind: TagKind): Promise<TagsTree[]> {
         return await this.tagsStore.fetchTagsTrees(kind);
@@ -37,7 +35,7 @@ export class TagsService implements ITagsService {
 
         // Clear parent for its children
         const tagTree = await this.tagsStore.fetchDescendants(id);
-        for (let child of tagTree.children) {
+        for (const child of tagTree.children) {
             const form: TagsForm = {
                 name: child.name,
                 desc: child.desc,

--- a/libs/api/database/src/lib/content/schemas/poetry-content.schema.ts
+++ b/libs/api/database/src/lib/content/schemas/poetry-content.schema.ts
@@ -65,7 +65,7 @@ export class PoetryContentDocument extends Document implements PoetryContent {
     sections?: string[] | SectionInfo[];
 
     @Prop({ type: [{ type: String, ref: 'Tags' }] })
-    tags: TagsModel[];
+    tags?: string[] | TagsModel[];
 }
 
 export const PoetryContentSchema = SchemaFactory.createForClass(PoetryContentDocument);

--- a/libs/api/database/src/lib/content/stores/content.store.ts
+++ b/libs/api/database/src/lib/content/stores/content.store.ts
@@ -22,6 +22,7 @@ import { UsersStore } from '../../users';
 import { ApprovalQueueStore } from '../../approval-queue';
 import { PublishSection, SectionForm } from '@dragonfish/shared/models/sections';
 import { SectionsStore } from './sections.store';
+import { MIN_PROSE_LENGTH } from '@dragonfish/shared/constants/content-constants';
 
 /**
  * ## Content Store
@@ -275,8 +276,8 @@ export class ContentStore {
             'audit.isDeleted': false,
         });
 
-        if (thisContent.kind !== ContentKind.PoetryContent && thisContent.stats.words < 750) {
-            throw new BadRequestException(`Content that isn't poetry needs to have a minimum word-count of 750. `);
+        if (thisContent.kind !== ContentKind.PoetryContent && thisContent.stats.words < MIN_PROSE_LENGTH) {
+            throw new BadRequestException(`Content that isn't poetry needs to have a minimum word-count of ${MIN_PROSE_LENGTH}. `);
         }
 
         await this.queue.addOneWork(contentId);

--- a/libs/api/database/src/lib/content/stores/poetry.store.ts
+++ b/libs/api/database/src/lib/content/stores/poetry.store.ts
@@ -35,6 +35,7 @@ export class PoetryStore {
             'meta.genres': poetryInfo.genres,
             'meta.rating': poetryInfo.rating,
             'meta.status': poetryInfo.status,
+            tags: poetryInfo.tags,
         });
 
         return await newPoetry.save();
@@ -60,6 +61,7 @@ export class PoetryStore {
                     'meta.genres': poetryInfo.genres,
                     'meta.rating': poetryInfo.rating,
                     'meta.status': poetryInfo.status,
+                    tags: poetryInfo.tags,
                 },
                 { new: true },
             );
@@ -76,6 +78,7 @@ export class PoetryStore {
                     'meta.genres': poetryInfo.genres,
                     'meta.rating': poetryInfo.rating,
                     'meta.status': poetryInfo.status,
+                    tags: poetryInfo.tags,
                 },
                 { new: true },
             );

--- a/libs/client/repository/src/lib/work-page/work-page.service.ts
+++ b/libs/client/repository/src/lib/work-page/work-page.service.ts
@@ -13,6 +13,7 @@ import { SectionsService } from './sections';
 import { PublishSection, Section } from '@dragonfish/shared/models/sections';
 import { RatingOption } from '@dragonfish/shared/models/reading-history';
 import { ContentLibraryRepository } from '../content-library';
+import { MIN_PROSE_LENGTH } from '@dragonfish/shared/constants/content-constants';
 
 @Injectable({ providedIn: 'root' })
 export class WorkPageService {
@@ -94,8 +95,8 @@ export class WorkPageService {
     }
 
     public publish(contentId: string) {
-        if (this.workQuery.wordCount < 750) {
-            this.alerts.error(`Works need a minimum of 750 words before you can submit.`);
+        if (this.workQuery.contentKind !== ContentKind.PoetryContent && this.workQuery.wordCount < MIN_PROSE_LENGTH) {
+            this.alerts.error(`Works other than poetry need a minimum of ${MIN_PROSE_LENGTH} words before you can submit.`);
             return of(null).pipe(take(1));
         }
 

--- a/libs/client/ui/src/lib/components/work-form/work-form.component.ts
+++ b/libs/client/ui/src/lib/components/work-form/work-form.component.ts
@@ -184,6 +184,7 @@ export class WorkFormComponent implements OnInit {
             collection: true,
             form: this.fields.form.value,
             genres: this.fields.genres.value,
+            tags: this.fields.tags.value,
             rating: this.fields.rating.value,
             status: this.fields.status.value,
         };

--- a/libs/shared/src/lib/constants/content-constants.ts
+++ b/libs/shared/src/lib/constants/content-constants.ts
@@ -1,6 +1,7 @@
 export const MIN_TEXT_LENGTH = 3;
 export const MAX_TITLE_LENGTH = 120;
 export const MAX_DESC_LENGTH = 250;
+export const MIN_PROSE_LENGTH = 750;
 
 export const MIN_GENRES = 1;
 export const MAX_GENRES = 3;

--- a/libs/shared/src/lib/models/content/poetry/create-poetry.model.ts
+++ b/libs/shared/src/lib/models/content/poetry/create-poetry.model.ts
@@ -12,6 +12,7 @@ export interface CreatePoetry {
     readonly collection: boolean;
     readonly form: PoetryForm;
     readonly genres: Genres[];
+    readonly tags: string[];
     readonly rating: ContentRating;
     readonly status: WorkStatus;
 }


### PR DESCRIPTION
## Description
Poetry has an unintended minimum word count of 750, and fandom tags aren't saved for poetry

## Changes
- Removes 750 word minimum from poetry
- Makes 750 a constant
- Fixes other Lint issues
- Saves and retrieves fandom tags for poetry

## Areas Affected
- [ ] Site Navigation
- [ ] Home
- [ ] Sign In/Out
- [ ] Registration
- [ ] Settings

.
- [ ] Profile
- [ ] My Library
- [ ] Bookshelves
- [ ] Editor
- [ ] Browse
- [ ] Work Card

.
- [x] Work Page
- [ ] Blog Page
- [ ] Comments
- [ ] Search
- [ ] Other Pages

.
- [ ] Account Authentication
- [ ] Dashboard
- [ ] Mobile
