### PR TITLE
If there's a failure in creating a pseudonym, then logs out

### DIFF
--- a/apps/bettafish/src/app/pages/registration/setup-pseud/setup-pseud.component.ts
+++ b/apps/bettafish/src/app/pages/registration/setup-pseud/setup-pseud.component.ts
@@ -49,10 +49,17 @@ export class SetupPseudComponent implements OnInit {
             pronouns: this.pseudForm.controls.pronouns.value,
         };
 
-        this.auth.createPseudonym(formData).subscribe(() => {
-            this.loading = false;
-            this.pseudForm.reset();
-            this.router.navigate(['/registration/select-pseud']).catch((err) => console.log(err));
+        this.auth.createPseudonym(formData).subscribe({
+            next: () => {
+                this.loading = false;
+                this.pseudForm.reset();
+                this.router.navigate(['/registration/select-pseud']).catch((err) => console.log(err));
+            },
+            error: () => {
+                this.auth.logout().subscribe(() => {
+                    this.router.navigate(['/']).catch((err) => console.log(err));
+                });
+            }
         });
     }
 }


### PR DESCRIPTION
## Description
Related to #783 but that turned out to not be connected to the issue with creating pseudonyms resulting in an infinite spinner and the newly created pseudonym successfully being created on the server but it not appearing locally until you log out, allowing you to create more pseudonyms than the limit.

Instead of fixing that error, this attempts to address the pseudonym issue.

## Changes
If there's an error when creating a pseudonym, then it logs the user out.

## Areas Affected
- [ ] Site Navigation
- [ ] Home
- [x] Sign In/Out
- [x] Registration
- [ ] Settings

.
- [ ] Profile
- [ ] My Library
- [ ] Bookshelves
- [ ] Editor
- [ ] Browse
- [ ] Work Card

.
- [ ] Work Page
- [ ] Blog Page
- [ ] Comments
- [ ] Search
- [ ] Other Pages

.
- [ ] Account Authentication
- [ ] Dashboard
- [ ] Mobile
