### PR TITLE
Adds more error handling around adding profiles, fixes error with setting local session store

### DIFF
--- a/apps/api/src/app/controllers/auth/auth.controller.ts
+++ b/apps/api/src/app/controllers/auth/auth.controller.ts
@@ -1,4 +1,14 @@
-import { Body, Controller, ForbiddenException, Get, NotFoundException, Post, Request, UseGuards } from '@nestjs/common';
+import {
+    Body,
+    Controller,
+    ForbiddenException,
+    Get,
+    NotFoundException,
+    Post,
+    Query,
+    Request,
+    UseGuards,
+} from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 import { Cookies, SetCookies } from '@nestjsplus/cookies';
 import { RefreshGuard, RolesGuard } from '../../guards';
@@ -79,5 +89,12 @@ export class AuthController {
     @Post('add-pseudonym')
     async addPseudonym(@User() user: JwtPayload, @Body() formData: PseudonymForm): Promise<Pseudonym> {
         return await this.auth.createPseudonym(user, formData);
+    }
+
+    @ApiTags(DragonfishTags.Auth)
+    @UseGuards(RolesGuard([Roles.User]))
+    @Get('user-tag-exists')
+    async userTagExists(@Query('userTag') userTag: string): Promise<boolean> {
+        return await this.auth.userTagExists(userTag);
     }
 }

--- a/apps/api/src/app/services/auth/auth.service.ts
+++ b/apps/api/src/app/services/auth/auth.service.ts
@@ -105,6 +105,10 @@ export class AuthService {
     //#region ---PSEUDONYMS---
 
     public async createPseudonym(user: JwtPayload, formInfo: PseudonymForm): Promise<Pseudonym> {
+        if (isNullOrUndefined(user)) {
+            throw new NotFoundException(`Your user information was not available.`);
+        }
+
         const thisAccount = await this.accountStore.fetchAccountById(user.sub);
 
         if (isNullOrUndefined(thisAccount)) {
@@ -114,6 +118,15 @@ export class AuthService {
         const newPseud = await this.pseudStore.createPseud(user, formInfo);
         await this.accountStore.addPseudonym(thisAccount._id, newPseud._id);
         return newPseud;
+    }
+
+    /**
+     * Determines if the given userTag is already in use
+     * @param userTag
+     * @returns
+     */
+    public async userTagExists(userTag: string): Promise<boolean> {
+        return await this.pseudStore.userTagExists(userTag);
     }
 
     //#endregion

--- a/apps/bettafish/src/app/pages/registration/setup-pseud/setup-pseud.component.html
+++ b/apps/bettafish/src/app/pages/registration/setup-pseud/setup-pseud.component.html
@@ -6,7 +6,7 @@
                 [formControlName]="'userTag'"
                 [name]="'userTag'"
                 [type]="'text'"
-                [label]="'Username'"
+                [label]="'User Tag'"
                 [placeholder]="'ABrandNewSoul'"
             ></dragonfish-text-field>
 

--- a/apps/bettafish/src/app/pages/registration/setup-pseud/setup-pseud.component.ts
+++ b/apps/bettafish/src/app/pages/registration/setup-pseud/setup-pseud.component.ts
@@ -32,7 +32,8 @@ export class SetupPseudComponent implements OnInit {
     async submitForm() {
         this.loading = true;
 
-        if (this.pseudForm.controls.userTag.invalid) {
+        const letters = /^[0-9a-zA-Z]+$/;
+        if (this.pseudForm.controls.userTag.invalid || !this.pseudForm.controls.userTag.value.match(letters)) {
             this.alerts.error(
                 `Make sure your user tag has no special characters or spaces, and is between 3 and 16 characters.`,
             );
@@ -41,7 +42,7 @@ export class SetupPseudComponent implements OnInit {
         }
 
         if (this.pseudForm.controls.screenName.invalid) {
-            this.alerts.error(`Screen names must be between 3 and 32 characters.`);
+            this.alerts.error(`Display names must be between 3 and 32 characters.`);
             this.loading = false;
             return;
         }
@@ -71,8 +72,13 @@ export class SetupPseudComponent implements OnInit {
                 this.auth.forceLogout()
                     .pipe(delay(1500))
                     .subscribe(() => {
-                        console.log("Got error creating profile: " + err.error.message);
-                        this.alerts.error(err.error.message);
+                        if (err.error) {
+                            console.log("Got error creating profile: " + err.error.message);
+                            this.alerts.error(err.error.message);
+                        } else {
+                            console.log("Got error creating profile: " + err);
+                            this.alerts.error(err);
+                        }
                     });
             }
         });

--- a/apps/bettafish/src/app/pages/registration/setup-pseud/setup-pseud.component.ts
+++ b/apps/bettafish/src/app/pages/registration/setup-pseud/setup-pseud.component.ts
@@ -6,6 +6,7 @@ import { AuthService } from '@dragonfish/client/repository/session/services';
 import { AlertsService } from '@dragonfish/client/alerts';
 import { Router } from '@angular/router';
 import { Constants, setTwoPartTitle } from '@dragonfish/shared/constants';
+import { delay, firstValueFrom } from 'rxjs';
 
 @Component({
     selector: 'dragonfish-setup-pseud',
@@ -28,18 +29,20 @@ export class SetupPseudComponent implements OnInit {
         setTwoPartTitle(Constants.ADD_PROFILE);
     }
 
-    submitForm() {
+    async submitForm() {
         this.loading = true;
 
         if (this.pseudForm.controls.userTag.invalid) {
             this.alerts.error(
                 `Make sure your user tag has no special characters or spaces, and is between 3 and 16 characters.`,
             );
+            this.loading = false;
             return;
         }
 
         if (this.pseudForm.controls.screenName.invalid) {
             this.alerts.error(`Screen names must be between 3 and 32 characters.`);
+            this.loading = false;
             return;
         }
 
@@ -49,16 +52,28 @@ export class SetupPseudComponent implements OnInit {
             pronouns: this.pseudForm.controls.pronouns.value,
         };
 
+        // Validate that user tag is unique
+        if (await firstValueFrom(this.auth.userTagExists(formData.userTag))) {
+            this.alerts.error(
+                `Username is already in use. Display names can be repeated, but usernames must be unique.`
+            );
+            this.loading = false;
+            return;
+        }
+
         this.auth.createPseudonym(formData).subscribe({
             next: () => {
                 this.loading = false;
                 this.pseudForm.reset();
                 this.router.navigate(['/registration/select-pseud']).catch((err) => console.log(err));
             },
-            error: () => {
-                this.auth.logout().subscribe(() => {
-                    this.router.navigate(['/']).catch((err) => console.log(err));
-                });
+            error: (err) => {
+                this.auth.forceLogout()
+                    .pipe(delay(1500))
+                    .subscribe(() => {
+                        console.log("Got error creating profile: " + err.error.message);
+                        this.alerts.error(err.error.message);
+                    });
             }
         });
     }

--- a/libs/api/database/src/lib/accounts/stores/pseudonyms.store.ts
+++ b/libs/api/database/src/lib/accounts/stores/pseudonyms.store.ts
@@ -55,7 +55,7 @@ export class PseudonymsStore {
         }
         if (query.charAt(0) === '@') {
             return await this.pseudModel.paginate(
-                { userTag: query.substr(1) },
+                { userTag: query.substring(1) },
                 {
                     page: pageNum,
                     limit: maxPerPage,
@@ -69,6 +69,17 @@ export class PseudonymsStore {
                 page: pageNum,
                 limit: maxPerPage,
             },
+        );
+    }
+
+    /**
+     * Determines if the given userTag is already in use
+     * @param userTag
+     * @returns
+     */
+    public async userTagExists(userTag: string): Promise<boolean> {
+        return this.pseudModel.exists(
+            { userTag: userTag }
         );
     }
 

--- a/libs/client/repository/src/lib/session/services/auth.service.ts
+++ b/libs/client/repository/src/lib/session/services/auth.service.ts
@@ -121,7 +121,11 @@ export class AuthService {
             tap((result: Pseudonym) => {
                 this.sessionStore.update(({ currAccount }) => {
                     if (currAccount && currAccount.pseudonyms) {
-                        currAccount.pseudonyms = [...currAccount.pseudonyms, result];
+                        const newPseudonyms = [...currAccount.pseudonyms, result];
+                        currAccount = {
+                            ...currAccount,
+                            pseudonyms: newPseudonyms
+                        }
                     }
                 });
                 this.pseudService.addOne(result);

--- a/libs/client/repository/src/lib/session/services/auth.service.ts
+++ b/libs/client/repository/src/lib/session/services/auth.service.ts
@@ -4,7 +4,7 @@ import { SessionQuery } from '../session.query';
 import { DragonfishNetworkService } from '@dragonfish/client/services';
 import { AlertsService } from '@dragonfish/client/alerts';
 import { LoginModel, AccountForm, PseudonymForm, Pseudonym } from '@dragonfish/shared/models/accounts';
-import { throwError } from 'rxjs';
+import { Observable, throwError } from 'rxjs';
 import { catchError, tap } from 'rxjs/operators';
 import { LoginPackage } from '@dragonfish/shared/models/auth';
 import { PseudonymsService } from '../../pseudonyms/services';
@@ -36,7 +36,7 @@ export class AuthService {
             }),
             catchError((err) => {
                 this.alerts.error(err.error.message);
-                return throwError(err);
+                return throwError(() => err);
             }),
         );
     }
@@ -56,7 +56,7 @@ export class AuthService {
             }),
             catchError((err) => {
                 this.alerts.error(err.error.message);
-                return throwError(err);
+                return throwError(() => err);
             }),
         );
     }
@@ -67,17 +67,25 @@ export class AuthService {
     public logout() {
         return this.network.logout().pipe(
             tap(() => {
-                this.sessionStore.update({
-                    token: null,
-                    currAccount: null,
-                });
-                this.pseudService.clearAll();
-                this.router.navigate(['/']).catch((err) => console.log(err));
+                this.postLogout();
                 this.alerts.success(`See you next time!`);
             }),
             catchError((err) => {
                 this.alerts.error(err.error.message);
-                return throwError(err);
+                return throwError(() => err);
+            }),
+        );
+    }
+
+    public forceLogout() {
+        return this.network.logout().pipe(
+            tap(() => {
+                this.postLogout();
+                this.alerts.error("Forcing logout to resolve error");
+            }),
+            catchError((err) => {
+                this.alerts.error(err.error.message);
+                return throwError(() => err);
             }),
         );
     }
@@ -89,12 +97,7 @@ export class AuthService {
         return this.network.refreshToken().pipe(
             tap((result: string | null) => {
                 if (result === null) {
-                    this.sessionStore.update({
-                        token: null,
-                        currAccount: null,
-                    });
-                    this.pseudService.clearAll();
-                    this.router.navigate(['/']).catch((err) => console.log(err));
+                    this.postLogout();
                     this.alerts.info(`Your token has expired, and you've been logged out.`);
                 } else {
                     this.sessionStore.update({
@@ -104,7 +107,7 @@ export class AuthService {
             }),
             catchError((err) => {
                 this.alerts.error(err.error.message);
-                return throwError(err);
+                return throwError(() => err);
             }),
         );
     }
@@ -117,13 +120,14 @@ export class AuthService {
         return this.network.addPseudonym(formData).pipe(
             tap((result: Pseudonym) => {
                 this.sessionStore.update(({ currAccount }) => {
-                    currAccount.pseudonyms = [...currAccount.pseudonyms, result];
+                    if (currAccount && currAccount.pseudonyms) {
+                        currAccount.pseudonyms = [...currAccount.pseudonyms, result];
+                    }
                 });
                 this.pseudService.addOne(result);
             }),
             catchError((err) => {
-                this.alerts.error(err.error.message);
-                return throwError(err);
+                return throwError(() => err);
             }),
         );
     }
@@ -138,5 +142,26 @@ export class AuthService {
         } else {
             return false;
         }
+    }
+
+    /**
+     * Determines if the given userTag is already in use
+     * @param userTag
+     * @returns
+     */
+    public userTagExists(userTag: string): Observable<boolean> {
+        return this.network.userTagExists(userTag);
+    }
+
+    /**
+     * Actions taken client-side after logout, both in user requested and forced logout cases
+     */
+    private postLogout() {
+        this.sessionStore.update({
+            token: null,
+            currAccount: null,
+        });
+        this.pseudService.clearAll();
+        this.router.navigate(['/']).catch((err) => console.log(err));
     }
 }

--- a/libs/client/services/src/lib/dragonfish-network.service.ts
+++ b/libs/client/services/src/lib/dragonfish-network.service.ts
@@ -1372,6 +1372,20 @@ export class DragonfishNetworkService {
     }
 
     /**
+     * Determines if the given userTag is already in use
+     * @param userTag
+     * @returns
+     */
+    public userTagExists(userTag: string): Observable<boolean> {
+        return handleResponse(
+            this.http.get<boolean>(`${this.baseUrl}/auth/user-tag-exists?userTag=${userTag}`, {
+                observe: 'response',
+                withCredentials: true,
+            }),
+        );
+    }
+
+    /**
      * Fetches a pseudonym from the backend.
      *
      * @param pseudId

--- a/libs/shared/src/lib/models/accounts/frontend-account.ts
+++ b/libs/shared/src/lib/models/accounts/frontend-account.ts
@@ -1,5 +1,5 @@
-import { Pseudonym } from '@dragonfish/shared/models/accounts/psuedonyms';
-import { Roles } from '@dragonfish/shared/models/accounts/audit';
+import { Pseudonym } from './psuedonyms';
+import { Roles } from './audit';
 
 export interface FrontendAccount {
     readonly _id: string;


### PR DESCRIPTION
## Description
Users have been reporting issues with creating profiles. I have not been able to determine what the cause is, so instead, I decided to add more error handling around adding profiles.
EDIT: Narrowed down the likely issue, see final change

## Changes
- Validates that user tag / username isn't already in use
- Adds exceptions for possible null cases
- Stops loading icon when submit profile form with problems
- When new profile has error and logs out, displays error message rather than success message
- Updates some deprecated method calls
- Moves shared code for actions after logout to its own private method
- Handles case where current account is null (not encountered in testing)
- Changes "Username" label to "User Tag"
- Adds validation for only numbers and letters in user tag
- For Lint, simplifies imports in frontend-account.ts
- Fixes error when updating local session store with new profile caused by pseudonym array being read-only sometimes. Unclear why this happens, but modified code to work even if read-only.

## Areas Affected
- [ ] Site Navigation
- [ ] Home
- [x] Sign In/Out
- [ ] Registration
- [ ] Settings

.
- [ ] Profile
- [ ] My Library
- [ ] Bookshelves
- [ ] Editor
- [ ] Browse
- [ ] Work Card

.
- [ ] Work Page
- [ ] Blog Page
- [ ] Comments
- [ ] Search
- [ ] Other Pages

.
- [ ] Account Authentication
- [ ] Dashboard
- [ ] Mobile
