### PR TITLE
Adds likes and section publish dates to work pages; handles works with deleted users; adds word counts to approval queue

### DIFF
--- a/libs/client/dashboard/src/lib/components/approval-queue/content-preview/content-preview.component.html
+++ b/libs/client/dashboard/src/lib/components/approval-queue/content-preview/content-preview.component.html
@@ -121,7 +121,7 @@
                 </div>
                 <div class="separator">//</div>
                 <div class="tag" title='Words'>
-                    <i-feather name="pen-tool"></i-feather>{{ currDoc.workToApprove.stats.words | abbreviate }}
+                    <i-feather name="pen-tool"></i-feather>{{ currDoc.workToApprove.stats.words }}
                 </div>
                 <div class="separator">//</div>
                 <div class="tag" title='Created On'>

--- a/libs/client/dashboard/src/lib/pages/approval-queue/approval-queue.component.html
+++ b/libs/client/dashboard/src/lib/pages/approval-queue/approval-queue.component.html
@@ -16,6 +16,7 @@
                 <th>Tags</th>
                 <th>Fandom Tags</th>
                 <th>Rating</th>
+                <th>Words</th>
                 <th>Submitted</th>
             </tr>
             </thead>
@@ -68,6 +69,9 @@
                 </td>
                 <td class="p-2 border-r border-gray-600 dark:border-white">
                     {{ entry.workToApprove.meta.rating }}
+                </td>
+                <td class="p-2 border-r border-gray-600 dark:border-white">
+                    {{ entry.workToApprove.stats.words | abbreviate }}
                 </td>
                 <td class="p-2">
                     {{ entry.createdAt | localedate: 'shortDate' }}

--- a/libs/client/ui/src/lib/components/sections-list/sections-list.component.html
+++ b/libs/client/ui/src/lib/components/sections-list/sections-list.component.html
@@ -12,7 +12,7 @@
                     <div class="text-sm uppercase flex flex-row items-center">
                             <span class="tag" [matTooltip]="'Words'" [matTooltipClass]="'offprint-tooltip'">
                                 <i-feather name="pen-tool"></i-feather>
-                                {{ section.stats.words | abbreviate }}
+                                {{ section.stats.words }}
                             </span>
                         <span class="divider">//</span>
                         <span

--- a/libs/client/ui/src/lib/components/work-card/work-card.component.html
+++ b/libs/client/ui/src/lib/components/work-card/work-card.component.html
@@ -18,12 +18,17 @@
     <div class="flex flex-wrap items-center pb-0.5 text-xs border-b border-gray-600 dark:border-white group-hover:border-white">
         <div class="flex-1">
             by 
-            <a
-                class="author-link"
-                [routerLink]="['/profile', content.author._id, content.author.userTag]"
-            >
-                {{ $any(content.author).screenName }}
-            </a>
+            <ng-container *ngIf="content.author !== null; else unknown">
+                <a
+                    class="author-link"
+                    [routerLink]="['/profile', content.author._id, content.author.userTag]"
+                >
+                    {{ $any(content.author).screenName }}
+                </a>
+            </ng-container>
+            <ng-template #unknown>
+                unknown
+            </ng-template>
         </div>
         <div class="flex items-center">
             <rmx-icon name="heart-line" class="relative top-1" style="width: 1rem;"></rmx-icon>
@@ -161,12 +166,17 @@
     <div class="rounded-md px-1 text-xs flex items-center bg-gray-200 dark:bg-gray-600">
         <div>
             by 
-            <a
-                class="author-link"
-                [routerLink]="['/profile', content.author._id, content.author.userTag]"
-            >
-                {{ $any(content.author).screenName }}
-            </a>
+            <ng-container *ngIf="content.author !== null; else unknown">
+                <a
+                    class="author-link"
+                    [routerLink]="['/profile', content.author._id, content.author.userTag]"
+                >
+                    {{ $any(content.author).screenName }}
+                </a>
+            </ng-container>
+            <ng-template #unknown>
+                unknown
+            </ng-template>
         </div>
         <div class="text-sm mx-0.5 relative -top-0.5">
             •

--- a/libs/client/work-page/src/lib/components/sections-list/sections-list.component.html
+++ b/libs/client/work-page/src/lib/components/sections-list/sections-list.component.html
@@ -30,7 +30,7 @@
                                 <div class="flex text-xs">
                                     <div class="flex items-center" [matTooltip]="'Words'" [matTooltipClass]="'offprint-tooltip'" [matTooltipShowDelay]="300">
                                         <rmx-icon name="pen-nib-line" class="relative top-1 mr-0.5" style="width: 1rem;"></rmx-icon>
-                                        <span>{{ indexedSection.section.stats.words | abbreviate }}</span>
+                                        <span>{{ indexedSection.section.stats.words }}</span>
                                     </div>
                                     <div class="text-sm mx-0.5 relative">
                                         •
@@ -67,7 +67,7 @@
                                 <div class="flex text-xs">
                                     <div class="flex items-center" [matTooltip]="'Words'" [matTooltipClass]="'offprint-tooltip'" [matTooltipShowDelay]="300">
                                         <rmx-icon name="pen-nib-line" class="relative top-1 mr-0.5" style="width: 1rem;"></rmx-icon>
-                                        <span>{{ indexedSection.section.stats.words | abbreviate }}</span>
+                                        <span>{{ indexedSection.section.stats.words }}</span>
                                     </div>
                                     <div class="text-sm mx-0.5 relative">
                                         •
@@ -110,7 +110,7 @@
                             <div class="flex text-xs">
                                 <div class="flex items-center" [matTooltip]="'Words'" [matTooltipClass]="'offprint-tooltip'" [matTooltipShowDelay]="300">
                                     <rmx-icon name="pen-nib-line" class="relative top-1 mr-0.5" style="width: 1rem;"></rmx-icon>
-                                    <span>{{ section.stats.words | abbreviate }}</span>
+                                    <span>{{ section.stats.words }}</span>
                                 </div>
                                 <div class="text-sm mx-0.5 relative">
                                     •

--- a/libs/client/work-page/src/lib/components/sections-list/sections-list.component.html
+++ b/libs/client/work-page/src/lib/components/sections-list/sections-list.component.html
@@ -23,22 +23,32 @@
                             >
                                 <rmx-icon name="checkbox-circle-line"></rmx-icon>
                             </div>
-                            <ng-container *ngIf="!mobileMode; else mobilePublished">
-                                <div class="section-button mid"
-                                    [routerLink]="goToSectionReader(indexedSection.index, indexedSection.section.title)"
-                                >
-                                    <div class="flex-1">{{ indexedSection.section.title }}</div>
-                                    <div>{{ indexedSection.section.stats.words | abbreviate }} word{{ indexedSection.section.stats.words | pluralize }}</div>
+                            <div class="section-button mid"
+                                [routerLink]="goToSectionReader(indexedSection.index, indexedSection.section.title)"
+                            >
+                                <div class="flex-1">{{ indexedSection.section.title }}</div>
+                                <div class="flex text-xs">
+                                    <div class="flex items-center" [matTooltip]="'Words'" [matTooltipClass]="'offprint-tooltip'" [matTooltipShowDelay]="300">
+                                        <rmx-icon name="pen-nib-line" class="relative top-1 mr-0.5" style="width: 1rem;"></rmx-icon>
+                                        <span>{{ indexedSection.section.stats.words | abbreviate }}</span>
+                                    </div>
+                                    <div class="text-sm mx-0.5 relative">
+                                        •
+                                    </div>
+                                    <ng-container *ngIf="indexedSection.section.audit.publishedOn; else creationDate">
+                                        <div class="flex items-center" [matTooltip]="'Published on'" [matTooltipClass]="'offprint-tooltip'" [matTooltipShowDelay]="300">
+                                            <rmx-icon name="calendar-2-line" class="relative top-1 mr-0.5" style="width: 1rem;"></rmx-icon>
+                                            <span>{{ indexedSection.section.audit.publishedOn | localedate: 'mediumDate' }}</span>
+                                        </div>
+                                    </ng-container>
+                                    <ng-template #creationDate>
+                                        <div class="flex items-center" [matTooltip]="'Created on'" [matTooltipClass]="'offprint-tooltip'" [matTooltipShowDelay]="300">
+                                            <rmx-icon name="calendar-2-line" class="relative top-1 mr-0.5" style="width: 1rem;"></rmx-icon>
+                                            <span>{{ indexedSection.section.createdAt | localedate: 'mediumDate' }}</span>
+                                        </div>
+                                    </ng-template>
                                 </div>
-                            </ng-container>
-                            <ng-template #mobilePublished>
-                                <div class="mobile-section-button mid"
-                                    [routerLink]="goToSectionReader(indexedSection.index, indexedSection.section.title)"
-                                >
-                                    <div class="flex-1">{{ indexedSection.section.title }}</div>
-                                    <div class="text-xs">{{ indexedSection.section.stats.words | abbreviate }} word{{ indexedSection.section.stats.words | pluralize }}</div>
-                                </div>
-                            </ng-template>
+                            </div>
                         </ng-container>
                         <ng-template #notPublished>
                             <div
@@ -50,22 +60,32 @@
                             >
                                 <rmx-icon name="checkbox-blank-circle-line"></rmx-icon>
                             </div>
-                            <ng-container *ngIf="!mobileMode; else mobileNotPublished">
-                                <div class="section-button mid"
-                                    [routerLink]="goToSectionAuthor(indexedSection.section._id)"
-                                >
-                                    <div class="flex-1">{{ indexedSection.section.title }}</div>
-                                    <div>{{ indexedSection.section.stats.words | abbreviate }} word{{ indexedSection.section.stats.words | pluralize }}</div>
+                            <div class="section-button mid"
+                                [routerLink]="goToSectionAuthor(indexedSection.section._id)"
+                            >
+                                <div class="flex-1">{{ indexedSection.section.title }}</div>
+                                <div class="flex text-xs">
+                                    <div class="flex items-center" [matTooltip]="'Words'" [matTooltipClass]="'offprint-tooltip'" [matTooltipShowDelay]="300">
+                                        <rmx-icon name="pen-nib-line" class="relative top-1 mr-0.5" style="width: 1rem;"></rmx-icon>
+                                        <span>{{ indexedSection.section.stats.words | abbreviate }}</span>
+                                    </div>
+                                    <div class="text-sm mx-0.5 relative">
+                                        •
+                                    </div>
+                                    <ng-container *ngIf="indexedSection.section.audit.publishedOn; else creationDate">
+                                        <div class="flex items-center" [matTooltip]="'Published on'" [matTooltipClass]="'offprint-tooltip'" [matTooltipShowDelay]="300">
+                                            <rmx-icon name="calendar-2-line" class="relative top-1 mr-0.5" style="width: 1rem;"></rmx-icon>
+                                            <span>{{ indexedSection.section.audit.publishedOn | localedate: 'mediumDate' }}</span>
+                                        </div>
+                                    </ng-container>
+                                    <ng-template #creationDate>
+                                        <div class="flex items-center" [matTooltip]="'Created on'" [matTooltipClass]="'offprint-tooltip'" [matTooltipShowDelay]="300">
+                                            <rmx-icon name="calendar-2-line" class="relative top-1 mr-0.5" style="width: 1rem;"></rmx-icon>
+                                            <span>{{ indexedSection.section.createdAt | localedate: 'mediumDate' }}</span>
+                                        </div>
+                                    </ng-template>
                                 </div>
-                            </ng-container>
-                            <ng-template #mobileNotPublished>
-                                <div class="mobile-section-button mid"
-                                    [routerLink]="goToSectionAuthor(indexedSection.section._id)"
-                                >
-                                    <div class="flex-1">{{ indexedSection.section.title }}</div>
-                                    <div class="text-xs">{{ indexedSection.section.stats.words | abbreviate }} word{{ indexedSection.section.stats.words | pluralize }}</div>
-                                </div>
-                            </ng-template>
+                            </div>
                         </ng-template>
                         <div
                             class="pub-button end border-gray-600 dark:border-white"
@@ -85,18 +105,30 @@
                     <li
                         class="section-item border-gray-600 dark:border-white"
                     >
-                        <ng-container *ngIf="!mobileMode; else mobileNotThisUser">
-                            <div class="section-button" [routerLink]="['section', i + 1, section.title | slugify]">
-                                <div class="flex-1">{{ section.title }}</div>
-                                <div>{{ section.stats.words | abbreviate }} word{{ section.stats.words | pluralize }}</div>
+                        <div class="section-button" [routerLink]="['section', i + 1, section.title | slugify]">
+                            <div class="flex-1">{{ section.title }}</div>
+                            <div class="flex text-xs">
+                                <div class="flex items-center" [matTooltip]="'Words'" [matTooltipClass]="'offprint-tooltip'" [matTooltipShowDelay]="300">
+                                    <rmx-icon name="pen-nib-line" class="relative top-1 mr-0.5" style="width: 1rem;"></rmx-icon>
+                                    <span>{{ section.stats.words | abbreviate }}</span>
+                                </div>
+                                <div class="text-sm mx-0.5 relative">
+                                    •
+                                </div>
+                                <ng-container *ngIf="section.audit.publishedOn; else creationDate">
+                                    <div class="flex items-center" [matTooltip]="'Published on'" [matTooltipClass]="'offprint-tooltip'" [matTooltipShowDelay]="300">
+                                        <rmx-icon name="calendar-2-line" class="relative top-1 mr-0.5" style="width: 1rem;"></rmx-icon>
+                                        <span>{{ section.audit.publishedOn | localedate: 'mediumDate' }}</span>
+                                    </div>
+                                </ng-container>
+                                <ng-template #creationDate>
+                                    <div class="flex items-center" [matTooltip]="'Created on'" [matTooltipClass]="'offprint-tooltip'" [matTooltipShowDelay]="300">
+                                        <rmx-icon name="calendar-2-line" class="relative top-1 mr-0.5" style="width: 1rem;"></rmx-icon>
+                                        <span>{{ section.createdAt | localedate: 'mediumDate' }}</span>
+                                    </div>
+                                </ng-template>
                             </div>
-                        </ng-container>
-                        <ng-template #mobileNotThisUser>
-                            <div class="mobile-section-button" [routerLink]="['section', i + 1, section.title | slugify]">
-                                <div class="flex-1">{{ section.title }}</div>
-                                <div class="text-xs">{{ section.stats.words | abbreviate }} word{{ section.stats.words | pluralize }}</div>
-                            </div>
-                        </ng-template>
+                        </div>
                     </li>
                 </ng-container>
             </ul>

--- a/libs/client/work-page/src/lib/components/sections-list/sections-list.component.scss
+++ b/libs/client/work-page/src/lib/components/sections-list/sections-list.component.scss
@@ -25,16 +25,6 @@ li.section-item {
         }
     }
     div.section-button {
-        @apply flex items-center px-4 py-2 flex-1 cursor-pointer;
-        &:hover {
-            @apply text-white;
-            background: var(--accent);
-        }
-        &.mid {
-            @apply rounded-none;
-        }
-    }
-    div.mobile-section-button {
         @apply items-center px-4 py-2 w-full cursor-pointer;
         &:hover {
             @apply text-white;

--- a/libs/client/work-page/src/lib/components/work-banner/work-banner.component.html
+++ b/libs/client/work-page/src/lib/components/work-banner/work-banner.component.html
@@ -2,7 +2,7 @@
     <ng-container *ngIf="!mobileMode; else mobile">
         <div class="flex w-11/12 md:w-9/12 lg:7/12 mx-auto px-4 py-6">
             <ng-container *ngIf="content.meta.coverArt; else uploadArt">
-                <ng-container *ngIf="auth.checkPseudonym(content.author._id); else notThisAuthorArt">
+                <ng-container *ngIf="content.author !== null && auth.checkPseudonym(content.author._id); else notThisAuthorArt">
                     <div
                         class="edit-cover-art rounded-md"
                         [matTooltip]="'Edit Cover Art'"
@@ -26,7 +26,7 @@
                     [matTooltip]="'Add Cover Art'"
                     [matTooltipClass]="'offprint-tooltip'"
                     (click)="uploadCoverArt(content._id, content.kind)"
-                    *ngIf="auth.checkPseudonym(content.author._id)"
+                    *ngIf="content.author !== null && auth.checkPseudonym(content.author._id)"
                 >
                     <rmx-icon name="add-box-line"></rmx-icon>
                 </div>
@@ -35,9 +35,16 @@
                 <div class="flex items-center">
                     <div class="flex-1">
                         <h1 class="text-white text-4xl font-medium">{{ content.title }}</h1>
-                        <h2 class="text-white text-xl italic hover:underline cursor-pointer" [routerLink]="['/profile', content.author._id, content.author.userTag]">
-                            by {{ content.author.screenName }}
-                        </h2>
+                        <ng-container *ngIf="content.author !== null; else unknown">
+                            <h2 class="text-white text-xl italic hover:underline cursor-pointer" [routerLink]="['/profile', content.author._id, content.author.userTag]">
+                                by {{ content.author.screenName }}
+                            </h2>
+                        </ng-container>
+                        <ng-template #unknown>
+                            <h2 class="text-white text-xl italic cursor-pointer">
+                                by unknown
+                            </h2>
+                        </ng-template>
                     </div>
                     <ng-container *ngIf="auth.checkPseudonym(workQuery.authorId); else otherButtons">
                         <ng-container [ngSwitch]="content.audit.published">
@@ -147,9 +154,16 @@
             <div class="flex flex-row items-center">
                 <div class="flex-1">
                     <h1 class="text-white text-4xl font-medium">{{ content.title }}</h1>
-                    <h2 class="text-white text-xl italic hover:underline cursor-pointer" [routerLink]="['/profile', content.author._id, content.author.userTag]">
-                        by {{ content.author.screenName }}
-                    </h2>
+                    <ng-container *ngIf="content.author !== null; else unknown">
+                        <h2 class="text-white text-xl italic hover:underline cursor-pointer" [routerLink]="['/profile', content.author._id, content.author.userTag]">
+                            by {{ content.author.screenName }}
+                        </h2>
+                    </ng-container>
+                    <ng-template #unknown>
+                        <h2 class="text-white text-xl italic cursor-pointer">
+                            by unknown
+                        </h2>
+                    </ng-template>
                 </div>
             </div>
             <!--Controls-->
@@ -211,7 +225,7 @@
             </div>
             <!--Cover Art-->
             <ng-container *ngIf="content.meta.coverArt; else uploadArt">
-                <ng-container *ngIf="auth.checkPseudonym(content.author._id); else notThisAuthorArt">
+                <ng-container *ngIf="content.author !== null && auth.checkPseudonym(content.author._id); else notThisAuthorArt">
                     <div
                         class="edit-cover-art rounded-md"
                         [matTooltip]="'Edit Cover Art'"
@@ -235,7 +249,7 @@
                     [matTooltip]="'Add Cover Art'"
                     [matTooltipClass]="'offprint-tooltip'"
                     (click)="uploadCoverArt(content._id, content.kind)"
-                    *ngIf="auth.checkPseudonym(content.author._id)"
+                    *ngIf="content.author !== null && auth.checkPseudonym(content.author._id)"
                 >
                     <rmx-icon name="add-box-line"></rmx-icon>
                 </div>

--- a/libs/client/work-page/src/lib/views/content-info/content-info.component.html
+++ b/libs/client/work-page/src/lib/views/content-info/content-info.component.html
@@ -20,57 +20,95 @@
                 </div>
             </div>
             <div class="flex flex-col items-center" style="width: 10.83625rem;">
-                <div class="flex items-center border-b border-gray-600 dark:border-white pb-2">
+                <div class="flex items-center pb-2">
                     <ng-container *ngIf="session.isLoggedIn; else noRatings">
                         <ng-container [ngSwitch]="workQuery.currRating">
                             <ng-container *ngSwitchCase="ratingOption.NoVote">
-                                <button class="border border-gray-600 dark:border-white px-4" (click)="workPage.addLike(content._id)">
+                                <button
+                                    class="border border-gray-600 dark:border-white"
+                                    (click)="addLike(content._id)"
+                                    [matTooltip]="'Like'"
+                                    [matTooltipClass]="'offprint-tooltip'"
+                                >
                                     <rmx-icon name="heart-line"></rmx-icon>
-                                    <span>Like</span>
+                                    <span>{{ likes }}</span>
                                 </button>
                                 <div class="mx-0.5"></div>
-                                <button class="border border-gray-600 dark:border-white" (click)="workPage.addDislike(content._id)">
+                                <button
+                                    class="border border-gray-600 dark:border-white"
+                                    (click)="addDislike(content._id)"
+                                    [matTooltip]="'Dislike'"
+                                    [matTooltipClass]="'offprint-tooltip'"
+                                >
                                     <rmx-icon name="dislike-line"></rmx-icon>
-                                    <span>Dislike</span>
+                                    <span>{{ dislikes }}</span>
                                 </button>
                             </ng-container>
                             <ng-container *ngSwitchCase="ratingOption.Liked">
-                                <button class="border border-gray-600 dark:border-white px-3.5 active" (click)="workPage.setNoVote(content._id)">
+                                <button
+                                    class="border border-gray-600 dark:border-white active"
+                                    (click)="setNoVote(content._id)"
+                                    [matTooltip]="'Liked'"
+                                    [matTooltipClass]="'offprint-tooltip'"
+                                >
                                     <rmx-icon name="heart-fill"></rmx-icon>
-                                    <span>Liked</span>
+                                    <span>{{ likes }}</span>
                                 </button>
                                 <div class="mx-0.5"></div>
-                                <button class="border border-gray-600 dark:border-white" (click)="workPage.addDislike(content._id)">
+                                <button
+                                    class="border border-gray-600 dark:border-white"
+                                    (click)="addDislike(content._id)"
+                                    [matTooltip]="'Dislike'"
+                                    [matTooltipClass]="'offprint-tooltip'"
+                                >
                                     <rmx-icon name="dislike-line"></rmx-icon>
-                                    <span>Dislike</span>
+                                    <span>{{ dislikes }}</span>
                                 </button>
                             </ng-container>
                             <ng-container *ngSwitchCase="ratingOption.Disliked">
-                                <button class="border border-gray-600 dark:border-white px-4" (click)="workPage.addLike(content._id)">
+                                <button
+                                    class="border border-gray-600 dark:border-white"
+                                    (click)="addLike(content._id)"
+                                    [matTooltip]="'Like'"
+                                    [matTooltipClass]="'offprint-tooltip'"
+                                >
                                     <rmx-icon name="heart-line"></rmx-icon>
-                                    <span>Like</span>
+                                    <span>{{ likes }}</span>
                                 </button>
                                 <div class="mx-0.5"></div>
-                                <button class="border border-gray-600 dark:border-white active" (click)="workPage.setNoVote(content._id)">
+                                <button
+                                    class="border border-gray-600 dark:border-white active"
+                                    (click)="setNoVote(content._id)"
+                                    [matTooltip]="'Disliked'"
+                                    [matTooltipClass]="'offprint-tooltip'"
+                                >
                                     <rmx-icon name="dislike-fill"></rmx-icon>
-                                    <span>Disliked</span>
+                                    <span>{{ dislikes }}</span>
                                 </button>
                             </ng-container>
                         </ng-container>
                     </ng-container>
                     <ng-template #noRatings>
-                        <button class="border border-gray-600 dark:border-white px-4">
+                        <button
+                            class="border border-gray-600 dark:border-white"
+                            [matTooltip]="'Like'"
+                            [matTooltipClass]="'offprint-tooltip'"
+                        >
                             <rmx-icon name="heart-line"></rmx-icon>
-                            <span>Like</span>
+                            <span>{{ likes }}</span>
                         </button>
                         <div class="mx-0.5"></div>
-                        <button class="border border-gray-600 dark:border-white">
+                        <button
+                            class="border border-gray-600 dark:border-white"
+                            [matTooltip]="'Dislike'"
+                            [matTooltipClass]="'offprint-tooltip'"
+                        >
                             <rmx-icon name="dislike-line"></rmx-icon>
-                            <span>Dislike</span>
+                            <span>{{ dislikes }}</span>
                         </button>
                     </ng-template>
                 </div>
-                <div class="text-center py-2 border-b border-gray-600 dark:border-white w-full">
+                <div class="text-center py-2 border-b border-t border-gray-600 dark:border-white w-full">
                     <ng-container *ngIf="content.audit.published === 'Published'">
                         <h4 class="text-xl font-medium">Published on</h4>
                         <span class="uppercase font-semibold font-serif text-lg tracking-wider">{{ content.audit.publishedOn | localedate:'mediumDate' }}</span>
@@ -103,49 +141,87 @@
                 <ng-container *ngIf="session.isLoggedIn; else noRatings">
                     <ng-container [ngSwitch]="workQuery.currRating">
                         <ng-container *ngSwitchCase="ratingOption.NoVote">
-                            <button class="border border-gray-600 dark:border-white px-4" (click)="workPage.addLike(content._id)">
+                            <button
+                                class="border border-gray-600 dark:border-white"
+                                (click)="addLike(content._id)"
+                                [matTooltip]="'Like'"
+                                [matTooltipClass]="'offprint-tooltip'"
+                            >
                                 <rmx-icon name="heart-line"></rmx-icon>
-                                <span>Like</span>
+                                <span>{{ likes }}</span>
                             </button>
                             <div class="mx-0.5"></div>
-                            <button class="border border-gray-600 dark:border-white" (click)="workPage.addDislike(content._id)">
+                            <button
+                                class="border border-gray-600 dark:border-white"
+                                (click)="addDislike(content._id)"
+                                [matTooltip]="'Dislike'"
+                                [matTooltipClass]="'offprint-tooltip'"
+                            >
                                 <rmx-icon name="dislike-line"></rmx-icon>
-                                <span>Dislike</span>
+                                <span>{{ dislikes }}</span>
                             </button>
                         </ng-container>
                         <ng-container *ngSwitchCase="ratingOption.Liked">
-                            <button class="border border-gray-600 dark:border-white px-3.5 active" (click)="workPage.setNoVote(content._id)">
+                            <button
+                                class="border border-gray-600 dark:border-white active"
+                                (click)="setNoVote(content._id)"
+                                [matTooltip]="'Liked'"
+                                [matTooltipClass]="'offprint-tooltip'"
+                            >
                                 <rmx-icon name="heart-fill"></rmx-icon>
-                                <span>Liked</span>
+                                <span>{{ likes }}</span>
                             </button>
                             <div class="mx-0.5"></div>
-                            <button class="border border-gray-600 dark:border-white" (click)="workPage.addDislike(content._id)">
+                            <button
+                                class="border border-gray-600 dark:border-white"
+                                (click)="addDislike(content._id)"
+                                [matTooltip]="'Dislike'"
+                                [matTooltipClass]="'offprint-tooltip'"
+                            >
                                 <rmx-icon name="dislike-line"></rmx-icon>
-                                <span>Dislike</span>
+                                <span>{{ dislikes }}</span>
                             </button>
                         </ng-container>
                         <ng-container *ngSwitchCase="ratingOption.Disliked">
-                            <button class="border border-gray-600 dark:border-white px-4" (click)="workPage.addLike(content._id)">
+                            <button
+                                class="border border-gray-600 dark:border-white"
+                                (click)="addLike(content._id)"
+                                [matTooltip]="'Like'"
+                                [matTooltipClass]="'offprint-tooltip'"
+                            >
                                 <rmx-icon name="heart-line"></rmx-icon>
-                                <span>Like</span>
+                                <span>{{ likes }}</span>
                             </button>
                             <div class="mx-0.5"></div>
-                            <button class="border border-gray-600 dark:border-white active" (click)="workPage.setNoVote(content._id)">
+                            <button
+                                class="border border-gray-600 dark:border-white active"
+                                (click)="setNoVote(content._id)"
+                                [matTooltip]="'Disliked'"
+                                [matTooltipClass]="'offprint-tooltip'"
+                            >
                                 <rmx-icon name="dislike-fill"></rmx-icon>
-                                <span>Disliked</span>
+                                <span>{{ dislikes }}</span>
                             </button>
                         </ng-container>
                     </ng-container>
                 </ng-container>
                 <ng-template #noRatings>
-                    <button class="border border-gray-600 dark:border-white px-4">
+                    <button
+                        class="border border-gray-600 dark:border-white"
+                        [matTooltip]="'Like'"
+                        [matTooltipClass]="'offprint-tooltip'"
+                    >
                         <rmx-icon name="heart-line"></rmx-icon>
-                        <span>Like</span>
+                        <span>{{ likes }}</span>
                     </button>
                     <div class="mx-0.5"></div>
-                    <button class="border border-gray-600 dark:border-white">
+                    <button
+                        class="border border-gray-600 dark:border-white"
+                        [matTooltip]="'Dislike'"
+                        [matTooltipClass]="'offprint-tooltip'"
+                    >
                         <rmx-icon name="dislike-line"></rmx-icon>
-                        <span>Dislike</span>
+                        <span>{{ dislikes }}</span>
                     </button>
                 </ng-template>
             </div>

--- a/libs/client/work-page/src/lib/views/content-info/content-info.component.ts
+++ b/libs/client/work-page/src/lib/views/content-info/content-info.component.ts
@@ -12,6 +12,8 @@ import { isMobile } from '@dragonfish/shared/functions';
 })
 export class ContentInfoComponent implements OnInit {
     ratingOption = RatingOption;
+    likes = 0;
+    dislikes = 0;
     mobileMode = false;
     mobileShowDescription = false;
     mobileShowInfo = false;
@@ -25,6 +27,53 @@ export class ContentInfoComponent implements OnInit {
 
     ngOnInit(): void {
         this.onResize();
+        this.likes = this.workQuery.likes;
+        this.dislikes = this.workQuery.dislikes;
+    }
+    
+    addLike(contentId: string): void {
+        switch (this.workQuery.currRating) {
+            case RatingOption.Liked:
+                return;
+            case RatingOption.Disliked:
+                this.likes = this.likes + 1;
+                this.dislikes = this.dislikes - 1;
+                break;
+            case RatingOption.NoVote:
+                this.likes = this.likes + 1;
+                break;
+        }
+
+        this.workPage.addLike(contentId);
+    }
+
+    addDislike(contentId: string): void {
+        switch (this.workQuery.currRating) {
+            case RatingOption.Disliked:
+                return;
+            case RatingOption.Liked:
+                this.likes = this.likes - 1;
+                this.dislikes = this.dislikes + 1;
+                break;
+            case RatingOption.NoVote:
+                this.dislikes = this.dislikes + 1;
+                break;
+        }
+
+        this.workPage.addDislike(contentId);
+    }
+
+    setNoVote(contentId: string): void {
+        switch (this.workQuery.currRating) {
+            case RatingOption.Liked:
+                this.likes = this.likes - 1;
+                break;
+            case RatingOption.Disliked:
+                this.dislikes = this.dislikes - 1;
+                break;
+        }
+        
+        this.workPage.setNoVote(contentId);
     }
 
     toggleShowDescription() {


### PR DESCRIPTION
## Description
Partially addresses #778
Closes #708

## Changes
- Display like and dislike numbers on work pages
- Removes "like" and "dislike" text, makes that text a tooltip
- Add publish dates to section listings
- Changes appearance of section listings
- Uses same appearance for desktop and mobile

![image](https://user-images.githubusercontent.com/71996084/148280630-be2fe771-c555-474b-a72d-7ed9b33aead4.png)
![image](https://user-images.githubusercontent.com/71996084/148280520-2d51df05-a86b-45c1-811c-12f5ffe6c1ee.png)

- Check if the author is null, and display name as "unknown" if so
- Displays word counts in claim work screen approval queue
- Displays actual word counts for works in approval queue, rather than rounding

## Areas Affected
- [ ] Site Navigation
- [ ] Home
- [ ] Sign In/Out
- [ ] Registration
- [ ] Settings

.
- [ ] Profile
- [ ] My Library
- [ ] Bookshelves
- [ ] Editor
- [x] Browse
- [x] Work Card

.
- [x] Work Page
- [ ] Blog Page
- [ ] Comments
- [ ] Search
- [ ] Other Pages

.
- [ ] Account Authentication
- [x] Dashboard
- [x] Mobile
