### PR TITLE
Fixes author on tag pages and search results

### DIFF
--- a/apps/api/src/modules/content/db/stores/content-group.store.ts
+++ b/apps/api/src/modules/content/db/stores/content-group.store.ts
@@ -291,11 +291,11 @@ export class ContentGroupStore {
     ): Promise<PaginateResult<ContentDocument>> {
         const paginateOptions: PaginateOptions = {
             sort: { 'audit.publishedOn': this.NEWEST_FIRST },
+            populate: 'author',
             page: pageNum,
             limit: maxPerPage,
             options: {
                 strictQuery: false,
-                populate: 'author',
             },
         };
         const paginateQuery = {


### PR DESCRIPTION
Author fields in work cards on tag pages and search results were displayed as undefined. This addresses it by moving where the author field is set to populate.