### PR TITLE
Removes conditions for pagination controls appearing on works and blogs pages

### DIFF
--- a/libs/client/profile/src/lib/views/blogs/blogs.component.html
+++ b/libs/client/profile/src/lib/views/blogs/blogs.component.html
@@ -119,19 +119,21 @@
         </ng-container>
     </ng-container>
     <ng-template #notThisUser>
-        <ng-container *ngIf="profile.profile$ | async as portUser">
-            <div class="my-6 w-7/12 mx-auto" *ngIf="userBlogsQuery.totalBlogs !== 0; else noGalleryBlogs">
-                <ng-container *ngFor="let blog of userBlogsQuery.pubBlogs | paginate: {itemsPerPage: userBlogsQuery.perPage, currentPage: userBlogsQuery.currPage, totalItems: userBlogsQuery.totalBlogs}">
-                    <dragonfish-blog-card [blog]="blog" [showAuthor]="false"></dragonfish-blog-card>
-                </ng-container>
-            </div>
-            <ng-template #noGalleryBlogs>
-                <div class="empty">
-                    <h3>There's nothing here...</h3>
-                    <p>Check back later to see if {{ portUser.screenName }} adds anything!</p>
+        <div class="mb-16">
+            <ng-container *ngIf="profile.profile$ | async as portUser">
+                <div class="my-6 w-7/12 mx-auto" *ngIf="userBlogsQuery.totalBlogs !== 0; else noGalleryBlogs">
+                    <ng-container *ngFor="let blog of userBlogsQuery.pubBlogs | paginate: {itemsPerPage: userBlogsQuery.perPage, currentPage: userBlogsQuery.currPage, totalItems: userBlogsQuery.totalBlogs}">
+                        <dragonfish-blog-card [blog]="blog" [showAuthor]="false"></dragonfish-blog-card>
+                    </ng-container>
                 </div>
-            </ng-template>
-            <pagination-controls (pageChange)="onPageChange($event)" previousLabel="" nextLabel=""></pagination-controls>
-        </ng-container>
+                <ng-template #noGalleryBlogs>
+                    <div class="empty">
+                        <h3>There's nothing here...</h3>
+                        <p>Check back later to see if {{ portUser.screenName }} adds anything!</p>
+                    </div>
+                </ng-template>
+                <pagination-controls (pageChange)="onPageChange($event)" previousLabel="" nextLabel=""></pagination-controls>
+            </ng-container>
+        </div>
     </ng-template>
 </div>

--- a/libs/client/profile/src/lib/views/blogs/blogs.component.html
+++ b/libs/client/profile/src/lib/views/blogs/blogs.component.html
@@ -131,9 +131,7 @@
                     <p>Check back later to see if {{ portUser.screenName }} adds anything!</p>
                 </div>
             </ng-template>
-            <ng-container *ngIf="userBlogsQuery.totalPages > 1">
-                <pagination-controls (pageChange)="onPageChange($event)" previousLabel="" nextLabel=""></pagination-controls>
-            </ng-container>
+            <pagination-controls (pageChange)="onPageChange($event)" previousLabel="" nextLabel=""></pagination-controls>
         </ng-container>
     </ng-template>
 </div>

--- a/libs/client/profile/src/lib/views/works/works.component.html
+++ b/libs/client/profile/src/lib/views/works/works.component.html
@@ -77,26 +77,28 @@
 </ng-container>
 
 <ng-template #nonUserWorksList>
-    <div class="grid 2xl:grid-cols-4 lg:grid-cols-3 md:grid-cols-2 sm:grid-cols-1 gap-2 w-11/12 mx-auto my-8 mb-16" *ngIf="userWorks.totalWorks !== 0; else noGalleryWorks">
-        <ng-container
-            *ngFor="
-                let work of userWorks.pubWorks
-                    | paginate
-                        : {
-                              itemsPerPage: userWorks.perPage,
-                              currentPage: userWorks.currPage,
-                              totalItems: userWorks.totalWorks
-                          }
-            "
-        >
-            <dragonfish-work-card [content]="work" [showAuthor]="false"></dragonfish-work-card>
-        </ng-container>
-    </div>
-    <ng-template #noGalleryWorks>
-        <div class="empty">
-            <h3>There's nothing here...</h3>
-            <p>Check back later to see if {{ profile.screenName }} adds anything!</p>
+    <div class="mb-16">
+        <div class="grid 2xl:grid-cols-4 lg:grid-cols-3 md:grid-cols-2 sm:grid-cols-1 gap-2 w-11/12 mx-auto my-8" *ngIf="userWorks.totalWorks !== 0; else noGalleryWorks">
+            <ng-container
+                *ngFor="
+                    let work of userWorks.pubWorks
+                        | paginate
+                            : {
+                                itemsPerPage: userWorks.perPage,
+                                currentPage: userWorks.currPage,
+                                totalItems: userWorks.totalWorks
+                            }
+                "
+            >
+                <dragonfish-work-card [content]="work" [showAuthor]="false"></dragonfish-work-card>
+            </ng-container>
         </div>
-    </ng-template>
-    <pagination-controls (pageChange)="onPageChange($event)" previousLabel="" nextLabel=""></pagination-controls>
+        <ng-template #noGalleryWorks>
+            <div class="empty">
+                <h3>There's nothing here...</h3>
+                <p>Check back later to see if {{ profile.screenName }} adds anything!</p>
+            </div>
+        </ng-template>
+        <pagination-controls (pageChange)="onPageChange($event)" previousLabel="" nextLabel=""></pagination-controls>
+    </div>
 </ng-template>

--- a/libs/client/profile/src/lib/views/works/works.component.html
+++ b/libs/client/profile/src/lib/views/works/works.component.html
@@ -98,7 +98,5 @@
             <p>Check back later to see if {{ profile.screenName }} adds anything!</p>
         </div>
     </ng-template>
-    <ng-container *ngIf="userWorks.currPage > 1">
-        <pagination-controls (pageChange)="onPageChange($event)" previousLabel="" nextLabel=""></pagination-controls>
-    </ng-container>
+    <pagination-controls (pageChange)="onPageChange($event)" previousLabel="" nextLabel=""></pagination-controls>
 </ng-template>


### PR DESCRIPTION
## Description
Issue where there are no pagination controls for works. Noticed by users.

## Changes
- Works pagination controls only appear if you're on a page after the first. The intention was to display if total pages are more than 1, but to match Search, I removed the condition entirely.
- I did the same for blogs.
- In the process of fixing bottom margins for the works page, also added bottom margins to the blogs page.

## Areas Affected
- [ ] Site Navigation
- [ ] Home
- [ ] Sign In/Out
- [ ] Registration
- [ ] Settings

.
- [ ] Profile
- [ ] My Library
- [ ] Bookshelves
- [ ] Editor
- [ ] Browse
- [ ] Work Card

.
- [x] Work Page
- [x] Blog Page
- [ ] Comments
- [ ] Search
- [ ] Other Pages

.
- [ ] Account Authentication
- [ ] Dashboard
- [ ] Mobile
