### PR TITLE
Fixes error when claim work and adds work card to approval queue

### DIFF
--- a/apps/client/src/lib/repo/approval-queue.repo.ts
+++ b/apps/client/src/lib/repo/approval-queue.repo.ts
@@ -66,7 +66,7 @@ export async function claimItem(profileId: string, docId: string): Promise<void>
     return claimContent(profileId, docId).then((res) => {
         approvalQueue.update((state) => {
             const itemIndex = state.queue.findIndex((item) => item._id === res._id);
-            state.queue[itemIndex] = res;
+            state.queue[itemIndex].claimedBy = res.claimedBy;
             return state;
         });
     });

--- a/apps/client/src/routes/dashboard/approval-queue/index.svelte
+++ b/apps/client/src/routes/dashboard/approval-queue/index.svelte
@@ -1,14 +1,13 @@
 <script lang="ts">
     import { goto } from '$app/navigation';
-    import { slugify, abbreviate, localeDate } from '$lib/util';
+    import { slugify } from '$lib/util';
     import { approvalQueue, setCurrItem, claimItem } from '$lib/repo/approval-queue.repo';
     import { session } from '$lib/repo/session.repo';
     import { CheckLine, CloseLine, Loader5Line } from 'svelte-remixicon';
     import { setQueue } from '$lib/repo/approval-queue.repo';
-    import TagBadge from '$lib/components/ui/content/TagBadge.svelte';
-    import { TagKind } from '$lib/models/content/works';
     import type { Content } from '$lib/models/content';
     import { ContentKind } from '$lib/models/content';
+    import WorkCard from '$lib/components/ui/content/WorkCard.svelte';
 
     function openItem(docId: string, content: Content) {
         setCurrItem(docId);
@@ -42,14 +41,7 @@
                     <thead class="border-b border-zinc-700 dark:border-white">
                         <tr>
                             <th>Claims</th>
-                            <th>Title</th>
-                            <th>Author</th>
-                            <th>Desc</th>
-                            <th>Tags</th>
-                            <!--<th>Fandom Tags</th>-->
-                            <th>Rating</th>
-                            <th>Words</th>
-                            <th>Submitted</th>
+                            <th>Works</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -75,54 +67,8 @@
                                         >
                                     {/if}
                                 </td>
-                                <td class="p-2 border-r border-gray-600 dark:border-white">
-                                    {item.workToApprove.title}
-                                </td>
-                                <td class="p-2 border-r border-gray-600 dark:border-white">
-                                    <a href="/profile/{item.workToApprove.author._id}">
-                                        {item.workToApprove.author.screenName}
-                                    </a>
-                                </td>
-                                <td class="p-2 border-r border-gray-600 dark:border-white">
-                                    <button>View >></button>
-                                </td>
-                                <td
-                                    class="p-2 flex items-center flex-wrap border-r border-gray-600 dark:border-white"
-                                >
-                                    <TagBadge
-                                        kind={TagKind.Type}
-                                        type={item.workToApprove.kind}
-                                        size={'large'}
-                                    />
-                                    <TagBadge
-                                        kind={TagKind.Category}
-                                        category={item.workToApprove.meta.category}
-                                        size={'large'}
-                                    />
-                                    {#each item.workToApprove.meta.genres as genre}
-                                        <TagBadge kind={TagKind.Genre} {genre} size={'large'} />
-                                    {/each}
-                                </td>
-                                <!--<td class="p-2 flex-wrap border-r border-gray-600 dark:border-white">
-                                    {#each item.workToApprove.tags as tag}
-                                    <ng-container *ngFor="let tag of entry.workToApprove.tags; let i = index">
-                                        <a
-                                            [routerLink]="['/tag', tag._id, tag.name | slugify]"
-                                            [innerHtml]="tag | displayTags | safeHtml"
-                                        ></a>
-                                        <ng-container *ngIf="i < entry.workToApprove.tags.length - 1">
-                                            ,
-                                        </ng-container>
-                                    </ng-container>
-                                </td>-->
-                                <td class="p-2 border-r border-gray-600 dark:border-white">
-                                    {item.workToApprove.meta.rating}
-                                </td>
-                                <td class="p-2 border-r border-gray-600 dark:border-white">
-                                    {abbreviate(item.workToApprove.stats.words)}
-                                </td>
                                 <td class="p-2">
-                                    {localeDate(item.workToApprove.createdAt, 'shortDate')}
+                                    <WorkCard content={item.workToApprove}/>
                                 </td>
                             </tr>
                         {/each}

--- a/apps/client/src/routes/dashboard/approval-queue/index.svelte
+++ b/apps/client/src/routes/dashboard/approval-queue/index.svelte
@@ -8,6 +8,7 @@
     import type { Content } from '$lib/models/content';
     import { ContentKind } from '$lib/models/content';
     import WorkCard from '$lib/components/ui/content/WorkCard.svelte';
+    import { Button } from '$lib/components/ui/misc';
 
     function openItem(docId: string, content: Content) {
         setCurrItem(docId);
@@ -49,9 +50,9 @@
                             <tr class="border-b border-zinc-700 dark:border-white">
                                 <td class="p-2 border-r border-zinc-700 dark:border-white">
                                     {#if item.claimedBy && item.claimedBy._id === $session.currProfile._id}
-                                        <button
+                                        <Button
                                             on:click={() => openItem(item._id, item.workToApprove)}
-                                            >View >></button
+                                            >View >></Button
                                         >
                                     {:else if item.claimedBy && item.claimedBy._id !== $session.currProfile._id}
                                         <img
@@ -60,10 +61,10 @@
                                             alt="avatar"
                                         />
                                     {:else}
-                                        <button
+                                        <Button
                                             on:click={() =>
                                                 claimItem($session.currProfile._id, item._id)}
-                                            >Claim</button
+                                            >Claim</Button
                                         >
                                     {/if}
                                 </td>


### PR DESCRIPTION
Closes OffprintStudios/Sailfish#43 

Fixes error when you claim a work and also redesigns the approval queue to use Work Cards rather than having the information all in a table. Note that since I took this picture, I have changed the appearance of the Claim and View buttons.
![image](https://user-images.githubusercontent.com/71996084/167563705-b98b1c7f-6ba4-4722-968c-2554ae08fd0d.png)
