### PR TITLE
Fix section issues - wrong word count on publish + error saving first section

### DIFF
--- a/apps/client/src/routes/poetry/[id]/create-section.svelte
+++ b/apps/client/src/routes/poetry/[id]/create-section.svelte
@@ -55,7 +55,13 @@
             createSection($session.currProfile._id, $content.content._id, formData),
         {
             onSuccess: (data) => {
-                queryClient.setQueryData('contentSections', (oldData) => [...oldData, data]);
+                queryClient.setQueryData('contentSections', (oldData) => {
+                    if (oldData) {
+                        return [...oldData, data];
+                    } else {
+                        return [data];
+                    }
+                });
                 success(`Section created!`);
                 goto(baseUrl);
             },

--- a/apps/client/src/routes/prose/[id]/create-section.svelte
+++ b/apps/client/src/routes/prose/[id]/create-section.svelte
@@ -55,7 +55,13 @@
             createSection($session.currProfile._id, $content.content._id, formData),
         {
             onSuccess: (data) => {
-                queryClient.setQueryData('contentSections', (oldData) => [...oldData, data]);
+                queryClient.setQueryData('contentSections', (oldData) => {
+                    if (oldData) {
+                        return [...oldData, data];
+                    } else {
+                        return [data];
+                    }
+                });
                 success(`Section created!`);
                 goto(baseUrl);
             },


### PR DESCRIPTION
Closes OffprintStudios/Sailfish#28

Correctly updates work word count when publish section
- Has it call sections.store method to match other section methods
Fixes issue where first section saved for chapter doesn't bring you back to main work page