### PR TITLE
Adds log-in button to mobile menu; changes appearance of avatar in menu

### DIFF
--- a/libs/client/ui/src/lib/components/auth/user-menu/user-menu.component.html
+++ b/libs/client/ui/src/lib/components/auth/user-menu/user-menu.component.html
@@ -1,91 +1,184 @@
 <ng-container *ngIf="pseudQuery.current$ | async as user">
-    <div class="absolute top-0 z-50 flex w-full" style="box-shadow: var(--dropshadow); left: 4.125rem;">
-        <div class="menu-box border-gray-600 dark:border-white">
-            <div class="cover-pic absolute z-10 w-full h-36 left-0 pointer-events-none" [ngClass]="user.profile.coverPic ? '' : 'has-accent'">
-                <img
-                    class="object-cover object-center w-full h-full"
-                    [src]="user.profile.coverPic"
-                    [alt]="'avatar'"
-                    *ngIf="user.profile.coverPic"
-                />
-            </div>
-            <div class="user-header">
-                <div class="flex flex-row items-center">
-                    <div class="user-avatar">
-                        <img [src]="user.profile.avatar" [alt]="'avatar'" />
-                    </div>
-                    <div class="ml-2">
-                        <div class="flex items-center">
-                            <dragonfish-role-badge [roles]="user.roles" [size]="'small'"></dragonfish-role-badge>
-                            <h2 class="text-2xl font-medium relative top-0.5">
-                                {{ user.screenName }}
-                            </h2>
+    <ng-container *ngIf="!mobileMode; else mobile">
+        <div class="absolute top-0 z-50 flex w-full" style="box-shadow: var(--dropshadow); left: 4.125rem;">
+            <div class="menu-box border-gray-600 dark:border-white">
+                <div class="cover-pic absolute z-10 w-full h-36 left-0 pointer-events-none" [ngClass]="user.profile.coverPic ? '' : 'has-accent'">
+                    <img
+                        class="object-cover object-center w-full h-full"
+                        [src]="user.profile.coverPic"
+                        [alt]="'avatar'"
+                        *ngIf="user.profile.coverPic"
+                    />
+                </div>
+                <div class="user-header">
+                    <div class="flex flex-row items-center">
+                        <div class="user-avatar">
+                            <img [src]="user.profile.avatar" [alt]="'avatar'" />
                         </div>
-                        <h3 class="text-sm font-medium">
-                            @{{ user.userTag }}
-                        </h3>
-                        <div class="flex items-center text-xs">
-                            <span>{{ user.stats.followers | abbreviate }} follower{{ user.stats.followers | pluralize }}</span>
-                            <span class="mx-1">|</span>
-                            <span>{{ user.stats.following | abbreviate }} following</span>
+                        <div class="ml-2">
+                            <div class="flex items-center">
+                                <dragonfish-role-badge [roles]="user.roles" [size]="'small'"></dragonfish-role-badge>
+                                <h2 class="text-2xl font-medium relative top-0.5">
+                                    {{ user.screenName }}
+                                </h2>
+                            </div>
+                            <h3 class="text-sm font-medium">
+                                @{{ user.userTag }}
+                            </h3>
+                            <div class="flex items-center text-xs">
+                                <span>{{ user.stats.followers | abbreviate }} follower{{ user.stats.followers | pluralize }}</span>
+                                <span class="mx-1">|</span>
+                                <span>{{ user.stats.following | abbreviate }} following</span>
+                            </div>
                         </div>
                     </div>
                 </div>
+                <div class="my-2"></div>
+                <div class="tab-buttons border-gray-600 dark:border-white">
+                    <div
+                        class="button border-gray-600 dark:border-white"
+                        [ngClass]="{'active': currTab === tabs.QuickOptionsTab}"
+                        (click)="switchTab(tabs.QuickOptionsTab)"
+                    >
+                        <rmx-icon name="user-settings-line"></rmx-icon>
+                        <span class="label">Account</span>
+                    </div>
+                    <div
+                        class="button border-gray-600 dark:border-white"
+                        [ngClass]="{'active': currTab === tabs.FriendsTab}"
+                        (click)="switchTab(tabs.FriendsTab)"
+                    >
+                        <rmx-icon name="group-line"></rmx-icon>
+                        <span class="label">Friends</span>
+                    </div>
+                    <div
+                        class="button border-gray-600 dark:border-white"
+                        [ngClass]="{'active': currTab === tabs.MessagesTab}"
+                        (click)="switchTab(tabs.MessagesTab)"
+                    >
+                        <rmx-icon name="chat-smile-3-line"></rmx-icon>
+                        <span class="label">Messages</span>
+                    </div>
+                    <div
+                        class="button border-gray-600 dark:border-white active"
+                        [ngClass]="{'active': currTab === tabs.NotificationsTab}"
+                        (click)="switchTab(tabs.NotificationsTab)"
+                        [matBadge]="notifications.count"
+                        [matBadgeHidden]="notifications.count === 0"
+                    >
+                        <rmx-icon name="notification-3-line"></rmx-icon>
+                        <span class="label">Notifications</span>
+                    </div>
+                </div>
+                <div class="flex-1 w-full h-full overflow-y-auto">
+                    <ng-container [ngSwitch]="currTab">
+                        <ng-container *ngSwitchCase="tabs.FriendsTab">
+                            <dragonfish-friends-list></dragonfish-friends-list>
+                        </ng-container>
+                        <ng-container *ngSwitchCase="tabs.MessagesTab">
+                            <dragonfish-messages-feed></dragonfish-messages-feed>
+                        </ng-container>
+                        <ng-container *ngSwitchCase="tabs.NotificationsTab">
+                            <dragonfish-notifications-list></dragonfish-notifications-list>
+                        </ng-container>
+                        <ng-container *ngSwitchCase="tabs.QuickOptionsTab">
+                            <dragonfish-quick-options></dragonfish-quick-options>
+                        </ng-container>
+                    </ng-container>
+                </div>
             </div>
-            <div class="my-2"></div>
-            <div class="tab-buttons border-gray-600 dark:border-white">
-                <div
-                    class="button border-gray-600 dark:border-white"
-                    [ngClass]="{'active': currTab === tabs.QuickOptionsTab}"
-                    (click)="switchTab(tabs.QuickOptionsTab)"
-                >
-                    <rmx-icon name="user-settings-line"></rmx-icon>
-                    <span class="label">Account</span>
-                </div>
-                <div
-                    class="button border-gray-600 dark:border-white"
-                    [ngClass]="{'active': currTab === tabs.FriendsTab}"
-                    (click)="switchTab(tabs.FriendsTab)"
-                >
-                    <rmx-icon name="group-line"></rmx-icon>
-                    <span class="label">Friends</span>
-                </div>
-                <div
-                    class="button border-gray-600 dark:border-white"
-                    [ngClass]="{'active': currTab === tabs.MessagesTab}"
-                    (click)="switchTab(tabs.MessagesTab)"
-                >
-                    <rmx-icon name="chat-smile-3-line"></rmx-icon>
-                    <span class="label">Messages</span>
-                </div>
-                <div
-                    class="button border-gray-600 dark:border-white active"
-                    [ngClass]="{'active': currTab === tabs.NotificationsTab}"
-                    (click)="switchTab(tabs.NotificationsTab)"
-                    [matBadge]="notifications.count"
-                    [matBadgeHidden]="notifications.count === 0"
-                >
-                    <rmx-icon name="notification-3-line"></rmx-icon>
-                    <span class="label">Notifications</span>
-                </div>
-            </div>
-            <div class="flex-1 w-full h-full overflow-y-auto">
-                <ng-container [ngSwitch]="currTab">
-                    <ng-container *ngSwitchCase="tabs.FriendsTab">
-                        <dragonfish-friends-list></dragonfish-friends-list>
-                    </ng-container>
-                    <ng-container *ngSwitchCase="tabs.MessagesTab">
-                        <dragonfish-messages-feed></dragonfish-messages-feed>
-                    </ng-container>
-                    <ng-container *ngSwitchCase="tabs.NotificationsTab">
-                        <dragonfish-notifications-list></dragonfish-notifications-list>
-                    </ng-container>
-                    <ng-container *ngSwitchCase="tabs.QuickOptionsTab">
-                        <dragonfish-quick-options></dragonfish-quick-options>
-                    </ng-container>
-                </ng-container>
-            </div>
+            <div class="blurred-background"></div>
         </div>
-        <div class="blurred-background"></div>
-    </div>
+    </ng-container>
+    <ng-template #mobile>
+        <div class="absolute top-0 flex w-full" style="box-shadow: var(--dropshadow);">
+            <div class="menu-box border-gray-600 dark:border-white">
+                <div class="cover-pic absolute z-10 w-full h-36 left-0 pointer-events-none" [ngClass]="user.profile.coverPic ? '' : 'has-accent'">
+                    <img
+                        class="object-cover object-center w-full h-full"
+                        [src]="user.profile.coverPic"
+                        [alt]="'avatar'"
+                        *ngIf="user.profile.coverPic"
+                    />
+                </div>
+                <div class="mobile-user-header">
+                    <div class="flex flex-row items-center">
+                        <div class="user-avatar">
+                            <img [src]="user.profile.avatar" [alt]="'avatar'" />
+                        </div>
+                        <div class="ml-2">
+                            <div class="flex items-center">
+                                <dragonfish-role-badge [roles]="user.roles" [size]="'small'"></dragonfish-role-badge>
+                                <h2 class="text-2xl font-medium relative top-0.5">
+                                    {{ user.screenName }}
+                                </h2>
+                            </div>
+                            <h3 class="text-sm font-medium">
+                                @{{ user.userTag }}
+                            </h3>
+                            <div class="flex items-center text-xs">
+                                <span>{{ user.stats.followers | abbreviate }} follower{{ user.stats.followers | pluralize }}</span>
+                                <span class="mx-1">|</span>
+                                <span>{{ user.stats.following | abbreviate }} following</span>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="my-2"></div>
+                <div class="tab-buttons border-gray-600 dark:border-white">
+                    <div
+                        class="button border-gray-600 dark:border-white"
+                        [ngClass]="{'active': currTab === tabs.QuickOptionsTab}"
+                        (click)="switchTab(tabs.QuickOptionsTab)"
+                    >
+                        <rmx-icon name="user-settings-line"></rmx-icon>
+                        <span class="label">Account</span>
+                    </div>
+                    <div
+                        class="button border-gray-600 dark:border-white"
+                        [ngClass]="{'active': currTab === tabs.FriendsTab}"
+                        (click)="switchTab(tabs.FriendsTab)"
+                    >
+                        <rmx-icon name="group-line"></rmx-icon>
+                        <span class="label">Friends</span>
+                    </div>
+                    <div
+                        class="button border-gray-600 dark:border-white"
+                        [ngClass]="{'active': currTab === tabs.MessagesTab}"
+                        (click)="switchTab(tabs.MessagesTab)"
+                    >
+                        <rmx-icon name="chat-smile-3-line"></rmx-icon>
+                        <span class="label">Messages</span>
+                    </div>
+                    <div
+                        class="button border-gray-600 dark:border-white active"
+                        [ngClass]="{'active': currTab === tabs.NotificationsTab}"
+                        (click)="switchTab(tabs.NotificationsTab)"
+                        [matBadge]="notifications.count"
+                        [matBadgeHidden]="notifications.count === 0"
+                    >
+                        <rmx-icon name="notification-3-line"></rmx-icon>
+                        <span class="label">Notifications</span>
+                    </div>
+                </div>
+                <div class="flex-1 w-full h-full overflow-y-auto mb-12">
+                    <ng-container [ngSwitch]="currTab">
+                        <ng-container *ngSwitchCase="tabs.FriendsTab">
+                            <dragonfish-friends-list></dragonfish-friends-list>
+                        </ng-container>
+                        <ng-container *ngSwitchCase="tabs.MessagesTab">
+                            <dragonfish-messages-feed></dragonfish-messages-feed>
+                        </ng-container>
+                        <ng-container *ngSwitchCase="tabs.NotificationsTab">
+                            <dragonfish-notifications-list></dragonfish-notifications-list>
+                        </ng-container>
+                        <ng-container *ngSwitchCase="tabs.QuickOptionsTab">
+                            <dragonfish-quick-options></dragonfish-quick-options>
+                        </ng-container>
+                    </ng-container>
+                </div>
+            </div>
+            <div class="blurred-background"></div>
+        </div>
+    </ng-template>
 </ng-container>

--- a/libs/client/ui/src/lib/components/auth/user-menu/user-menu.component.scss
+++ b/libs/client/ui/src/lib/components/auth/user-menu/user-menu.component.scss
@@ -23,6 +23,22 @@ div.menu-box {
             color: var(--text-color);
         }
     }
+    div.mobile-user-header {
+        @apply w-full relative z-20 mt-4 px-4;
+        div.user-avatar {
+            align-self: center;
+            img {
+                width: 75px;
+                height: 75px;
+                border-radius: 0.375rem;
+                border: 1px solid var(--borders);
+                box-shadow: var(--dropshadow);
+            }
+        }
+        h2, h3 {
+            color: var(--text-color);
+        }
+    }
     div.button {
         @apply p-2.5 flex items-center my-2 rounded-md transition transform cursor-pointer;
         rmx-icon {

--- a/libs/client/ui/src/lib/components/auth/user-menu/user-menu.component.ts
+++ b/libs/client/ui/src/lib/components/auth/user-menu/user-menu.component.ts
@@ -1,7 +1,8 @@
-import { Component } from '@angular/core';
+import { Component, HostListener } from '@angular/core';
 import { SessionQuery } from '@dragonfish/client/repository/session';
 import { PseudonymsQuery } from '@dragonfish/client/repository/pseudonyms';
 import { NotificationsRepository } from '@dragonfish/client/repository/notifications';
+import { isMobile } from '@dragonfish/shared/functions';
 
 enum MenuTabs {
     FriendsTab,
@@ -18,14 +19,22 @@ enum MenuTabs {
 export class UserMenuComponent {
     tabs = MenuTabs;
     currTab = MenuTabs.QuickOptionsTab;
+    mobileMode = false;
 
     constructor(
         public pseudQuery: PseudonymsQuery,
         public sessionQuery: SessionQuery,
         public notifications: NotificationsRepository,
-    ) {}
+    ) {
+        this.onResize();
+    }
 
     switchTab(tab: MenuTabs) {
         this.currTab = tab;
+    }
+
+    @HostListener('window:resize', ['$event'])
+    onResize() {
+        this.mobileMode = isMobile();
     }
 }

--- a/libs/client/ui/src/lib/components/nav/mobile-nav/mobile-nav.component.html
+++ b/libs/client/ui/src/lib/components/nav/mobile-nav/mobile-nav.component.html
@@ -2,7 +2,7 @@
     <ng-container *ngIf="sessionQuery.currAccount$ | async; else login">
         <ng-container *ngIf="pseudQuery.current$ | async as profile; else selectProfile">
             <a
-                class="link cursor-pointer"
+                class="profile cursor-pointer"
                 [matTooltip]="'My Profile'"
                 [matTooltipPosition]="'right'"
                 [matTooltipClass]="'offprint-tooltip'"
@@ -11,9 +11,9 @@
                 [matBadge]="notifications.count"
                 [matBadgeHidden]="activeUserMenu || notifications.count < 1"
             >
-                <span class="link-icon">
+                <span class="profile-icon">
                     <ng-container *ngIf="!userMenu; else userMenuOpened">
-                        <img [src]="profile.profile.avatar" class="block object-cover rounded-md" style="width: 44px;" [alt]="'avatar'">
+                        <img [src]="profile.profile.avatar" class="block object-cover rounded-md link-icon" [alt]="'avatar'">
                     </ng-container>
                     <ng-template #userMenuOpened>
                         <rmx-icon name="close-line"></rmx-icon>

--- a/libs/client/ui/src/lib/components/nav/mobile-nav/mobile-nav.component.html
+++ b/libs/client/ui/src/lib/components/nav/mobile-nav/mobile-nav.component.html
@@ -1,4 +1,52 @@
 <div class="flex items-center justify-center absolute bottom-0 z-50 w-full" style="background: var(--accent-dark);">
+    <ng-container *ngIf="sessionQuery.currAccount$ | async; else login">
+        <ng-container *ngIf="pseudQuery.current$ | async as profile; else selectProfile">
+            <a
+                class="link cursor-pointer"
+                [matTooltip]="'My Profile'"
+                [matTooltipPosition]="'right'"
+                [matTooltipClass]="'offprint-tooltip'"
+                (click)="openUserMenu()"
+                [ngClass]="{'active': userMenu, 'no-padding': !userMenu}"
+                [matBadge]="notifications.count"
+                [matBadgeHidden]="activeUserMenu || notifications.count < 1"
+            >
+                <span class="link-icon">
+                    <ng-container *ngIf="!userMenu; else userMenuOpened">
+                        <img [src]="profile.profile.avatar" class="block object-cover rounded-md" style="width: 44px;" [alt]="'avatar'">
+                    </ng-container>
+                    <ng-template #userMenuOpened>
+                        <rmx-icon name="close-line"></rmx-icon>
+                    </ng-template>
+                </span>
+            </a>
+        </ng-container>
+        <ng-template #selectProfile>
+            <a
+                class="link"
+                [routerLink]="['/registration/select-pseud']"
+                [routerLinkActive]="'active'"
+                [matTooltip]="'Select Profile'"
+                [matTooltipPosition]="'right'"
+                [matTooltipClass]="'offprint-tooltip'"
+            >
+                <span class="link-icon"><rmx-icon name="user-line"></rmx-icon></span>
+            </a>
+        </ng-template>
+    </ng-container>
+
+    <ng-template #login>
+        <a
+            class="link"
+            [routerLink]="['/registration']"
+            [routerLinkActive]="'active'"
+            [matTooltip]="'Login/Register'"
+            [matTooltipPosition]="'right'"
+            [matTooltipClass]="'offprint-tooltip'"
+        >
+            <span class="link-icon"><rmx-icon name="login-circle-line"></rmx-icon></span>
+        </a>
+    </ng-template>
     <a
         class="link"
         [routerLink]="['/']"

--- a/libs/client/ui/src/lib/components/nav/mobile-nav/mobile-nav.component.html
+++ b/libs/client/ui/src/lib/components/nav/mobile-nav/mobile-nav.component.html
@@ -68,16 +68,34 @@
     >
         <span class="link-icon"><rmx-icon name="compass-3-line"></rmx-icon></span>
     </a>
-    <a
-        class="link"
-        [routerLink]="['/social']"
-        [routerLinkActive]="'active'"
-        [matTooltip]="'Social'"
-        [matTooltipPosition]="'right'"
-        [matTooltipClass]="'offprint-tooltip'"
-    >
-        <span class="link-icon"><rmx-icon name="group-line"></rmx-icon></span>
-    </a>
+    <ng-container *ngIf="sessionQuery.currAccount$ | async as account">
+        <ng-container *ngIf="notifications.contentUpdates$ | async as contentUpdates">
+            <a
+                class="link"
+                [routerLink]="['/my-library']"
+                [routerLinkActive]="'active'"
+                [matTooltip]="'My Library'"
+                [matTooltipPosition]="'right'"
+                [matTooltipClass]="'offprint-tooltip'"
+                [matBadge]="contentUpdates.length"
+                [matBadgeHidden]="contentUpdates.length === 0"
+            >
+                <span class="link-icon"><rmx-icon name="book-mark-line"></rmx-icon></span>
+            </a>
+        </ng-container>
+        <ng-container *ngIf="canSeeDash(account.roles)">
+            <a
+                class="link"
+                [routerLink]="['/dashboard']"
+                [routerLinkActive]="'active'"
+                [matTooltip]="'Dashboard'"
+                [matTooltipPosition]="'right'"
+                [matTooltipClass]="'offprint-tooltip'"
+            >
+                <span class="link-icon"><rmx-icon name="dashboard-2-line"></rmx-icon></span>
+            </a>
+        </ng-container>
+    </ng-container>
     <a
         class="link"
         [routerLink]="['/search']"

--- a/libs/client/ui/src/lib/components/nav/mobile-nav/mobile-nav.component.scss
+++ b/libs/client/ui/src/lib/components/nav/mobile-nav/mobile-nav.component.scss
@@ -13,3 +13,35 @@ a.link {
         }
     }
 }
+
+a.profile {
+    @apply p-2.5 mx-2 mb-1 border-2 border-transparent rounded-md text-white transition transform;
+    border-color: gray;
+    &.no-padding {
+        @apply cursor-pointer p-0;
+    }
+    &:hover {
+        @apply no-underline scale-110;
+        box-shadow: var(--dropshadow);
+        background: var(--accent);
+        color: white;
+        border-color: white;
+    }
+    &.active {
+        @apply no-underline shadow-xl;
+        background: var(--accent);
+        color: white;
+        border-color: white;
+    }
+    span.profile-icon {
+        img {
+            width: 44px;
+            height: 44px;
+            stroke-width: 1;
+        }
+        rmx-icon {
+            width: 26px;
+            stroke-width: 1;
+        }
+    }
+}

--- a/libs/client/ui/src/lib/components/nav/mobile-nav/mobile-nav.component.ts
+++ b/libs/client/ui/src/lib/components/nav/mobile-nav/mobile-nav.component.ts
@@ -1,8 +1,73 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { SessionQuery } from '@dragonfish/client/repository/session';
+import { PseudonymsQuery } from '@dragonfish/client/repository/pseudonyms';
+import { Roles } from '@dragonfish/shared/models/accounts';
+import { isAllowed } from '@dragonfish/shared/functions';
+import { DragonfishElectronService } from '@dragonfish/client/services';
+import { UserMenuComponent } from '../../auth/user-menu/user-menu.component';
+import { ViewRef, ViewService } from '@ngneat/overview';
+import { NavigationStart, Router } from '@angular/router';
+import { untilDestroyed } from '@ngneat/until-destroy';
+import { combineLatestWith, interval, switchMap } from 'rxjs';
+import { NotificationsRepository } from '@dragonfish/client/repository/notifications';
 
 @Component({
     selector: 'dragonfish-mobile-nav',
     templateUrl: './mobile-nav.component.html',
     styleUrls: ['./mobile-nav.component.scss']
 })
-export class MobileNavComponent {}
+export class MobileNavComponent implements OnInit {
+    userMenu: ViewRef;
+    activeUserMenu = false;
+    constructor(
+        public sessionQuery: SessionQuery,
+        public pseudQuery: PseudonymsQuery,
+        public electron: DragonfishElectronService,
+        private router: Router,
+        private viewService: ViewService,
+        public notifications: NotificationsRepository,
+    ) {}
+
+    ngOnInit(): void {
+        this.router.events.pipe(untilDestroyed(this)).subscribe((event) => {
+            if (event instanceof NavigationStart) {
+                if (this.userMenu) {
+                    this.userMenu.destroy();
+                    this.userMenu = undefined;
+                    this.activeUserMenu = false;
+                }
+            }
+        });
+
+        this.sessionQuery.currAccount$
+            .pipe(combineLatestWith(this.pseudQuery.current$), untilDestroyed(this))
+            .subscribe((values) => {
+                const [account, profile] = values;
+                if (account && profile) {
+                    this.notifications
+                        .getAllUnread()
+                        .pipe(untilDestroyed(this))
+                        .subscribe(() => {
+                            interval(15000)
+                                .pipe(
+                                    switchMap(() => this.notifications.getAllUnread()),
+                                    untilDestroyed(this),
+                                )
+                                .subscribe();
+                        });
+                }
+            });
+    }
+
+    openUserMenu() {
+        if (!this.userMenu) {
+            this.userMenu = this.viewService.createView(UserMenuComponent);
+            document.body.appendChild(this.userMenu.getElement() as any);
+            this.activeUserMenu = true;
+        } else {
+            this.userMenu.destroy();
+            this.userMenu = undefined;
+            this.activeUserMenu = false;
+        }
+    }
+}

--- a/libs/client/ui/src/lib/components/nav/mobile-nav/mobile-nav.component.ts
+++ b/libs/client/ui/src/lib/components/nav/mobile-nav/mobile-nav.component.ts
@@ -59,6 +59,10 @@ export class MobileNavComponent implements OnInit {
             });
     }
 
+    canSeeDash(userRoles: Roles[]) {
+        return isAllowed(userRoles, [Roles.Admin, Roles.Moderator, Roles.WorkApprover]);
+    }
+
     openUserMenu() {
         if (!this.userMenu) {
             this.userMenu = this.viewService.createView(UserMenuComponent);

--- a/libs/client/ui/src/lib/components/nav/sidebar/sidebar.component.html
+++ b/libs/client/ui/src/lib/components/nav/sidebar/sidebar.component.html
@@ -6,7 +6,7 @@
     <ng-container *ngIf="sessionQuery.currAccount$ | async; else login">
         <ng-container *ngIf="pseudQuery.current$ | async as profile; else selectProfile">
             <a
-                class="link cursor-pointer"
+                class="profile cursor-pointer"
                 [matTooltip]="'My Profile'"
                 [matTooltipPosition]="'right'"
                 [matTooltipClass]="'offprint-tooltip'"
@@ -15,9 +15,9 @@
                 [matBadge]="notifications.count"
                 [matBadgeHidden]="activeUserMenu || notifications.count < 1"
             >
-                <span class="link-icon">
+                <span class="profile-icon">
                     <ng-container *ngIf="!userMenu; else userMenuOpened">
-                        <img [src]="profile.profile.avatar" class="block object-cover rounded-md" style="width: 44px;" [alt]="'avatar'">
+                        <img [src]="profile.profile.avatar" class="block object-cover rounded-md" [alt]="'avatar'">
                     </ng-container>
                     <ng-template #userMenuOpened>
                         <rmx-icon name="close-line"></rmx-icon>

--- a/libs/client/ui/src/lib/components/nav/sidebar/sidebar.component.scss
+++ b/libs/client/ui/src/lib/components/nav/sidebar/sidebar.component.scss
@@ -23,3 +23,35 @@ a.link {
         }
     }
 }
+
+a.profile {
+    @apply p-2.5 mx-2 mb-1 border-2 border-transparent rounded-md text-white transition transform;
+    border-color: gray;
+    &.no-padding {
+        @apply cursor-pointer p-0;
+    }
+    &:hover {
+        @apply no-underline scale-110;
+        box-shadow: var(--dropshadow);
+        background: var(--accent);
+        color: white;
+        border-color: white;
+    }
+    &.active {
+        @apply no-underline shadow-xl;
+        background: var(--accent);
+        color: white;
+        border-color: white;
+    }
+    span.profile-icon {
+        img {
+            width: 44px;
+            height: 44px;
+            stroke-width: 1;
+        }
+        rmx-icon {
+            width: 26px;
+            stroke-width: 1;
+        }
+    }
+}

--- a/libs/client/ui/src/lib/components/nav/sidebar/sidebar.component.ts
+++ b/libs/client/ui/src/lib/components/nav/sidebar/sidebar.component.ts
@@ -8,7 +8,7 @@ import { UserMenuComponent } from '../../auth/user-menu/user-menu.component';
 import { ViewRef, ViewService } from '@ngneat/overview';
 import { NavigationStart, Router } from '@angular/router';
 import { untilDestroyed } from '@ngneat/until-destroy';
-import { combineLatestWith, interval, switchMap, tap, zip } from 'rxjs';
+import { combineLatestWith, interval, switchMap } from 'rxjs';
 import { NotificationsRepository } from '@dragonfish/client/repository/notifications';
 
 @Component({


### PR DESCRIPTION
## Description
Closes #682
Mobile has no way to log in

## Changes
- Adds log-in button to mobile menu
- Profile menu is not optimized for mobile yet
- Fixes user menu appearance on mobile
- Creates separate set of HTML for menu if mobile
- Displays the bottom menu while the user menu is open in mobile
- Adds margin below scrollable portion to account for bottom menu
- Reduces spacing at top of user menu in mobile
- Adds user menu button to mobile bottom menu
- Includes gray border around button, to handle case where image doesn't load
- Adds gray border around user menu button in side menu to account for image not loading
- On mobile, replaces Social icon with My Library and Dashboard if available

![image](https://user-images.githubusercontent.com/71996084/143494162-1ccf3a68-70c9-43b1-b031-27bbb8ef3086.png)

## Areas Affected
- [x] Site Navigation
- [ ] Home
- [x] Sign In/Out
- [x] Registration
- [ ] Settings

.
- [ ] Profile
- [ ] My Library
- [ ] Bookshelves
- [ ] Editor
- [ ] Browse
- [ ] Work Card

.
- [ ] Work Page
- [ ] Blog Page
- [ ] Comments
- [ ] Search
- [ ] Other Pages

.
- [ ] Account Authentication
- [ ] Dashboard
- [x] Mobile
