### PR TITLE
Mobile fix 3 - Explore

### DIFF
--- a/apps/client/src/lib/components/ui/misc/Paginator.svelte
+++ b/apps/client/src/lib/components/ui/misc/Paginator.svelte
@@ -30,7 +30,7 @@
         </li>
         {#if totalPages <= 10}
             {#each range(totalPages, 1) as page}
-                <li class:active={page === currPage} class="hidden md:block">
+                <li class:active={page === currPage} class="block">
                     <button on:click={() => changePage(page)}>
                         {page}
                     </button>
@@ -41,7 +41,7 @@
             <!--1234(5) with buffer of 2 displays 1, the selected 5, the two before it, and also 2 because "..." takes up the same space-->
             {#if currPage <= PAGE_BUFFER + 3}
                 {#each range(currPage, 1) as page}
-                    <li class:active={page === currPage} class="hidden md:block">
+                    <li class:active={page === currPage} class="block">
                         <button on:click={() => changePage(page)}>
                             {page}
                         </button>
@@ -49,24 +49,24 @@
                 {/each}
             <!--Otherwise, display 1 then "..." then the buffer before the current page, and current page-->
             {:else}
-                <li class:active={false} class="hidden md:block">
+                <li class:active={false} class="block">
                     <button on:click={() => changePage(1)}>
                         1
                     </button>
                 </li>
-                <li class:active={false} class="hidden md:block">
+                <li class:active={false} class="block">
                     <button>
                         <MoreLine/>
                     </button>
                 </li>
                 {#each range(PAGE_BUFFER, currPage - PAGE_BUFFER) as page}
-                    <li class:active={false} class="hidden md:block">
+                    <li class:active={false} class="block">
                         <button on:click={() => changePage(page)}>
                             {page}
                         </button>
                     </li>
                 {/each}
-                <li class:active={true} class="hidden md:block">
+                <li class:active={true} class="block">
                     <button on:click={() => changePage(currPage)}>
                         {currPage}
                     </button>
@@ -76,7 +76,7 @@
             <!--(5)6789 with buffer of 2 displays the two after the selected, the last, and also 8 because "..." takes up the same space-->
             {#if totalPages - currPage <= PAGE_BUFFER + 2}
                 {#each range(totalPages - currPage, currPage + 1) as page}
-                    <li class:active={false} class="hidden md:block">
+                    <li class:active={false} class="block">
                         <button on:click={() => changePage(page)}>
                             {page}
                         </button>
@@ -85,18 +85,18 @@
             <!--Otherwise displays buffer after current page, then "..." then last page-->
             {:else}
                 {#each range(PAGE_BUFFER, currPage + 1) as page}
-                    <li class:active={false} class="hidden md:block">
+                    <li class:active={false} class="block">
                         <button on:click={() => changePage(page)}>
                             {page}
                         </button>
                     </li>
                 {/each}
-                <li class:active={false} class="hidden md:block">
+                <li class:active={false} class="block">
                     <button>
                         <MoreLine/>
                     </button>
                 </li>
-                <li class:active={false} class="hidden md:block">
+                <li class:active={false} class="block">
                     <button on:click={() => changePage(totalPages)}>
                         {totalPages}
                     </button>

--- a/apps/client/src/routes/explore/__layout.svelte
+++ b/apps/client/src/routes/explore/__layout.svelte
@@ -89,7 +89,7 @@
     });
 </script>
 
-<div class="flex flex-col md:flex-row w-full h-screen">
+<div class="flex flex-col md:flex-row w-full h-[calc(100vh-51px)] md:h-screen overflow-y-auto md:overflow-y-visible">
     <PageNav>
         <svelte:fragment slot="header">
             <h3>Explore</h3>

--- a/apps/client/src/routes/explore/index.svelte
+++ b/apps/client/src/routes/explore/index.svelte
@@ -43,7 +43,7 @@
     <title>New Works &mdash; Offprint</title>
 </svelte:head>
 
-<div class="w-full h-[calc(100vh-51px)] md:h-screen overflow-y-auto">
+<div class="w-full h-[calc(100vh-51px)] md:h-screen md:overflow-y-auto">
     {#if !$session || !$session.account }
         <NotifyBanner
             message={ALPHA_MESSAGE}
@@ -57,10 +57,10 @@
             </div>
         </div>
     {:else if contentResults && contentResults.totalDocs > 0}
-        <div class="w-full overflow-y-auto">
+        <div class="w-full">
             <div class="w-11/12 mx-auto my-6 max-w-7xl">
                 <div
-                    class="grid 2xl:grid-cols-4 lg:grid-cols-3 md:grid-cols-2 sm:grid-cols-1 gap-3 mb-6"
+                    class="w-11/12 mx-auto max-w-7xl grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4 gap-2 lg:gap-4"
                 >
                     {#each contentResults.docs.filter((work) => work.author !== null) as work}
                         <WorkCard content={work} />

--- a/apps/client/src/routes/explore/tags.svelte
+++ b/apps/client/src/routes/explore/tags.svelte
@@ -59,7 +59,7 @@
     <title>Tags &mdash; Offprint</title>
 </svelte:head>
 
-<div class="w-full h-[calc(100vh-51px)] md:h-screen overflow-y-auto flex flex-col mx-auto p-2">
+<div class="w-full h-[calc(100vh-51px)] md:h-screen md:overflow-y-auto flex flex-col mx-auto p-2">
     <div class="flex flex-wrap items-center justify-center text-2xl">
         {#each alphabeticalTags as section, index}
             {#if index !== 0}


### PR DESCRIPTION
Fixes appearance of Explore New Works page on mobile
- In mobile, establishes scrollable area height and scrollability in layout
- Outside of mobile, keeps it in index
- Fixes New Works results grid to display the same way as Search results
- Makes the Explore header part of the scrollable area

Fixes scrollability of Explore Tags page on mobile
- Scrollability is handled in layout rather than tags file on mobile

Displays full paginator on mobile, no reason not to

![image](https://user-images.githubusercontent.com/71996084/184526184-2bbb0e53-5551-4246-a44d-242e604d8291.png)
