### PR TITLE
Removes edit icon from cover art to allow right-clicking

### DIFF
--- a/libs/client/work-page/src/lib/components/work-banner/work-banner.component.html
+++ b/libs/client/work-page/src/lib/components/work-banner/work-banner.component.html
@@ -6,11 +6,8 @@
                     class="edit-cover-art rounded-md"
                     [matTooltip]="'Edit Cover Art'"
                     [matTooltipClass]="'offprint-tooltip'"
-                    (mouseenter)="addEditIcon = true"
-                    (mouseleave)="addEditIcon = false"
                     (click)="uploadCoverArt(content._id, content.kind)"
                 >
-                    <span class="edit-icon" *ngIf="addEditIcon"><rmx-icon name="image-edit-line"></rmx-icon></span>
                     <img class="rounded-md" [src]="content.meta.coverArt" />
                 </div>
             </ng-container>

--- a/libs/client/work-page/src/lib/components/work-banner/work-banner.component.scss
+++ b/libs/client/work-page/src/lib/components/work-banner/work-banner.component.scss
@@ -12,16 +12,6 @@ div.header {
 
 div.edit-cover-art {
     @apply relative cursor-pointer mr-6;
-    span.edit-icon {
-        @apply absolute rounded-md w-full h-full;
-        rmx-icon {
-            @apply relative;
-            width: 3.125rem;
-            top: 38%;
-            left: 38%;
-            color: black;
-        }
-    }
     img {
         @apply object-contain rounded-md border-4 border-white;
         max-width: 180px;
@@ -34,9 +24,6 @@ div.edit-cover-art {
     &:hover {
         img {
             @apply blur-lg;
-        }
-        span.edit-icon {
-            @apply backdrop-blur;
         }
     }
 }

--- a/libs/client/work-page/src/lib/components/work-banner/work-banner.component.ts
+++ b/libs/client/work-page/src/lib/components/work-banner/work-banner.component.ts
@@ -18,7 +18,6 @@ export class WorkBannerComponent implements OnInit {
     @Input() content;
     contentUrl = [];
     moreMenuOpened = false;
-    addEditIcon = false;
     tagKind = TagKind;
     genres = Genres;
     pubStatus = PubStatus;


### PR DESCRIPTION
Closes #734

## Description
Work authors would like to be able to right-click their cover images, so this removes the edit icon overlay.

## Changes
- Removes edit icon from cover art if you're the work's author
- Allows author to right click image
- All use cases remain the same, can still click to edit

## Areas Affected
- [ ] Site Navigation
- [ ] Home
- [ ] Sign In/Out
- [ ] Registration
- [ ] Settings

.
- [ ] Profile
- [ ] My Library
- [ ] Bookshelves
- [ ] Editor
- [ ] Browse
- [ ] Work Card

.
- [x] Work Page
- [ ] Blog Page
- [ ] Comments
- [ ] Search
- [ ] Other Pages

.
- [ ] Account Authentication
- [ ] Dashboard
- [ ] Mobile
