### PR TITLE
Sort works on your profile by published date

### DIFF
--- a/apps/api/src/app/controllers/content/content.controller.ts
+++ b/apps/api/src/app/controllers/content/content.controller.ts
@@ -101,14 +101,6 @@ export class ContentController {
     @ApiTags(DragonfishTags.Content)
     @UseGuards(IdentityGuard)
     @Identity(Roles.User)
-    @Get('fetch-all')
-    async fetchAll(@User() user: JwtPayload, @Query('pseudId') pseudId: string) {
-        return await this.content.fetchAll(pseudId);
-    }
-
-    @ApiTags(DragonfishTags.Content)
-    @UseGuards(IdentityGuard)
-    @Identity(Roles.User)
     @Get('fetch-all-by-kind')
     async fetchAllByKind(@Query('pseudId') pseudId: string, @Query('kinds') kinds: ContentKind[]) {
         return await this.content.fetchAllByKind(pseudId, kinds);

--- a/apps/api/src/app/services/content/content.service.ts
+++ b/apps/api/src/app/services/content/content.service.ts
@@ -50,10 +50,6 @@ export class ContentService {
         return await this.contentGroup.fetchOnePublished(contentId, kind, user);
     }
 
-    public async fetchAll(userId: string): Promise<ContentModel[]> {
-        return await this.content.fetchAll(userId);
-    }
-
     public async fetchAllByKind(userId: string, kinds: ContentKind[]): Promise<PaginateResult<ContentModel>> {
         return await this.content.fetchAllByKind(userId, kinds);
     }

--- a/libs/api/database/src/lib/content/stores/content.store.ts
+++ b/libs/api/database/src/lib/content/stores/content.store.ts
@@ -81,21 +81,6 @@ export class ContentStore {
     }
 
     /**
-     * Finds a bunch of content documents belonging to a user, per that user's
-     * request.
-     *
-     * @param userId The user making the request
-     */
-    async fetchAll(userId: string): Promise<ContentDocument[]> {
-        return this.content
-            .find({
-                author: userId,
-                'audit.isDeleted': false,
-            })
-            .sort({ createdAt: 1 });
-    }
-
-    /**
      * Finds a bunch of content documents belonging to a user, per that user's request, filtered by ContentKind.
      *
      * @param userId
@@ -107,7 +92,10 @@ export class ContentStore {
             kind: { $in: kinds },
             'audit.isDeleted': false,
         };
-        const paginateOptions: PaginateOptions = { sort: { createdAt: this.NEWEST_FIRST }, pagination: false };
+        const paginateOptions: PaginateOptions = {
+            sort: { 'audit.publishedOn': this.NEWEST_FIRST, createdAt: this.NEWEST_FIRST },
+            pagination: false
+        };
 
         return await this.content.paginate(query, paginateOptions);
     }

--- a/libs/client/profile/src/lib/views/works/works.component.html
+++ b/libs/client/profile/src/lib/views/works/works.component.html
@@ -37,8 +37,8 @@
             </ng-container>
             <ng-template #hasPubWorks>
                 <div class="grid 2xl:grid-cols-4 lg:grid-cols-3 md:grid-cols-2 sm:grid-cols-1 gap-2 w-11/12 mx-auto my-8 mb-16">
-                    <ng-container *ngFor="let blog of userWorks.pubWorks">
-                        <dragonfish-work-card [content]="blog"></dragonfish-work-card>
+                    <ng-container *ngFor="let work of userWorks.pubWorks">
+                        <dragonfish-work-card [content]="work"></dragonfish-work-card>
                     </ng-container>
                 </div>
             </ng-template>

--- a/libs/client/services/src/lib/dragonfish-network.service.ts
+++ b/libs/client/services/src/lib/dragonfish-network.service.ts
@@ -1079,20 +1079,6 @@ export class DragonfishNetworkService {
     }
 
     /**
-     * Fetches all files related to the current user from the backend.
-     *
-     * @returns Observable
-     */
-    public fetchAll(pseudId: string): Observable<ContentModel[]> {
-        return handleResponse(
-            this.http.get<ContentModel[]>(`${this.baseUrl}/content/fetch-all?pseudId=${pseudId}`, {
-                observe: 'response',
-                withCredentials: true,
-            }),
-        );
-    }
-
-    /**
      * Sends a request to create a piece of content to the backend, with the route determined by its
      * `ContentKind`.
      *


### PR DESCRIPTION
## Description
I noticed that with works that are published well after creation, this results in works appearing in a different order when looking at your work list while signed in and while signed out / logged in as a different user.

## Changes
- Sorts works on your profile by published date
- If published date isn't present, sorts by created on date like before
- Removes unused method fetchAll()
- Fixes variable name in works.component.html

## Areas Affected
- [ ] Site Navigation
- [ ] Home
- [ ] Sign In/Out
- [ ] Registration
- [ ] Settings

.
- [x] Profile
- [ ] My Library
- [ ] Bookshelves
- [ ] Editor
- [ ] Browse
- [ ] Work Card

.
- [ ] Work Page
- [ ] Blog Page
- [ ] Comments
- [ ] Search
- [ ] Other Pages

.
- [ ] Account Authentication
- [ ] Dashboard
- [ ] Mobile
