### PR TITLE
Fixes loading issues on Explore

### DIFF
--- a/apps/client/src/routes/explore/index.svelte
+++ b/apps/client/src/routes/explore/index.svelte
@@ -2,69 +2,75 @@
     import { Query } from '@sveltestack/svelte-query';
     import { page } from '$app/stores';
     import { fetchAllNew } from '$lib/services/content.service';
-    import { ContentKind } from '$lib/models/content';
+    import { Content, ContentKind } from '$lib/models/content';
     import { app } from '$lib/repo/app.repo';
     import { Loader5Line } from 'svelte-remixicon';
     import Paginator from '$lib/components/ui/misc/Paginator.svelte';
     import WorkCard from '$lib/components/ui/content/WorkCard.svelte';
     import { updateUrlParams } from '$lib/util';
+    import { onMount } from 'svelte';
+    import type { PaginateResult } from '$lib/models/util';
 
     let currPage = $page.url.searchParams.has('page') ? +$page.url.searchParams.get('page') : 1;
-    function setNewPage(pageNum: number) {
-        currPage = pageNum;
+    let contentResults: PaginateResult<Content> = null;
+    let loading = false;
+
+    onMount(async () => {
+        fetchPage(currPage);
+    })
+
+    async function fetchPage(page: number) {
+        loading = true;
+        currPage = page;
         updateUrlParams({
             page: currPage > 1 ? currPage.toString() : null,
         })
-    }
 
-    const fetchCurrPage = (page = currPage) =>
-        fetchAllNew(page, [ContentKind.PoetryContent, ContentKind.ProseContent], $app.filter);
+        contentResults = await fetchAllNew(
+            currPage,
+            [ContentKind.PoetryContent, ContentKind.ProseContent],
+            $app.filter
+        ).then((res) => {
+            loading = false;
+            return res;
+        })
+    }
 </script>
 
 <svelte:head>
     <title>New Works &mdash; Offprint</title>
 </svelte:head>
 
-<Query
-    options={{
-        queryKey: ['newWorks', currPage],
-        queryFn: () => fetchCurrPage(currPage),
-        keepPreviousData: true,
-    }}
->
-    <svelte:fragment slot="query" let:queryResult>
-        {#if queryResult.status === 'loading'}
-            <div class="w-full h-screen flex flex-col items-center justify-center">
-                <div class="flex items-center">
-                    <Loader5Line class="animate-spin mr-2" size="32px" />
-                    <span class="uppercase font-bold tracking-widest">Loading...</span>
-                </div>
+<div class="w-full h-[calc(100vh-51px)] md:h-screen overflow-y-auto">
+    {#if loading}
+        <div class="w-full flex flex-col items-center justify-center h-48 md:h-96">
+            <div class="flex items-center">
+                <Loader5Line class="animate-spin mr-2" size="24px" />
+                <span class="uppercase tracking-widest font-bold">Loading...</span>
             </div>
-        {:else if queryResult.status === 'error'}
-            <div class="w-full h-screen flex flex-col items-center justify-center">
-                <div class="flex items-center">
-                    <span class="uppercase font-bold tracking-widest"
-                        >ERROR: Could not fetch content</span
-                    >
+        </div>
+    {:else if contentResults && contentResults.totalDocs > 0}
+        <div class="w-full overflow-y-auto">
+            <div class="w-11/12 mx-auto my-6 max-w-7xl">
+                <div
+                    class="grid 2xl:grid-cols-4 lg:grid-cols-3 md:grid-cols-2 sm:grid-cols-1 gap-3 mb-6"
+                >
+                    {#each contentResults.docs.filter((work) => work.author !== null) as work}
+                        <WorkCard content={work} />
+                    {/each}
                 </div>
+                <Paginator
+                    {currPage}
+                    totalPages={contentResults.totalPages}
+                    on:change={(e) => fetchPage(e.detail)}
+                />
             </div>
-        {:else}
-            <div class="w-full overflow-y-auto">
-                <div class="w-11/12 mx-auto my-6 max-w-7xl">
-                    <div
-                        class="grid 2xl:grid-cols-4 lg:grid-cols-3 md:grid-cols-2 sm:grid-cols-1 gap-3 mb-6"
-                    >
-                        {#each queryResult.data.docs as work}
-                            <WorkCard content={work} />
-                        {/each}
-                    </div>
-                    <Paginator
-                        {currPage}
-                        totalPages={queryResult.data.totalPages}
-                        on:change={(e) => setNewPage(e.detail)}
-                    />
-                </div>
+        </div>
+    {:else}
+        <div class="w-full flex flex-col items-center justify-center h-96">
+            <div class="flex items-center">
+                <span class="uppercase tracking-widest font-bold">No results found</span>
             </div>
-        {/if}
-    </svelte:fragment>
-</Query>
+        </div>
+    {/if}
+</div>


### PR DESCRIPTION
Fixes #814 

- Uses same techniques as Search, which I confirmed has no loading issues on the live site
- Will stop page from fetching content every time focus shifts to the page
