### PR TITLE
Fix mobile profile and enable tags

### DIFF
--- a/libs/client/profile/src/lib/components/profile-topbar/profile-topbar.component.html
+++ b/libs/client/profile/src/lib/components/profile-topbar/profile-topbar.component.html
@@ -1,126 +1,248 @@
 <ng-container *ngIf="profile.profile$ | async as currProfile">
-    <div class="profile-header">
-        <div>
-            <ng-container *ngIf="currProfile.profile.coverPic; else noCoverPic">
-                <img class="cover" [src]="currProfile.profile.coverPic" [alt]="'cover pic'">
-            </ng-container>
-            <ng-template #noCoverPic>
-                <div class="cover"></div>
-            </ng-template>
-            <div class="header-bar">
-                <div class="header-items">
-                    <img class="avatar" [src]="currProfile.profile.avatar" [alt]="'avatar'">
-                    <div class="flex-1">
-                        <div class="flex items-center relative mb-0.5">
-                            <dragonfish-role-badge [roles]="currProfile.roles" [size]="'normal'"></dragonfish-role-badge>
-                            <h3 class="text-3xl font-medium text-white relative top-1 ml-1.5">
-                                {{ currProfile.screenName }}
-                            </h3>
+    <ng-container *ngIf="!mobileMode; else mobile">
+        <div class="profile-header">
+            <div>
+                <ng-container *ngIf="currProfile.profile.coverPic; else noCoverPic">
+                    <img class="cover" [src]="currProfile.profile.coverPic" [alt]="'cover pic'">
+                </ng-container>
+                <ng-template #noCoverPic>
+                    <div class="cover"></div>
+                </ng-template>
+                <div class="header-bar">
+                    <div class="header-items">
+                        <img class="avatar" [src]="currProfile.profile.avatar" [alt]="'avatar'">
+                        <div class="flex-1">
+                            <div class="flex items-center relative mb-0.5">
+                                <dragonfish-role-badge [roles]="currProfile.roles" [size]="'normal'"></dragonfish-role-badge>
+                                <h3 class="text-3xl font-medium text-white relative top-1 ml-1.5">
+                                    {{ currProfile.screenName }}
+                                </h3>
+                            </div>
+                            <h4 class="italic text-white">@{{ currProfile.userTag }}</h4>
+                            <div class="flex items-center text-white text-xs">
+                                <span>{{ currProfile.stats.followers | abbreviate }} Followers</span>
+                                <span class="text-xl mx-1.5">·</span>
+                                <span>{{ currProfile.stats.following | abbreviate }} Following</span>
+                            </div>
                         </div>
-                        <h4 class="italic text-white">@{{ currProfile.userTag }}</h4>
-                        <div class="flex items-center text-white text-xs">
-                            <span>{{ currProfile.stats.followers | abbreviate }} Followers</span>
-                            <span class="text-xl mx-1.5">·</span>
-                            <span>{{ currProfile.stats.following | abbreviate }} Following</span>
-                        </div>
-                    </div>
-                    <ng-container *ngIf="auth.checkPseudonym(currProfile._id); else notThisUser">
-                        <button
-                            class="px-2.5"
-                            [matTooltip]="'Change Cover'"
-                            [matTooltipClass]="'offprint-tooltip'"
-                            (click)="changeCover()"
-                        >
-                            <rmx-icon name="image-add-line" class="mr-0"></rmx-icon>
-                        </button>
-                        <button [routerLink]="['/settings/profile']">
-                            <rmx-icon name="edit-line"></rmx-icon>
-                            <span>Edit</span>
-                        </button>
-                    </ng-container>
-                    <ng-template #notThisUser>
-                        <ng-container *ngIf="session.currAccount">
-                            <ng-container *ngIf="loadingFollowing; else notLoadingFollowing">
-                                <button>
-                                    <rmx-icon name="loader-4-line" class="loading"></rmx-icon>
-                                    <span>Saving...</span>
-                                </button>
-                            </ng-container>
-                            <ng-template #notLoadingFollowing>
-                                <ng-container *ngIf="profile.isFollowing; else notFollowing">
-                                    <button (click)="unfollow()">
-                                        <rmx-icon name="user-unfollow-line"></rmx-icon>
-                                        <span>Unfollow</span>
-                                    </button>
-                                </ng-container>
-                                <ng-template #notFollowing>
-                                    <button (click)="follow()">
-                                        <rmx-icon name="user-follow-line"></rmx-icon>
-                                        <span>Follow</span>
-                                    </button>
-                                </ng-template>
-                            </ng-template>
+                        <ng-container *ngIf="auth.checkPseudonym(currProfile._id); else notThisUser">
                             <button
                                 class="px-2.5"
-                                [matTooltip]="'Send Friend Request'"
+                                [matTooltip]="'Change Cover'"
                                 [matTooltipClass]="'offprint-tooltip'"
-                                (click)="friendRequest()"
+                                (click)="changeCover()"
                             >
-                                <rmx-icon name="user-smile-line" class="mr-0"></rmx-icon>
+                                <rmx-icon name="image-add-line" class="mr-0"></rmx-icon>
                             </button>
-                            <button
-                                class="px-2.5"
-                                [ngClass]="{'active': isMoreOpened}"
-                                [matTooltip]="'More'"
-                                [matTooltipClass]="'offprint-tooltip'"
-                                [matMenuTriggerFor]="moreOptions"
-                                (menuOpened)="toggleMore()"
-                                (menuClosed)="toggleMore()"
-                            >
-                                <rmx-icon name="more-2-fill" class="mr-0"></rmx-icon>
+                            <button [routerLink]="['/settings/profile']">
+                                <rmx-icon name="edit-line"></rmx-icon>
+                                <span>Edit</span>
                             </button>
                         </ng-container>
-                    </ng-template>
-                </div>
-                <div class="nav-items">
-                    <a
-                        class="link"
-                        (click)="setTitle()"
-                        [routerLink]="['/profile', currProfile._id, currProfile.userTag]"
-                        [routerLinkActive]="'active'"
-                        [routerLinkActiveOptions]="{ exact: true }"
-                    >
-                        <rmx-icon name="home-5-line"></rmx-icon>
-                        <span>Home</span>
-                    </a>
-                    <a
-                        class="link"
-                        [routerLink]="['works']"
-                        [routerLinkActive]="'active'"
-                    >
-                        <rmx-icon name="quill-pen-line"></rmx-icon>
-                        <span>{{ currProfile.stats.works | abbreviate }} Work{{ currProfile.stats.works | pluralize }}</span>
-                    </a>
-                    <a
-                        class="link"
-                        [routerLink]="['blogs']"
-                        [routerLinkActive]="'active'"
-                    >
-                        <rmx-icon name="cup-line"></rmx-icon>
-                        <span>{{ currProfile.stats.blogs | abbreviate }} Blog{{ currProfile.stats.blogs | pluralize }}</span>
-                    </a>
-                    <a
-                        class="link"
-                        [routerLink]="['bookshelves']"
-                        [routerLinkActive]="'active'"
-                    >
-                        <rmx-icon name="bar-chart-fill"></rmx-icon>
-                        <span>Bookshelves</span>
-                    </a>
+                        <ng-template #notThisUser>
+                            <ng-container *ngIf="session.currAccount">
+                                <ng-container *ngIf="loadingFollowing; else notLoadingFollowing">
+                                    <button>
+                                        <rmx-icon name="loader-4-line" class="loading"></rmx-icon>
+                                        <span>Saving...</span>
+                                    </button>
+                                </ng-container>
+                                <ng-template #notLoadingFollowing>
+                                    <ng-container *ngIf="profile.isFollowing; else notFollowing">
+                                        <button (click)="unfollow()">
+                                            <rmx-icon name="user-unfollow-line"></rmx-icon>
+                                            <span>Unfollow</span>
+                                        </button>
+                                    </ng-container>
+                                    <ng-template #notFollowing>
+                                        <button (click)="follow()">
+                                            <rmx-icon name="user-follow-line"></rmx-icon>
+                                            <span>Follow</span>
+                                        </button>
+                                    </ng-template>
+                                </ng-template>
+                                <button
+                                    class="px-2.5"
+                                    [matTooltip]="'Send Friend Request'"
+                                    [matTooltipClass]="'offprint-tooltip'"
+                                    (click)="friendRequest()"
+                                >
+                                    <rmx-icon name="user-smile-line" class="mr-0"></rmx-icon>
+                                </button>
+                                <button
+                                    class="px-2.5"
+                                    [ngClass]="{'active': isMoreOpened}"
+                                    [matTooltip]="'More'"
+                                    [matTooltipClass]="'offprint-tooltip'"
+                                    [matMenuTriggerFor]="moreOptions"
+                                    (menuOpened)="toggleMore()"
+                                    (menuClosed)="toggleMore()"
+                                >
+                                    <rmx-icon name="more-2-fill" class="mr-0"></rmx-icon>
+                                </button>
+                            </ng-container>
+                        </ng-template>
+                    </div>
+                    <div class="nav-items">
+                        <a
+                            class="link"
+                            (click)="setTitle()"
+                            [routerLink]="['/profile', currProfile._id, currProfile.userTag]"
+                            [routerLinkActive]="'active'"
+                            [routerLinkActiveOptions]="{ exact: true }"
+                        >
+                            <rmx-icon name="home-5-line"></rmx-icon>
+                            <span>Home</span>
+                        </a>
+                        <a
+                            class="link"
+                            [routerLink]="['works']"
+                            [routerLinkActive]="'active'"
+                        >
+                            <rmx-icon name="quill-pen-line"></rmx-icon>
+                            <span>{{ currProfile.stats.works | abbreviate }} Work{{ currProfile.stats.works | pluralize }}</span>
+                        </a>
+                        <a
+                            class="link"
+                            [routerLink]="['blogs']"
+                            [routerLinkActive]="'active'"
+                        >
+                            <rmx-icon name="cup-line"></rmx-icon>
+                            <span>{{ currProfile.stats.blogs | abbreviate }} Blog{{ currProfile.stats.blogs | pluralize }}</span>
+                        </a>
+                        <a
+                            class="link"
+                            [routerLink]="['bookshelves']"
+                            [routerLinkActive]="'active'"
+                        >
+                            <rmx-icon name="bar-chart-fill"></rmx-icon>
+                            <span>Bookshelves</span>
+                        </a>
+                    </div>
                 </div>
             </div>
         </div>
-    </div>
+    </ng-container>
+    <ng-template #mobile>
+        <div class="mobile-profile-header">
+            <div>
+                <div class="header-bar">
+                    <div class="header-items">
+                        <div class="flex items-center relative mb-0.5">
+                            <img class="avatar" [src]="currProfile.profile.avatar" [alt]="'avatar'">
+                            <dragonfish-role-badge [roles]="currProfile.roles" [size]="'normal'"></dragonfish-role-badge>
+                            <div class="flex-1">
+                                <h3 class="text-2xl font-medium text-white relative top-1 ml-1.5">
+                                    {{ currProfile.screenName }}
+                                </h3>
+                                <h4 class="italic text-white ml-1.5">@{{ currProfile.userTag }}</h4>
+                                <div class="flex items-center text-white text-xs ml-1.5">
+                                    <span>{{ currProfile.stats.followers | abbreviate }} Followers</span>
+                                    <span class="text-xl mx-1.5">·</span>
+                                    <span>{{ currProfile.stats.following | abbreviate }} Following</span>
+                                </div>
+                            </div>
+                        </div>
+                        <ng-container *ngIf="auth.checkPseudonym(currProfile._id); else notThisUser">
+                            <div class="flex justify-center">
+                                <button
+                                    class="px-2.5"
+                                    [matTooltip]="'Change Cover'"
+                                    [matTooltipClass]="'offprint-tooltip'"
+                                    (click)="changeCover()"
+                                >
+                                    <rmx-icon name="image-add-line" class="mr-0"></rmx-icon>
+                                </button>
+                                <button [routerLink]="['/settings/profile']">
+                                    <rmx-icon name="edit-line"></rmx-icon>
+                                    <span>Edit</span>
+                                </button>
+                            </div>
+                        </ng-container>
+                        <ng-template #notThisUser>
+                            <ng-container *ngIf="session.currAccount">
+                                <div class="flex justify-center">
+                                    <ng-container *ngIf="loadingFollowing; else notLoadingFollowing">
+                                        <button>
+                                            <rmx-icon name="loader-4-line" class="loading"></rmx-icon>
+                                            <span>Saving...</span>
+                                        </button>
+                                    </ng-container>
+                                    <ng-template #notLoadingFollowing>
+                                        <ng-container *ngIf="profile.isFollowing; else notFollowing">
+                                            <button (click)="unfollow()">
+                                                <rmx-icon name="user-unfollow-line"></rmx-icon>
+                                                <span>Unfollow</span>
+                                            </button>
+                                        </ng-container>
+                                        <ng-template #notFollowing>
+                                            <button (click)="follow()">
+                                                <rmx-icon name="user-follow-line"></rmx-icon>
+                                                <span>Follow</span>
+                                            </button>
+                                        </ng-template>
+                                    </ng-template>
+                                    <button
+                                        class="px-2.5"
+                                        [matTooltip]="'Send Friend Request'"
+                                        [matTooltipClass]="'offprint-tooltip'"
+                                        (click)="friendRequest()"
+                                    >
+                                        <rmx-icon name="user-smile-line" class="mr-0"></rmx-icon>
+                                    </button>
+                                    <button
+                                        class="px-2.5"
+                                        [ngClass]="{'active': isMoreOpened}"
+                                        [matTooltip]="'More'"
+                                        [matTooltipClass]="'offprint-tooltip'"
+                                        [matMenuTriggerFor]="moreOptions"
+                                        (menuOpened)="toggleMore()"
+                                        (menuClosed)="toggleMore()"
+                                    >
+                                        <rmx-icon name="more-2-fill" class="mr-0"></rmx-icon>
+                                    </button>
+                                </div>
+                            </ng-container>
+                        </ng-template>
+                    </div>
+                    <div class="nav-items">
+                        <a
+                            class="link"
+                            (click)="setTitle()"
+                            [routerLink]="['/profile', currProfile._id, currProfile.userTag]"
+                            [routerLinkActive]="'active'"
+                            [routerLinkActiveOptions]="{ exact: true }"
+                        >
+                            <rmx-icon name="home-5-line"></rmx-icon>
+                        </a>
+                        <a
+                            class="link"
+                            [routerLink]="['works']"
+                            [routerLinkActive]="'active'"
+                        >
+                            <rmx-icon name="quill-pen-line"></rmx-icon>
+                            <span class="label">{{ currProfile.stats.works | abbreviate }} Work{{ currProfile.stats.works | pluralize }}</span>
+                        </a>
+                        <a
+                            class="link"
+                            [routerLink]="['blogs']"
+                            [routerLinkActive]="'active'"
+                        >
+                            <rmx-icon name="cup-line"></rmx-icon>
+                            <span class="label">{{ currProfile.stats.blogs | abbreviate }} Blog{{ currProfile.stats.blogs | pluralize }}</span>
+                        </a>
+                        <a
+                            class="link"
+                            [routerLink]="['bookshelves']"
+                            [routerLinkActive]="'active'"
+                        >
+                            <rmx-icon name="bar-chart-fill"></rmx-icon>
+                        </a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </ng-template>
 
     <mat-menu #moreOptions='matMenu'>
         <button mat-menu-item class="hover:scale-100 tracking-normal" (click)="sendMessage()">

--- a/libs/client/profile/src/lib/components/profile-topbar/profile-topbar.component.scss
+++ b/libs/client/profile/src/lib/components/profile-topbar/profile-topbar.component.scss
@@ -59,3 +59,53 @@ div.profile-header {
     }
 }
 
+div.mobile-profile-header {
+    @apply relative z-40 top-0;
+    box-shadow: var(--dropshadow);
+    background: var(--accent);
+    div.header-bar {
+        background: var(--accent);
+        @apply relative w-full;
+        div.header-items {
+            @apply w-11/12 md:w-8/12 lg:w-7/12 mx-auto items-center relative;
+            height: 7.5rem;
+            img.avatar {
+                @apply object-cover h-16 w-16 relative rounded-md border-4 border-white mr-2;
+                box-shadow: var(--dropshadow);
+            }
+        }
+        div.nav-items {
+            @apply w-11/12 md:w-8/12 lg:w-7/12 mx-auto flex items-center justify-center;
+        }
+    }
+    div.scrolled-header {
+        @apply py-4;
+        background: var(--accent);
+        div.scrolled-header-items {
+            @apply flex items-center w-11/12 mx-auto;
+            img.avatar {
+                @apply object-cover h-24 w-24 relative rounded-md border-2 border-white mr-4;
+                box-shadow: var(--dropshadow);
+            }
+        }
+    }
+    button {
+        @apply text-white border border-white ml-1;
+        &:hover, &.active {
+            background: var(--accent-light);
+        }
+    }
+    a.link {
+        @apply flex items-center text-white px-3.5 py-2 uppercase font-medium text-sm tracking-widest border-b-4 border-transparent;
+        &.active {
+            border-color: white;
+        }
+        &:hover {
+            @apply no-underline;
+            border-color: var(--accent-light);
+        }
+        span.label {
+            @apply ml-1;
+        }
+    }
+}

--- a/libs/client/profile/src/lib/components/profile-topbar/profile-topbar.component.ts
+++ b/libs/client/profile/src/lib/components/profile-topbar/profile-topbar.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, HostListener, OnInit } from '@angular/core';
 import { ProfileRepository } from '@dragonfish/client/repository/profile';
 import { AuthService } from '@dragonfish/client/repository/session/services';
 import { AlertsService } from '@dragonfish/client/alerts';
@@ -6,15 +6,17 @@ import { SessionQuery } from '@dragonfish/client/repository/session';
 import { MatDialog } from '@angular/material/dialog';
 import { CoverPicUploadComponent } from '@dragonfish/client/settings';
 import { setThreePartTitle, Constants } from '@dragonfish/shared/constants';
+import { isMobile } from '@dragonfish/shared/functions';
 
 @Component({
     selector: 'dragonfish-profile-topbar',
     templateUrl: './profile-topbar.component.html',
     styleUrls: ['./profile-topbar.component.scss'],
 })
-export class ProfileTopbarComponent {
+export class ProfileTopbarComponent implements OnInit {
     isMoreOpened = false;
     loadingFollowing = false;
+    mobileMode = false;
 
     constructor(
         public profile: ProfileRepository,
@@ -23,6 +25,10 @@ export class ProfileTopbarComponent {
         private alerts: AlertsService,
         private dialog: MatDialog,
     ) {}
+
+    ngOnInit(): void {
+        this.onResize();
+    }
 
     toggleMore() {
         this.isMoreOpened = !this.isMoreOpened;
@@ -72,5 +78,10 @@ export class ProfileTopbarComponent {
             height: '100vh',
             disableClose: true
         });
+    }
+
+    @HostListener('window:resize', ['$event'])
+    onResize() {
+        this.mobileMode = isMobile();
     }
 }

--- a/libs/client/profile/src/lib/views/profile-info/profile-info.component.html
+++ b/libs/client/profile/src/lib/views/profile-info/profile-info.component.html
@@ -1,60 +1,125 @@
-<div class="flex flex-row justify-center w-11/12 mx-auto my-6">
-    <ng-container *ngIf="profile.profile$ | async as portUser">
-        <div class="p-4 w-52">
-            <h5 class="text-2xl font-medium text-center">About Me</h5>
-            <ng-container *ngIf="portUser.profile.bio">
-                <p class="text-sm text-center">{{ portUser.profile.bio }}</p>
-                <div class="my-2.5 border-b" style="border-color: var(--borders)"><!--spacer--></div>
-            </ng-container>
-            <div class="flex flex-col items-center">
-                <div class="flex flex-row items-center text-sm">
-                    <rmx-icon name="gift-2-line" class="mr-1"></rmx-icon>Joined {{ portUser.createdAt | localedate: 'mediumDate' }}
-                </div>
-            </div>
-        </div>
-    </ng-container>
-    <div class="mx-4"><!--spacer--></div>
-    <ng-container *ngIf="profile.blogs$ | async as blogs">
-        <div class="flex-1 max-w-lg">
-            <div class="border-b mb-4" style="border-color: var(--borders)">
-                <h3 class="text-3xl font-medium">Latest Blogs</h3>
-            </div>
-            <ng-container *ngIf="blogs.length === 0; else hasBlogs">
-                <div class="empty">
-                    <h3>Nothing to see here...</h3>
-                    <p>
-                        Check back when this user has posted something!
-                    </p>
-                </div>
-            </ng-container>
-            <ng-template #hasBlogs>
-                <ng-container *ngFor="let blog of blogs">
-                    <dragonfish-blog-card [blog]="blog" [showAuthor]="false"></dragonfish-blog-card>
-                    <div class="my-3.5"><!--spacer--></div>
+<ng-container *ngIf="!mobileMode; else mobile">
+    <div class="flex flex-row justify-center w-11/12 mx-auto my-6">
+        <ng-container *ngIf="profile.profile$ | async as portUser">
+            <div class="p-4 w-52">
+                <h5 class="text-2xl font-medium text-center">About Me</h5>
+                <ng-container *ngIf="portUser.profile.bio">
+                    <p class="text-sm text-center">{{ portUser.profile.bio }}</p>
+                    <div class="my-2.5 border-b" style="border-color: var(--borders)"><!--spacer--></div>
                 </ng-container>
-            </ng-template>
-        </div>
-    </ng-container>
-    <div class="mx-4"><!--spacer--></div>
-    <ng-container *ngIf="profile.works$ | async as works">
-        <div class="max-w-sm">
-            <div class="border-b mb-4" style="border-color: var(--borders)">
-                <h3 class="text-3xl font-medium">Latest Works</h3>
-            </div>
-            <ng-container *ngIf="works.length === 0; else hasWorks">
-                <div class="empty">
-                    <h3>Nothing to see here...</h3>
-                    <p>
-                        Check back when this user has posted something!
-                    </p>
+                <div class="flex flex-col items-center">
+                    <div class="flex flex-row items-center text-sm">
+                        <rmx-icon name="gift-2-line" class="mr-1"></rmx-icon>Joined {{ portUser.createdAt | localedate: 'mediumDate' }}
+                    </div>
                 </div>
-            </ng-container>
-            <ng-template #hasWorks>
-                <ng-container *ngFor="let work of works">
-                    <dragonfish-work-card [content]="work" [showAuthor]="false" [size]="'small'"></dragonfish-work-card>
-                    <div class="my-3.5"><!--spacer--></div>
+            </div>
+        </ng-container>
+        <div class="mx-4"><!--spacer--></div>
+        <ng-container *ngIf="profile.blogs$ | async as blogs">
+            <div class="flex-1 max-w-lg">
+                <div class="border-b mb-4" style="border-color: var(--borders)">
+                    <h3 class="text-3xl font-medium">Latest Blogs</h3>
+                </div>
+                <ng-container *ngIf="blogs.length === 0; else hasBlogs">
+                    <div class="empty">
+                        <h3>Nothing to see here...</h3>
+                        <p>
+                            Check back when this user has posted something!
+                        </p>
+                    </div>
                 </ng-container>
-            </ng-template>
-        </div>
-    </ng-container>
-</div>
+                <ng-template #hasBlogs>
+                    <ng-container *ngFor="let blog of blogs">
+                        <dragonfish-blog-card [blog]="blog" [showAuthor]="false"></dragonfish-blog-card>
+                        <div class="my-3.5"><!--spacer--></div>
+                    </ng-container>
+                </ng-template>
+            </div>
+        </ng-container>
+        <div class="mx-4"><!--spacer--></div>
+        <ng-container *ngIf="profile.works$ | async as works">
+            <div class="max-w-sm">
+                <div class="border-b mb-4" style="border-color: var(--borders)">
+                    <h3 class="text-3xl font-medium">Latest Works</h3>
+                </div>
+                <ng-container *ngIf="works.length === 0; else hasWorks">
+                    <div class="empty">
+                        <h3>Nothing to see here...</h3>
+                        <p>
+                            Check back when this user has posted something!
+                        </p>
+                    </div>
+                </ng-container>
+                <ng-template #hasWorks>
+                    <ng-container *ngFor="let work of works">
+                        <dragonfish-work-card [content]="work" [showAuthor]="false" [size]="'small'"></dragonfish-work-card>
+                        <div class="my-3.5"><!--spacer--></div>
+                    </ng-container>
+                </ng-template>
+            </div>
+        </ng-container>
+    </div>
+</ng-container>
+<ng-template #mobile>
+    <div class="justify-center w-11/12 mx-auto my-6 mb-16">
+        <ng-container *ngIf="profile.profile$ | async as portUser">
+            <div class="max-w-sm">
+                <div class="border-b mb-4" style="border-color: var(--borders)">
+                    <h3 class="text-3xl font-medium">About Me</h3>
+                </div>
+                <ng-container *ngIf="portUser.profile.bio">
+                    <p class="text-sm">{{ portUser.profile.bio }}</p>
+                </ng-container>
+                <div class="flex flex-col">
+                    <div class="flex flex-row text-sm">
+                        <rmx-icon name="gift-2-line" class="mr-1"></rmx-icon>Joined {{ portUser.createdAt | localedate: 'mediumDate' }}
+                    </div>
+                </div>
+            </div>
+        </ng-container>
+        <div class="my-4"><!--spacer--></div>
+        <ng-container *ngIf="profile.works$ | async as works">
+            <div class="max-w-sm">
+                <div class="border-b mb-4" style="border-color: var(--borders)">
+                    <h3 class="text-3xl font-medium">Latest Works</h3>
+                </div>
+                <ng-container *ngIf="works.length === 0; else hasWorks">
+                    <div class="empty">
+                        <h3>Nothing to see here...</h3>
+                        <p>
+                            Check back when this user has posted something!
+                        </p>
+                    </div>
+                </ng-container>
+                <ng-template #hasWorks>
+                    <ng-container *ngFor="let work of works">
+                        <dragonfish-work-card [content]="work" [showAuthor]="false" [size]="'small'"></dragonfish-work-card>
+                        <div class="my-3.5"><!--spacer--></div>
+                    </ng-container>
+                </ng-template>
+            </div>
+        </ng-container>
+        <div class="my-4"><!--spacer--></div>
+        <ng-container *ngIf="profile.blogs$ | async as blogs">
+            <div class="flex-1 max-w-lg">
+                <div class="border-b mb-4" style="border-color: var(--borders)">
+                    <h3 class="text-3xl font-medium">Latest Blogs</h3>
+                </div>
+                <ng-container *ngIf="blogs.length === 0; else hasBlogs">
+                    <div class="empty">
+                        <h3>Nothing to see here...</h3>
+                        <p>
+                            Check back when this user has posted something!
+                        </p>
+                    </div>
+                </ng-container>
+                <ng-template #hasBlogs>
+                    <ng-container *ngFor="let blog of blogs">
+                        <dragonfish-blog-card [blog]="blog" [showAuthor]="false"></dragonfish-blog-card>
+                        <div class="my-3.5"><!--spacer--></div>
+                    </ng-container>
+                </ng-template>
+            </div>
+        </ng-container>
+    </div>
+</ng-template>

--- a/libs/client/profile/src/lib/views/profile-info/profile-info.component.ts
+++ b/libs/client/profile/src/lib/views/profile-info/profile-info.component.ts
@@ -1,11 +1,22 @@
-import { Component } from '@angular/core';
+import { Component, HostListener, OnInit } from '@angular/core';
 import { ProfileRepository } from '@dragonfish/client/repository/profile';
+import { isMobile } from '@dragonfish/shared/functions';
 
 @Component({
     selector: 'dragonfish-profile-home',
     templateUrl: './profile-info.component.html',
     styleUrls: ['./profile-info.component.scss'],
 })
-export class ProfileInfoComponent {
+export class ProfileInfoComponent implements OnInit {
+    mobileMode = false;
     constructor(public profile: ProfileRepository) {}
+
+    ngOnInit(): void {
+        this.onResize();
+    }
+
+    @HostListener('window:resize', ['$event'])
+    onResize() {
+        this.mobileMode = isMobile();
+    }
 }

--- a/libs/client/profile/src/lib/views/works/works.component.html
+++ b/libs/client/profile/src/lib/views/works/works.component.html
@@ -36,7 +36,7 @@
                 </div>
             </ng-container>
             <ng-template #hasPubWorks>
-                <div class="grid 2xl:grid-cols-4 lg:grid-cols-3 md:grid-cols-2 sm:grid-cols-1 gap-2 w-11/12 mx-auto my-6">
+                <div class="grid 2xl:grid-cols-4 lg:grid-cols-3 md:grid-cols-2 sm:grid-cols-1 gap-2 w-11/12 mx-auto my-8">
                     <ng-container *ngFor="let blog of userWorks.pubWorks">
                         <dragonfish-work-card [content]="blog"></dragonfish-work-card>
                     </ng-container>
@@ -51,7 +51,7 @@
                 </div>
             </ng-container>
             <ng-template #hasDraftWorks>
-                <div class="grid 2xl:grid-cols-4 lg:grid-cols-3 md:grid-cols-2 sm:grid-cols-1 gap-2 w-11/12 mx-auto my-6">
+                <div class="grid 2xl:grid-cols-4 lg:grid-cols-3 md:grid-cols-2 sm:grid-cols-1 gap-2 w-11/12 mx-auto my-8">
                     <ng-container *ngFor="let work of userWorks.draftWorks">
                         <dragonfish-work-card [content]="work"></dragonfish-work-card>
                     </ng-container>
@@ -66,7 +66,7 @@
                 </div>
             </ng-container>
             <ng-template #hasPendingWorks>
-                <div class="grid 2xl:grid-cols-4 lg:grid-cols-3 md:grid-cols-2 sm:grid-cols-1 gap-2 w-11/12 mx-auto my-6">
+                <div class="grid 2xl:grid-cols-4 lg:grid-cols-3 md:grid-cols-2 sm:grid-cols-1 gap-2 w-11/12 mx-auto my-8">
                     <ng-container *ngFor="let work of userWorks.pendingWorks">
                         <dragonfish-work-card [content]="work"></dragonfish-work-card>
                     </ng-container>

--- a/libs/client/profile/src/lib/views/works/works.component.html
+++ b/libs/client/profile/src/lib/views/works/works.component.html
@@ -36,7 +36,7 @@
                 </div>
             </ng-container>
             <ng-template #hasPubWorks>
-                <div class="grid 2xl:grid-cols-4 lg:grid-cols-3 md:grid-cols-2 sm:grid-cols-1 gap-2 w-11/12 mx-auto my-8">
+                <div class="grid 2xl:grid-cols-4 lg:grid-cols-3 md:grid-cols-2 sm:grid-cols-1 gap-2 w-11/12 mx-auto my-8 mb-16">
                     <ng-container *ngFor="let blog of userWorks.pubWorks">
                         <dragonfish-work-card [content]="blog"></dragonfish-work-card>
                     </ng-container>
@@ -51,7 +51,7 @@
                 </div>
             </ng-container>
             <ng-template #hasDraftWorks>
-                <div class="grid 2xl:grid-cols-4 lg:grid-cols-3 md:grid-cols-2 sm:grid-cols-1 gap-2 w-11/12 mx-auto my-8">
+                <div class="grid 2xl:grid-cols-4 lg:grid-cols-3 md:grid-cols-2 sm:grid-cols-1 gap-2 w-11/12 mx-auto my-8 mb-16">
                     <ng-container *ngFor="let work of userWorks.draftWorks">
                         <dragonfish-work-card [content]="work"></dragonfish-work-card>
                     </ng-container>
@@ -66,7 +66,7 @@
                 </div>
             </ng-container>
             <ng-template #hasPendingWorks>
-                <div class="grid 2xl:grid-cols-4 lg:grid-cols-3 md:grid-cols-2 sm:grid-cols-1 gap-2 w-11/12 mx-auto my-8">
+                <div class="grid 2xl:grid-cols-4 lg:grid-cols-3 md:grid-cols-2 sm:grid-cols-1 gap-2 w-11/12 mx-auto my-8 mb-16">
                     <ng-container *ngFor="let work of userWorks.pendingWorks">
                         <dragonfish-work-card [content]="work"></dragonfish-work-card>
                     </ng-container>
@@ -77,7 +77,7 @@
 </ng-container>
 
 <ng-template #nonUserWorksList>
-    <div class="grid 2xl:grid-cols-4 lg:grid-cols-3 md:grid-cols-2 sm:grid-cols-1 gap-2 w-11/12 mx-auto my-8" *ngIf="userWorks.totalWorks !== 0; else noGalleryWorks">
+    <div class="grid 2xl:grid-cols-4 lg:grid-cols-3 md:grid-cols-2 sm:grid-cols-1 gap-2 w-11/12 mx-auto my-8 mb-16" *ngIf="userWorks.totalWorks !== 0; else noGalleryWorks">
         <ng-container
             *ngFor="
                 let work of userWorks.pubWorks

--- a/libs/client/ui/src/lib/components/work-card/work-card.component.scss
+++ b/libs/client/ui/src/lib/components/work-card/work-card.component.scss
@@ -3,6 +3,7 @@ span.medium-card {
     color: var(--text-color);
     h3.title {
         @apply relative top-0.5 font-medium flex-1 text-xl overflow-hidden overflow-ellipsis whitespace-nowrap;
+        width: 1rem;
     }
     &:hover {
         @apply text-white scale-105 no-underline z-30;

--- a/libs/shared/src/lib/constants/content-constants.ts
+++ b/libs/shared/src/lib/constants/content-constants.ts
@@ -7,4 +7,4 @@ export const MIN_GENRES = 1;
 export const MAX_GENRES = 3;
 export const MAX_FANDOM_TAGS = 5;
 
-export const TAGS_ENABLED = false;
+export const TAGS_ENABLED = true;


### PR DESCRIPTION
## Description
Mostly addresses #688

## Changes
- Fix profile header for mobile
- Fixes profile home page on mobile
- Fixes appearance of works list on mobile
- By setting a starting width for work cards, they properly expand to hold their content, rather than growing too large with long titles
- Enable tags

Doesn't fix profile blog and bookshelf pages, though they aren't terrible on mobile right now

## Areas Affected
- [ ] Site Navigation
- [ ] Home
- [ ] Sign In/Out
- [ ] Registration
- [ ] Settings

.
- [x] Profile
- [ ] My Library
- [ ] Bookshelves
- [ ] Editor
- [ ] Browse
- [ ] Work Card

.
- [ ] Work Page
- [ ] Blog Page
- [ ] Comments
- [ ] Search
- [ ] Other Pages

.
- [ ] Account Authentication
- [ ] Dashboard
- [x] Mobile
