### PR TITLE
Fixes saving of $, <, and > in titles and descriptions

### DIFF
--- a/apps/api/src/modules/accounts/db/schemas/index.ts
+++ b/apps/api/src/modules/accounts/db/schemas/index.ts
@@ -2,7 +2,7 @@ import { AccountDocument, AccountSchema } from './account.schema';
 import { PseudonymDocument, PseudonymSchema } from './pseudonym.schema';
 import sanitizeHtml from 'sanitize-html';
 import { argon2id, hash } from 'argon2';
-import { sanitizeOptions } from '$shared/util';
+import { htmlReplace, sanitizeOptions } from '$shared/util';
 import { InviteCodesSchema } from './invite-codes.schema';
 import paginate from 'mongoose-paginate-v2';
 
@@ -55,19 +55,19 @@ export async function setupPseudonymCollection() {
 
     schema.pre<PseudonymDocument>('save', async function (next) {
         if (this.isModified('userTag')) {
-            this.set('userTag', sanitizeHtml(this.userTag));
+            this.set('userTag', htmlReplace(sanitizeHtml(this.userTag)));
         }
 
         if (this.isModified('screenName')) {
-            this.set('screenName', sanitizeHtml(this.screenName));
+            this.set('screenName', htmlReplace(sanitizeHtml(this.screenName)));
         }
 
         if (this.isModified('profile.bio')) {
-            this.set('profile.bio', sanitizeHtml(this.profile.bio, sanitizeOptions));
+            this.set('profile.bio', htmlReplace(sanitizeHtml(this.profile.bio, sanitizeOptions)));
         }
 
         if (this.isModified('profile.tagline')) {
-            this.set('profile.tagline', sanitizeHtml(this.profile.tagline));
+            this.set('profile.tagline', htmlReplace(sanitizeHtml(this.profile.tagline)));
         }
 
         return next();

--- a/apps/api/src/modules/content/db/schemas/index.ts
+++ b/apps/api/src/modules/content/db/schemas/index.ts
@@ -1,5 +1,5 @@
 import sanitizeHtml from 'sanitize-html';
-import { sanitizeOptions } from '$shared/util';
+import { htmlReplace, sanitizeOptions } from '$shared/util';
 import { ContentDocument, ContentSchema } from './content.schema';
 import { RatingsSchema } from './ratings.schema';
 import { ReadingHistorySchema } from './reading-history.schema';
@@ -39,13 +39,13 @@ export async function setupContentCollection() {
     schema.index({ title: 'text' });
 
     schema.pre<ContentDocument>('save', async function (next) {
-        this.set('title', sanitizeHtml(this.title, sanitizeOptions));
+        this.set('title', htmlReplace(sanitizeHtml(this.title, sanitizeOptions)));
         this.set('body', sanitizeHtml(this.body, sanitizeOptions));
 
         // this will only trigger if any creation or editing functions has modified the `desc` field,
         // otherwise we'll leave it alone
         if (this.isModified('desc')) {
-            this.set('desc', sanitizeHtml(this.desc, sanitizeOptions));
+            this.set('desc', htmlReplace(sanitizeHtml(this.desc, sanitizeOptions)));
         }
 
         return next();
@@ -64,7 +64,7 @@ export async function setupContentCollection() {
 export async function setupSectionsCollection() {
     const schema = SectionsSchema;
     schema.pre<SectionsDocument>('save', async function (next) {
-        this.set('title', sanitizeHtml(this.title, sanitizeOptions));
+        this.set('title', htmlReplace(sanitizeHtml(this.title, sanitizeOptions)));
         this.set('body', sanitizeHtml(this.body, sanitizeOptions));
         if (this.authorsNote) {
             this.set('authorsNote', sanitizeHtml(this.authorsNote, sanitizeOptions));
@@ -140,9 +140,9 @@ export async function setupBookshelvesCollection() {
     schema.plugin(paginate);
 
     schema.pre<BookshelfDocument>('save', async function (next) {
-        this.set('name', sanitizeHtml(this.name, sanitizeOptions));
+        this.set('name', htmlReplace(sanitizeHtml(this.name, sanitizeOptions)));
         if (this.isModified('desc')) {
-            this.set('desc', sanitizeHtml(this.desc, sanitizeOptions));
+            this.set('desc', htmlReplace(sanitizeHtml(this.desc, sanitizeOptions)));
         }
         return next();
     });

--- a/apps/api/src/modules/content/db/stores/blogs.store.ts
+++ b/apps/api/src/modules/content/db/stores/blogs.store.ts
@@ -3,7 +3,7 @@ import { InjectModel } from '@nestjs/mongoose';
 import { PaginateModel } from 'mongoose';
 import sanitizeHtml from 'sanitize-html';
 import { countWords, stripTags } from 'voca';
-import { sanitizeOptions } from '$shared/util';
+import { htmlReplace, sanitizeOptions } from '$shared/util';
 import { BlogsContentDocument } from '../schemas';
 import { BlogForm, NewsChange, PubChange } from '$shared/models/content';
 
@@ -24,8 +24,8 @@ export class BlogsStore {
     async createNewBlog(user: string, blogInfo: BlogForm): Promise<BlogsContentDocument> {
         const newBlog = new this.blogsModel({
             author: user,
-            title: sanitizeHtml(blogInfo.title),
-            desc: blogInfo.desc ? sanitizeHtml(blogInfo.desc) : null,
+            title: htmlReplace(sanitizeHtml(blogInfo.title)),
+            desc: blogInfo.desc ? htmlReplace(sanitizeHtml(blogInfo.desc)) : null,
             body: sanitizeHtml(blogInfo.body, sanitizeOptions),
             'meta.rating': blogInfo.rating,
             'stats.words': countWords(stripTags(sanitizeHtml(blogInfo.body, sanitizeOptions))),
@@ -53,8 +53,8 @@ export class BlogsStore {
             .findOneAndUpdate(
                 { _id: blogId, author: user },
                 {
-                    title: sanitizeHtml(blogInfo.title),
-                    desc: blogInfo.desc ? sanitizeHtml(blogInfo.desc) : null,
+                    title: htmlReplace(sanitizeHtml(blogInfo.title)),
+                    desc: blogInfo.desc ? htmlReplace(sanitizeHtml(blogInfo.desc)) : null,
                     body: sanitizeHtml(blogInfo.body, sanitizeOptions),
                     'meta.rating': blogInfo.rating,
                     'stats.words': wordCount,

--- a/apps/api/src/modules/content/db/stores/poetry.store.ts
+++ b/apps/api/src/modules/content/db/stores/poetry.store.ts
@@ -3,7 +3,7 @@ import { InjectModel } from '@nestjs/mongoose';
 import { PaginateModel } from 'mongoose';
 import sanitizeHtml from 'sanitize-html';
 import { countWords, stripTags } from 'voca';
-import { sanitizeOptions } from '$shared/util';
+import { htmlReplace, sanitizeOptions } from '$shared/util';
 import { CreatePoetry } from '$shared/models/content';
 import { PoetryContentDocument } from '../schemas';
 
@@ -23,8 +23,8 @@ export class PoetryStore {
     async createPoetry(user: string, poetryInfo: CreatePoetry): Promise<PoetryContentDocument> {
         const newPoetry = new this.poetryModel({
             author: user,
-            title: sanitizeHtml(poetryInfo.title),
-            desc: sanitizeHtml(poetryInfo.desc),
+            title: htmlReplace(sanitizeHtml(poetryInfo.title)),
+            desc: htmlReplace(sanitizeHtml(poetryInfo.desc)),
             body: sanitizeHtml(poetryInfo.body, sanitizeOptions),
             'stats.words': poetryInfo.collection
                 ? 0
@@ -58,8 +58,8 @@ export class PoetryStore {
                 .findOneAndUpdate(
                     { _id: poetryId, author: user },
                     {
-                        title: sanitizeHtml(poetryInfo.title),
-                        desc: sanitizeHtml(poetryInfo.desc),
+                        title: htmlReplace(sanitizeHtml(poetryInfo.title)),
+                        desc: htmlReplace(sanitizeHtml(poetryInfo.desc)),
                         body: sanitizeHtml(poetryInfo.body, sanitizeOptions),
                         'meta.category': poetryInfo.category,
                         'meta.form': poetryInfo.form,
@@ -76,8 +76,8 @@ export class PoetryStore {
                 .findOneAndUpdate(
                     { _id: poetryId, author: user },
                     {
-                        title: sanitizeHtml(poetryInfo.title),
-                        desc: sanitizeHtml(poetryInfo.desc),
+                        title: htmlReplace(sanitizeHtml(poetryInfo.title)),
+                        desc: htmlReplace(sanitizeHtml(poetryInfo.desc)),
                         body: sanitizeHtml(poetryInfo.body, sanitizeOptions),
                         'stats.words': countWords(
                             stripTags(sanitizeHtml(poetryInfo.body, sanitizeOptions)),

--- a/apps/api/src/modules/content/db/stores/prose.store.ts
+++ b/apps/api/src/modules/content/db/stores/prose.store.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import { PaginateModel } from 'mongoose';
 import sanitizeHtml from 'sanitize-html';
-import { sanitizeOptions } from '$shared/util';
+import { htmlReplace, sanitizeOptions } from '$shared/util';
 import { CreateProse } from '$shared/models/content';
 import { ProseContentDocument } from '../schemas';
 
@@ -22,8 +22,8 @@ export class ProseStore {
     async createProse(user: string, proseInfo: CreateProse): Promise<ProseContentDocument> {
         const newProse = new this.proseModel({
             author: user,
-            title: sanitizeHtml(proseInfo.title),
-            desc: sanitizeHtml(proseInfo.desc),
+            title: htmlReplace(sanitizeHtml(proseInfo.title)),
+            desc: htmlReplace(sanitizeHtml(proseInfo.desc)),
             body: sanitizeHtml(proseInfo.body, sanitizeOptions),
             'meta.category': proseInfo.category,
             'meta.genres': proseInfo.genres,
@@ -51,8 +51,8 @@ export class ProseStore {
             .findOneAndUpdate(
                 { _id: proseId, author: user },
                 {
-                    title: sanitizeHtml(proseInfo.title),
-                    desc: sanitizeHtml(proseInfo.desc),
+                    title: htmlReplace(sanitizeHtml(proseInfo.title)),
+                    desc: htmlReplace(sanitizeHtml(proseInfo.desc)),
                     body: sanitizeHtml(proseInfo.body, sanitizeOptions),
                     'meta.category': proseInfo.category,
                     'meta.genres': proseInfo.genres,

--- a/apps/api/src/modules/content/db/stores/tags.store.ts
+++ b/apps/api/src/modules/content/db/stores/tags.store.ts
@@ -11,6 +11,7 @@ import {
     TagsModel,
 } from '$shared/models/content';
 import sanitizeHtml from 'sanitize-html';
+import { htmlReplace } from '$shared/util';
 
 @Injectable()
 export class TagsStore {
@@ -200,8 +201,8 @@ export class TagsStore {
         }
 
         const newTag = new this.tags({
-            name: sanitizeHtml(form.name),
-            desc: sanitizeHtml(form.desc),
+            name: htmlReplace(sanitizeHtml(form.name)),
+            desc: htmlReplace(sanitizeHtml(form.desc)),
             kind: tagKind,
             parent: form.parent,
         });
@@ -264,8 +265,8 @@ export class TagsStore {
             }
         }
 
-        tag.name = sanitizeHtml(form.name);
-        tag.desc = sanitizeHtml(form.desc);
+        tag.name = htmlReplace(sanitizeHtml(form.name));
+        tag.desc = htmlReplace(sanitizeHtml(form.desc));
 
         const parentsToUpdate: string[] = [];
 

--- a/apps/api/src/modules/content/services/content.service.ts
+++ b/apps/api/src/modules/content/services/content.service.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, Injectable, UnauthorizedException } from '@nestjs/common';
+import { BadRequestException, Injectable } from '@nestjs/common';
 import { PaginateResult } from 'mongoose';
 import {
     BlogsStore,
@@ -12,7 +12,8 @@ import { JwtPayload } from '$shared/auth';
 import {
     ContentFilter,
     ContentKind,
-    ContentModel, ContentSorting,
+    ContentModel,
+    ContentSorting,
     CreateProse,
     FormType,
     NewsChange,

--- a/apps/api/src/modules/content/services/search.service.ts
+++ b/apps/api/src/modules/content/services/search.service.ts
@@ -2,6 +2,7 @@ import { PseudonymsStore } from '$modules/accounts/db/stores';
 import { Pseudonym } from '$shared/models/accounts';
 import { ContentFilter, ContentModel, ContentKind, WorkKind, Genres } from '$shared/models/content';
 import { SearchKind, SearchMatch } from '$shared/models/search';
+import { htmlReplace } from '$shared/util';
 import { BadRequestException, Injectable } from '@nestjs/common';
 import { PaginateResult } from 'mongoose';
 import sanitizeHtml from 'sanitize-html';
@@ -31,7 +32,7 @@ export class SearchService {
         pageNum: number,
         contentFilter: ContentFilter,
     ): Promise<PaginateResult<ContentModel>> {
-        const parsedQuery = query ? sanitizeHtml(query) : null;
+        const parsedQuery = query ? htmlReplace(sanitizeHtml(query)) : null;
         const kinds: ContentKind[] = [];
         switch (searchKind) {
             case SearchKind.Blog:
@@ -100,7 +101,7 @@ export class SearchService {
     }
 
     async searchUsers(query: string, pageNum: number): Promise<PaginateResult<Pseudonym>> {
-        const parsedQuery = sanitizeHtml(query);
+        const parsedQuery = htmlReplace(sanitizeHtml(query));
         return await this.pseudStore.findRelatedUsers(parsedQuery, pageNum, this.MAX_PER_PAGE);
     }
 }

--- a/apps/api/src/shared/util/html-replace.ts
+++ b/apps/api/src/shared/util/html-replace.ts
@@ -1,0 +1,22 @@
+/**
+ * Replaces &amp; with &, &lt; with <, and &gt; with >
+ * @param original
+ */
+export function htmlReplace(original: string): string {
+    if (!original) {
+        return null;
+    }
+
+    return original.replace(/&amp;|&lt;|&gt;/g, function (matched) {
+        switch (matched) {
+            case '&amp;':
+                return '&';
+            case '&lt;':
+                return '<';
+            case '&gt;':
+                return '>';
+            default:
+                return matched;
+        }
+    });
+}

--- a/apps/api/src/shared/util/index.ts
+++ b/apps/api/src/shared/util/index.ts
@@ -3,3 +3,4 @@ export type { DeviceInfo } from './device-info';
 export { Device } from './device';
 export * from './secrets';
 export { isNullOrUndefined } from './is-null-or-undefined';
+export { htmlReplace } from './html-replace';

--- a/apps/client/src/lib/components/ui/content/WorkBanner.svelte
+++ b/apps/client/src/lib/components/ui/content/WorkBanner.svelte
@@ -21,7 +21,7 @@
     import { PubStatus } from '$lib/models/content';
 
     const rating = useQuery('contentRatings', () => fetchRatings($content.content._id), {
-        enabled: !!$session.account && $content.content.audit.published === PubStatus.Published,
+        enabled: !!$session.account && !!$content.content && $content.content.audit.published === PubStatus.Published,
         cacheTime: 1500,
     });
 

--- a/apps/client/src/routes/blog/[id].svelte
+++ b/apps/client/src/routes/blog/[id].svelte
@@ -106,9 +106,9 @@
             return errors;
         },
         initialValues: {
-            title: $content.content.title,
-            desc: $content.content.desc,
-            body: $content.content.body,
+            title: $content.content ? $content.content.title : null,
+            desc: $content.content ? $content.content.desc : null,
+            body: $content.content ? $content.content.body : null,
         },
     });
 
@@ -201,6 +201,7 @@
     function canMakeNewsPost() {
         return (
             $session.currProfile &&
+            $content.content &&
             $session.currProfile._id === $content.content.author._id &&
             isAllowed($session.currProfile.roles, [Roles.Admin, Roles.Moderator, Roles.Contributor])
         );

--- a/apps/client/src/routes/explore/library/shelf/[id].svelte
+++ b/apps/client/src/routes/explore/library/shelf/[id].svelte
@@ -61,7 +61,7 @@
 {:else}
     <div class="flex-1 h-screen overflow-y-auto">
         <div class="w-11/12 mx-auto md:max-w-4xl my-6">
-            <BookshelfHeader shelf={$thisShelf.data} showTools="true" />
+            <BookshelfHeader shelf={$thisShelf.data} showTools={true} />
             {#if $shelfItems.isLoading}
                 <div class="h-96 w-full flex flex-col items-center justify-center">
                     <div class="flex items-center">
@@ -83,7 +83,7 @@
                     class="grid 2xl:grid-cols-4 lg:grid-cols-3 md:grid-cols-2 sm:grid-cols-1 gap-2 w-11/12 mx-auto my-8"
                 >
                     {#each $shelfItems.data as work}
-                        <WorkCard content={work} />
+                        <WorkCard content={work.content} />
                     {/each}
                 </div>
             {:else}


### PR DESCRIPTION
Closes OffprintStudios/Sailfish#30

Fixes saving of $, <, and > in titles and descriptions
- Also in user names and bios
- Fixes some type errors and Lint warnings
- Addresses some areas where $content.content can be null with null checks

