### PR TITLE
Create new pagination controls logic

### DIFF
--- a/apps/client/src/lib/components/ui/misc/Paginator.svelte
+++ b/apps/client/src/lib/components/ui/misc/Paginator.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { ArrowLeftSLine, ArrowRightSLine } from 'svelte-remixicon';
+    import { ArrowLeftSLine, ArrowRightSLine, MoreLine } from 'svelte-remixicon';
     import { createEventDispatcher } from 'svelte';
 
     const PAGE_BUFFER = 2;
@@ -56,7 +56,7 @@
                 </li>
                 <li class:active={false} class="hidden md:block">
                     <button>
-                        ...
+                        <MoreLine/>
                     </button>
                 </li>
                 {#each range(PAGE_BUFFER, currPage - PAGE_BUFFER) as page}
@@ -93,7 +93,7 @@
                 {/each}
                 <li class:active={false} class="hidden md:block">
                     <button>
-                        ...
+                        <MoreLine/>
                     </button>
                 </li>
                 <li class:active={false} class="hidden md:block">

--- a/apps/client/src/lib/components/ui/misc/Paginator.svelte
+++ b/apps/client/src/lib/components/ui/misc/Paginator.svelte
@@ -2,6 +2,7 @@
     import { ArrowLeftSLine, ArrowRightSLine } from 'svelte-remixicon';
     import { createEventDispatcher } from 'svelte';
 
+    const PAGE_BUFFER = 2;
     export let currPage: number;
     export let totalPages: number;
 
@@ -27,13 +28,81 @@
                 <ArrowLeftSLine size="28px" />
             </button>
         </li>
-        {#each range(totalPages, 1) as page}
-            <li class:active={page === currPage} class="hidden md:block">
-                <button on:click={() => changePage(page)}>
-                    {page}
-                </button>
-            </li>
-        {/each}
+        {#if totalPages <= 10}
+            {#each range(totalPages, 1) as page}
+                <li class:active={page === currPage} class="hidden md:block">
+                    <button on:click={() => changePage(page)}>
+                        {page}
+                    </button>
+                </li>
+            {/each}
+        {:else}
+            <!--If current page is close enough to first page to display everything before and including it-->
+            <!--1234(5) with buffer of 2 displays 1, the selected 5, the two before it, and also 2 because "..." takes up the same space-->
+            {#if currPage <= PAGE_BUFFER + 3}
+                {#each range(currPage, 1) as page}
+                    <li class:active={page === currPage} class="hidden md:block">
+                        <button on:click={() => changePage(page)}>
+                            {page}
+                        </button>
+                    </li>
+                {/each}
+            <!--Otherwise, display 1 then "..." then the buffer before the current page, and current page-->
+            {:else}
+                <li class:active={false} class="hidden md:block">
+                    <button on:click={() => changePage(1)}>
+                        1
+                    </button>
+                </li>
+                <li class:active={false} class="hidden md:block">
+                    <button>
+                        ...
+                    </button>
+                </li>
+                {#each range(PAGE_BUFFER, currPage - PAGE_BUFFER) as page}
+                    <li class:active={false} class="hidden md:block">
+                        <button on:click={() => changePage(page)}>
+                            {page}
+                        </button>
+                    </li>
+                {/each}
+                <li class:active={true} class="hidden md:block">
+                    <button on:click={() => changePage(currPage)}>
+                        {currPage}
+                    </button>
+                </li>
+            {/if}
+            <!--If current page is close enough to last page, then display everything after it-->
+            <!--(5)6789 with buffer of 2 displays the two after the selected, the last, and also 8 because "..." takes up the same space-->
+            {#if totalPages - currPage <= PAGE_BUFFER + 2}
+                {#each range(totalPages - currPage, currPage + 1) as page}
+                    <li class:active={false} class="hidden md:block">
+                        <button on:click={() => changePage(page)}>
+                            {page}
+                        </button>
+                    </li>
+                {/each}
+            <!--Otherwise displays buffer after current page, then "..." then last page-->
+            {:else}
+                {#each range(PAGE_BUFFER, currPage + 1) as page}
+                    <li class:active={false} class="hidden md:block">
+                        <button on:click={() => changePage(page)}>
+                            {page}
+                        </button>
+                    </li>
+                {/each}
+                <li class:active={false} class="hidden md:block">
+                    <button>
+                        ...
+                    </button>
+                </li>
+                <li class:active={false} class="hidden md:block">
+                    <button on:click={() => changePage(totalPages)}>
+                        {totalPages}
+                    </button>
+                </li>
+            {/if}
+        {/if}
         <li class="mr-0" class:disabled={currPage === totalPages}>
             <button on:click={() => changePage(currPage + 1)} disabled={currPage === totalPages}>
                 <ArrowRightSLine size="28px" />


### PR DESCRIPTION
Should fix #822

If the current page is far enough from the start or end, it displays some number of pages then "..."
Looking at AO3, there's no drop down to select a page, so I think we can go without it.

It's set to display all pages if there are 10 or fewer. That was set to a lower value to take these pictures.
![image](https://user-images.githubusercontent.com/71996084/161461282-297b0bd0-c325-45a1-92ff-dcef0ea88214.png)
![image](https://user-images.githubusercontent.com/71996084/161461306-1adb3ed8-f51a-493a-9766-e2313f847521.png)
![image](https://user-images.githubusercontent.com/71996084/161461342-ce9b2f9d-f65d-4406-8355-45ef6bef7e80.png)
![image](https://user-images.githubusercontent.com/71996084/161461372-a4506bcc-ebe6-4532-b701-72fb215f6b60.png)
![image](https://user-images.githubusercontent.com/71996084/161461396-dcd0669d-6555-443a-9d59-a73915eeabfd.png)
