### PR TITLE
Attempts to fix emoji picker error by removing style import

### DIFF
--- a/apps/bettafish/src/styles.scss
+++ b/apps/bettafish/src/styles.scss
@@ -44,7 +44,6 @@ $bettafish-theme: mat-light-theme((
 @import './mixins.scss';
 @import '~ngx-tabset/ngx-tabset.scss';
 @import "~@ng-select/ng-select/themes/default.theme.css";
-@import '~@ctrl/ngx-emoji-mart/picker';
 
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@100;200;300;400;500;600;700;800;900&family=Josefin+Sans:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;1,100;1,200;1,300;1,400;1,500;1,600;1,700&display=swap');
 


### PR DESCRIPTION
## Description

There's a build error involving the emoji picker
./apps/bettafish/src/styles.scss - Error: Module build failed (from ./node_modules/mini-css-extract-plugin/dist/loader.js):
ModuleBuildError: Module build failed (from ./node_modules/sass-loader/dist/cjs.js):
SassError: Can't find stylesheet to import.
   ╷
47 │ @import '~@ctrl/ngx-emoji-mart/picker';
   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ╵

## Changes

Removes the style import

## Areas Affected
- [ ] Site Navigation
- [ ] Home
- [ ] Sign In/Out
- [ ] Registration
- [ ] Settings

.
- [ ] Profile
- [ ] My Library
- [ ] Bookshelves
- [x] Editor
- [ ] Browse
- [ ] Work Card

.
- [ ] Work Page
- [ ] Blog Page
- [ ] Comments
- [ ] Search
- [ ] Other Pages

.
- [ ] Account Authentication
- [ ] Dashboard
- [ ] Mobile
