### PR TITLE
Add links to work cards and fix them on mobile; fixes cut-off on Browse screens

### DIFF
--- a/apps/bettafish/src/app/pages/browse/browse.component.html
+++ b/apps/bettafish/src/app/pages/browse/browse.component.html
@@ -46,5 +46,8 @@
                 <router-outlet></router-outlet>
             </div>
         </ng-template>
+        <ng-container *ngIf="mobileMode">
+            <div class="mb-16"></div>
+        </ng-container>
     </div>
 </div>

--- a/libs/client/ui/src/lib/components/work-card/work-card.component.html
+++ b/libs/client/ui/src/lib/components/work-card/work-card.component.html
@@ -1,5 +1,5 @@
 <span class="medium-card border border-gray-600 dark:border-white group" *ngIf="size === 'large'">
-    <div class="flex items-center">
+    <div class="flex flex-wrap items-center">
         <h3
             class="title"
             [matTooltip]="content.title"
@@ -15,7 +15,7 @@
         </h3>
         <dragonfish-tag-badge [kind]="tagKind.Rating" [rating]="content.meta.rating" [hasIcon]="false"></dragonfish-tag-badge>
     </div>
-    <div class="flex items-center pb-0.5 text-xs border-b border-gray-600 dark:border-white group-hover:border-white">
+    <div class="flex flex-wrap items-center pb-0.5 text-xs border-b border-gray-600 dark:border-white group-hover:border-white">
         <div class="flex-1">
             by 
             <a
@@ -125,7 +125,7 @@
     *ngIf="size === 'small'"
     [ngClass]="{'active': isActive, 'h-full': fullHeight}"
 >
-    <div class="flex">
+    <div class="flex flex-wrap">
         <h4
             class="block align-top text-lg font-medium overflow-ellipsis overflow-hidden whitespace-nowrap flex-1 self-center group-hover:text-white"
             style="line-height: 2rem;"

--- a/libs/client/ui/src/lib/components/work-card/work-card.component.html
+++ b/libs/client/ui/src/lib/components/work-card/work-card.component.html
@@ -17,7 +17,13 @@
     </div>
     <div class="flex items-center pb-0.5 text-xs border-b border-gray-600 dark:border-white group-hover:border-white">
         <div class="flex-1">
-            by {{ $any(content.author).screenName }}
+            by 
+            <a
+                class="author-link"
+                [routerLink]="['/profile', content.author._id, content.author.userTag]"
+            >
+                {{ $any(content.author).screenName }}
+            </a>
         </div>
         <div class="flex items-center">
             <rmx-icon name="heart-line" class="relative top-1" style="width: 1rem;"></rmx-icon>
@@ -154,7 +160,13 @@
     </div>
     <div class="rounded-md px-1 text-xs flex items-center bg-gray-200 dark:bg-gray-600">
         <div>
-            by {{ $any(content.author).screenName }}
+            by 
+            <a
+                class="author-link"
+                [routerLink]="['/profile', content.author._id, content.author.userTag]"
+            >
+                {{ $any(content.author).screenName }}
+            </a>
         </div>
         <div class="text-sm mx-0.5 relative -top-0.5">
             •

--- a/libs/client/ui/src/lib/components/work-card/work-card.component.html
+++ b/libs/client/ui/src/lib/components/work-card/work-card.component.html
@@ -38,7 +38,7 @@
         </ng-container>
     </div>
     <ng-container *ngIf="content.tags !== null && content.tags.length > 0">
-        <div class="card-tags flex flex-row items-center">
+        <div class="card-tags flex flex-wrap items-center">
             <ng-container *ngIf="content.tags.length === 1; else multipleTags">
                     <a
                         class="tags"
@@ -55,7 +55,7 @@
                                 [innerHtml]="tag | displayTags | safeHtml"
                             ></a>
                             <ng-container *ngIf="i < content.tags.length - 1">
-                                ,
+                                ,&nbsp;
                             </ng-container>
                         </ng-container>
                     <rmx-icon name="arrow-up-s-line" (click)="toggleShowAllTags()"></rmx-icon>

--- a/libs/client/ui/src/lib/components/work-card/work-card.component.html
+++ b/libs/client/ui/src/lib/components/work-card/work-card.component.html
@@ -29,35 +29,32 @@
     <ng-container *ngIf="content.tags !== null && content.tags.length > 0">
         <div class="card-tags flex flex-row items-center">
             <ng-container *ngIf="content.tags.length === 1; else multipleTags">
-                    <span class="tag tags">
-                        <a
-                            [routerLink]="['/tag', content.tags[0]._id, content.tags[0].name | slugify]"
-                            [innerHtml]="content.tags[0] | displayTags | safeHtml"
-                        ></a>
-                    </span>
+                    <a
+                        class="tags"
+                        [routerLink]="['/tag', content.tags[0]._id, content.tags[0].name | slugify]"
+                        [innerHtml]="content.tags[0] | displayTags | safeHtml"
+                    ></a>
             </ng-container>
             <ng-template #multipleTags>
                 <ng-container *ngIf="showAllTags; else showOneTag">
-                        <span class="tag tags">
-                            <ng-container *ngFor="let tag of content.tags; let i = index">
-                                <a
-                                    [routerLink]="['/tag', tag._id, tag.name | slugify]"
-                                    [innerHtml]="tag | displayTags | safeHtml"
-                                ></a>
-                                <ng-container *ngIf="i < content.tags.length - 1">
-                                    ,
-                                </ng-container>
+                        <ng-container *ngFor="let tag of content.tags; let i = index">
+                            <a
+                                class="tags"
+                                [routerLink]="['/tag', tag._id, tag.name | slugify]"
+                                [innerHtml]="tag | displayTags | safeHtml"
+                            ></a>
+                            <ng-container *ngIf="i < content.tags.length - 1">
+                                ,
                             </ng-container>
-                        </span>
+                        </ng-container>
                     <rmx-icon name="arrow-up-s-line" (click)="toggleShowAllTags()"></rmx-icon>
                 </ng-container>
                 <ng-template #showOneTag>
-                        <span class="tag tags">
-                            <a
-                                [routerLink]="['/tag', content.tags[0]._id, content.tags[0].name | slugify]"
-                                [innerHtml]="content.tags[0] | displayTags | safeHtml"
-                            ></a>
-                        </span>
+                        <a
+                            class="tags"
+                            [routerLink]="['/tag', content.tags[0]._id, content.tags[0].name | slugify]"
+                            [innerHtml]="content.tags[0] | displayTags | safeHtml"
+                        ></a>
                     <rmx-icon name="arrow-down-s-line" (click)="toggleShowAllTags()"></rmx-icon>
                 </ng-template>
             </ng-template>

--- a/libs/client/ui/src/lib/components/work-card/work-card.component.html
+++ b/libs/client/ui/src/lib/components/work-card/work-card.component.html
@@ -1,4 +1,4 @@
-<a class="medium-card border border-gray-600 dark:border-white group" [routerLink]="createContentUrl(content.kind, content._id, content.title)" *ngIf="size === 'large'">
+<span class="medium-card border border-gray-600 dark:border-white group" *ngIf="size === 'large'">
     <div class="flex items-center">
         <h3
             class="title"
@@ -6,7 +6,12 @@
             [matTooltipClass]="'offprint-tooltip'"
             [matTooltipShowDelay]="600"
         >
-            {{ content.title }}
+            <a
+                class="title-link"
+                [routerLink]="createContentUrl(content.kind, content._id, content.title)"
+            >
+                {{ content.title }}
+            </a>
         </h3>
         <dragonfish-tag-badge [kind]="tagKind.Rating" [rating]="content.meta.rating" [hasIcon]="false"></dragonfish-tag-badge>
     </div>
@@ -107,23 +112,28 @@
             {{ content.meta.status }}
         </div>
     </div>
-</a>
+</span>
 
-<a
+<span
     class="small-card block group flex flex-col p-2 transition transform select-none cursor-pointer border border-gray-600 dark:border-white rounded-md hover:scale-105 hover:text-white hover:no-underline hover:z-30"
     *ngIf="size === 'small'"
-    [routerLink]="createContentUrl(content.kind, content._id, content.title)"
     [ngClass]="{'active': isActive, 'h-full': fullHeight}"
 >
     <div class="flex">
         <h4
             class="block align-top text-lg font-medium overflow-ellipsis overflow-hidden whitespace-nowrap flex-1 self-center group-hover:text-white"
-            style="line-height: 1.15rem;"
+            style="line-height: 2rem;"
             [matTooltip]="content.title"
             [matTooltipClass]="'offprint-tooltip'"
             [matTooltipShowDelay]="300"
+            [routerLink]="createContentUrl(content.kind, content._id, content.title)"
         >
-            {{ content.title }}
+            <a
+                class="title-link"
+                [routerLink]="createContentUrl(content.kind, content._id, content.title)"
+            >
+                {{ content.title }}
+            </a>
         </h4>
         <dragonfish-tag-badge [kind]="tagKind.Rating" [rating]="content.meta.rating" [size]="'small'" [hasIcon]="false"></dragonfish-tag-badge>
     </div>
@@ -158,4 +168,4 @@
             <span>{{ calcApprovalRating(content.stats.likes, content.stats.dislikes) }}%</span>
         </div>
     </div>
-</a>
+</span>

--- a/libs/client/ui/src/lib/components/work-card/work-card.component.scss
+++ b/libs/client/ui/src/lib/components/work-card/work-card.component.scss
@@ -14,6 +14,9 @@ span.medium-card {
         a.title-link {
             @apply text-white;
         }
+        a.author-link {
+            @apply text-white;
+        }
         div.work-meta {
             background: var(--accent-light);
         }
@@ -69,6 +72,9 @@ span.small-card {
             background: var(--accent-light);
         }
         a.title-link {
+            @apply text-white;
+        }
+        a.author-link {
             @apply text-white;
         }
     }

--- a/libs/client/ui/src/lib/components/work-card/work-card.component.scss
+++ b/libs/client/ui/src/lib/components/work-card/work-card.component.scss
@@ -1,4 +1,4 @@
-a.medium-card {
+span.medium-card {
     @apply block flex flex-col p-2 transition transform select-none cursor-pointer h-full rounded-md;
     color: var(--text-color);
     h3.title {
@@ -9,6 +9,9 @@ a.medium-card {
         background: var(--accent);
         box-shadow: var(--dropshadow);
         h3.title {
+            @apply text-white;
+        }
+        a.title-link {
             @apply text-white;
         }
         div.work-meta {
@@ -57,13 +60,16 @@ a.medium-card {
     }
 }
 
-a.small-card {
+span.small-card {
     color: var(--text-color);
     &:hover {
         box-shadow: var(--dropshadow);
         background: var(--accent);
         div.work-meta {
             background: var(--accent-light);
+        }
+        a.title-link {
+            @apply text-white;
         }
     }
     &:active {

--- a/libs/client/ui/src/lib/components/work-card/work-card.component.scss
+++ b/libs/client/ui/src/lib/components/work-card/work-card.component.scss
@@ -14,6 +14,9 @@ a.medium-card {
         div.work-meta {
             background: var(--accent-light);
         }
+        a.tags {
+            @apply text-white;
+        }
     }
     div.work-body {
         @apply flex-1 mb-2;


### PR DESCRIPTION
## Description
Closes #642

## Changes
- Makes tags on work cards turn white on hover; blended into background on hover before
- Converts work cards to not be links
- Uses links in title, which can be right-clicked
- Fixes issue where small card cuts off top of title when hovered over
- Adds author links to work cards
- On work cards, places expanded tags on multiple lines
- Fixes issue where work cards expand past screen on mobile
- Adds margin to browse screens on mobile so menu cuts nothing off

## Areas Affected
- [ ] Site Navigation
- [ ] Home
- [ ] Sign In/Out
- [ ] Registration
- [ ] Settings

.
- [ ] Profile
- [ ] My Library
- [ ] Bookshelves
- [ ] Editor
- [x] Browse
- [x] Work Card

.
- [ ] Work Page
- [ ] Blog Page
- [ ] Comments
- [ ] Search
- [ ] Other Pages

.
- [ ] Account Authentication
- [ ] Dashboard
- [ ] Mobile
