### PR TITLE
Makes the profile icon a constant size

### DIFF
--- a/libs/client/ui/src/lib/components/nav/sidebar/sidebar.component.html
+++ b/libs/client/ui/src/lib/components/nav/sidebar/sidebar.component.html
@@ -17,7 +17,7 @@
             >
                 <span class="link-icon">
                     <ng-container *ngIf="!userMenu; else userMenuOpened">
-                        <img [src]="profile.profile.avatar" class="block object-cover rounded-md" style="max-width: 44px;" [alt]="'avatar'">
+                        <img [src]="profile.profile.avatar" class="block object-cover rounded-md" style="width: 44px;" [alt]="'avatar'">
                     </ng-container>
                     <ng-template #userMenuOpened>
                         <rmx-icon name="close-line"></rmx-icon>


### PR DESCRIPTION
Closes #755

## Description
Users with small avatars run into the issue of their profile icon being small too

## Changes
- Makes the profile icon a constant size, instead of specifying a max size
- Small images won't shrink the profile icon

## Areas Affected
- [x] Site Navigation
- [ ] Home
- [ ] Sign In/Out
- [ ] Registration
- [ ] Settings

.
- [ ] Profile
- [ ] My Library
- [ ] Bookshelves
- [ ] Editor
- [ ] Browse
- [ ] Work Card

.
- [ ] Work Page
- [ ] Blog Page
- [ ] Comments
- [ ] Search
- [ ] Other Pages

.
- [ ] Account Authentication
- [ ] Dashboard
- [ ] Mobile
