### PR TITLE
Miscellaneous fixes for Nav Bar, mobile menu, mobile registration screen

### DIFF
--- a/apps/client/src/lib/components/forms/Toggle.svelte
+++ b/apps/client/src/lib/components/forms/Toggle.svelte
@@ -24,6 +24,7 @@
         background: transparent;
         padding: 0.2rem;
         cursor: pointer;
+        min-width: 3rem;
         div.switch {
             background: gray;
         }

--- a/apps/client/src/lib/components/nav/MobileMenu.svelte
+++ b/apps/client/src/lib/components/nav/MobileMenu.svelte
@@ -63,7 +63,7 @@
                 <span><InboxLine size="24px" class="mr-1" /></span>
                 <span>Inbox</span>
             </div>
-            <div class="w-10/12 mx-auto border-b border-white my-4"><!--separator--></div>
+            <div class="w-10/12 mx-auto border-b border-zinc-600 dark:border-white my-4"><!--separator--></div>
         {/if}
         <a href="/" class="menu-link border-zinc-600 dark:border-white">
             <span><Home5Line size="24px" class="mr-1" /></span>

--- a/apps/client/src/lib/components/nav/Nav.svelte
+++ b/apps/client/src/lib/components/nav/Nav.svelte
@@ -77,7 +77,7 @@
 </script>
 
 <div class="navbar">
-    <div class="py-2 flex-col items-center h-full hidden md:flex">
+    <div class="flex-col items-center h-full hidden overflow-x-hidden overflow-y-auto md:flex">
         {#if $session.currProfile}
             {#if currentMenu === MenuOptions.UserMenu}
                 <div
@@ -157,7 +157,7 @@
                 <span class="link-name">Log In</span>
             </a>
         {/if}
-        <div class="w-10/12 mx-auto border-b border-white my-2"><!--separator--></div>
+        <div class="w-10/12 mx-auto border-b border-white my-1"><!--separator--></div>
         <a
             class="link"
             href="/"
@@ -204,7 +204,7 @@
             </a>
         {/if}
         <div class="flex-1"><!--fill space--></div>
-        <div class="w-10/12 mx-auto border-b border-white my-2"><!--separator--></div>
+        <div class="w-10/12 mx-auto border-b border-white my-1"><!--separator--></div>
         <a
             class="link"
             href="/settings"
@@ -256,7 +256,7 @@
 
     a.link,
     div.link {
-        @apply p-2 mx-2 mb-1 border-2 border-transparent rounded-lg transition transform text-white flex flex-col items-center justify-center w-[61px] h-[61px] relative;
+        @apply p-2 mx-2 mb-1 border-2 border-transparent rounded-lg transition transform text-white flex flex-col items-center justify-center w-[61px] h-[55px] relative;
         &:hover {
             @apply no-underline scale-105;
             box-shadow: var(--dropshadow);

--- a/apps/client/src/lib/components/ui/user/RegisterForm.svelte
+++ b/apps/client/src/lib/components/ui/user/RegisterForm.svelte
@@ -96,7 +96,7 @@
         errorMessage={$errors.inviteCode}
     />
     <div class="my-0.5" />
-    <Toggle bind:value={$data.ageCheck}>I am at least 13 years of age or older.</Toggle>
+    <Toggle bind:value={$data.ageCheck}>I am 13 years of age or older.</Toggle>
     <Toggle bind:value={$data.termsAgree}>
         I agree to the Terms & Conditions, Privacy Policy, and Code of Conduct.
     </Toggle>


### PR DESCRIPTION
- Makes Nav Bar scrollable, and reduces spacing so scrollbar won't appear on laptop
- Fixes separator color in mobile menu
- Forces minimum width for toggle, to prevent issue where text makes it shrink and breaks enable animation
- Fixes redundant wording in registration age check toggle

![image](https://user-images.githubusercontent.com/71996084/183279514-ff04f0e4-f175-4b0b-8d7e-c441a417523a.png)
![image](https://user-images.githubusercontent.com/71996084/183279534-4a6e1407-8551-400a-88ae-1d501558a33f.png)
